### PR TITLE
all: update external assets retrieval logic

### DIFF
--- a/admin/src/components/base/LinkedConnectionSelector/LinkedConnectionSelector.tsx
+++ b/admin/src/components/base/LinkedConnectionSelector/LinkedConnectionSelector.tsx
@@ -10,6 +10,7 @@ import SlIcon from '@shoelace-style/shoelace/dist/react/icon/index.js';
 import SlMenuItem from '@shoelace-style/shoelace/dist/react/menu-item/index.js';
 import LittleLogo from '../LittleLogo/LittleLogo';
 import Grid from '../Grid/Grid';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 interface ConnectionSelectorProps {
 	linkedConnections: Number[] | null;
@@ -109,7 +110,10 @@ const LinkedConnectionSelector = ({
 											if (!isAlreadySelected) {
 												return (
 													<SlMenuItem key={c.id} value={String(c.id)}>
-														<LittleLogo code={c.connector.code} />
+														<LittleLogo
+															code={c.connector.code}
+															path={CONNECTORS_ASSETS_PATH}
+														/>
 														{c.name}
 													</SlMenuItem>
 												);

--- a/admin/src/components/base/LinkedConnectionSelector/useLinkedConnectionsGrid.tsx
+++ b/admin/src/components/base/LinkedConnectionSelector/useLinkedConnectionsGrid.tsx
@@ -4,6 +4,7 @@ import TransformedConnection from '../../../lib/core/connection';
 import AppContext from '../../../context/AppContext';
 import SlButton from '@shoelace-style/shoelace/dist/react/button/index.js';
 import LittleLogo from '../LittleLogo/LittleLogo';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const LINKED_CONNECTIONS_COLUMNS: GridColumn[] = [
 	{
@@ -76,7 +77,7 @@ const useLinkedConnectionsGrid = (
 		for (const fc of fullLinkedConnections) {
 			const nameCell = (
 				<div className='linked-connection-grid__name'>
-					<LittleLogo code={fc.connector.code} />
+					<LittleLogo code={fc.connector.code} path={CONNECTORS_ASSETS_PATH} />
 					{fc.name}
 				</div>
 			);

--- a/admin/src/components/base/LittleLogo/LittleLogo.tsx
+++ b/admin/src/components/base/LittleLogo/LittleLogo.tsx
@@ -4,12 +4,13 @@ import { ExternalLogo } from '../../routes/ExternalLogo/ExternalLogo';
 
 interface LittleLogoProps {
 	code: string;
+	path: string;
 }
 
-const LittleLogo = ({ code }: LittleLogoProps) => {
+const LittleLogo = ({ code, path }: LittleLogoProps) => {
 	return (
 		<div className='little-logo'>
-			<ExternalLogo code={code} />
+			<ExternalLogo code={code} path={path} />
 		</div>
 	);
 };

--- a/admin/src/components/routes/ActionWrapper/ActionFile.tsx
+++ b/admin/src/components/routes/ActionWrapper/ActionFile.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../helpers/getSchemaComboboxItems';
 import { Combobox } from '../../base/Combobox/Combobox';
 import { ActionIssues } from './ActionIssues';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const ActionFile = () => {
 	const [fileFields, setFileFields] = useState<ConnectorFieldInterface[]>([]);
@@ -202,7 +203,7 @@ const ActionFile = () => {
 			>
 				{action.format !== '' && (
 					<div className='action__file-format-logo' slot='prefix'>
-						<LittleLogo code={formatCode} />
+						<LittleLogo code={formatCode} path={CONNECTORS_ASSETS_PATH} />
 					</div>
 				)}
 				{formats.map((f) => {
@@ -216,7 +217,7 @@ const ActionFile = () => {
 					return (
 						<SlOption key={f.code} value={f.code}>
 							<div slot='prefix'>
-								<LittleLogo code={f.code} />
+								<LittleLogo code={f.code} path={CONNECTORS_ASSETS_PATH} />
 							</div>
 							{f.label}
 						</SlOption>

--- a/admin/src/components/routes/ActionWrapper/ActionHeader.tsx
+++ b/admin/src/components/routes/ActionWrapper/ActionHeader.tsx
@@ -6,6 +6,7 @@ import SlButton from '@shoelace-style/shoelace/dist/react/button/index.js';
 import SlIconButton from '@shoelace-style/shoelace/dist/react/icon-button/index.js';
 import { ActionIssues } from './ActionIssues';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const ActionHeader = () => {
 	const [isNameEditable, setIsNameEditable] = useState(false);
@@ -100,7 +101,7 @@ const ActionHeader = () => {
 	return (
 		<div className='action__header'>
 			<div className='action__header-title'>
-				<LittleLogo code={connection.connector.code} />
+				<LittleLogo code={connection.connector.code} path={CONNECTORS_ASSETS_PATH} />
 				<div className='action__header-name'>
 					{isNameEditable ? (
 						<span>

--- a/admin/src/components/routes/ActionWrapper/ActionTransformation.tsx
+++ b/admin/src/components/routes/ActionWrapper/ActionTransformation.tsx
@@ -84,6 +84,7 @@ import { mapExpressionArguments, buildMapExpression } from '../../../utils/mapEx
 import { isPlainObject } from '../../../utils/isPlainObject';
 import { ExternalLogo } from '../ExternalLogo/ExternalLogo';
 import { toJavascriptType, toMeergoStringType, toPythonType } from '../../helpers/types';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const lastChangeTimeFormats = {
 	iso8601: 'ISO8601',
@@ -1131,7 +1132,10 @@ const TransformationBox = ({
 									{transformationType === 'mappings' ? (
 										<SlIcon name='shuffle' />
 									) : (
-										<ExternalLogo code={selectedLanguage.toLowerCase()} />
+										<ExternalLogo
+											code={selectedLanguage.toLowerCase()}
+											path={CONNECTORS_ASSETS_PATH}
+										/>
 									)}
 								</span>
 								<div className='transformation-box__header-text'>

--- a/admin/src/components/routes/ConnectionActions/ActionsGrid.tsx
+++ b/admin/src/components/routes/ConnectionActions/ActionsGrid.tsx
@@ -18,6 +18,7 @@ import AlertDialog from '../../base/AlertDialog/AlertDialog';
 import { Variant } from '../App/App.types';
 import { serializeFilter } from '../../../utils/filters';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const GRID_COLUMNS: GridColumn[] = [{ name: 'Action' }, { name: 'Filter' }, { name: 'Enabled' }, { name: '' }];
 
@@ -178,7 +179,7 @@ const ActionsGrid = ({ newActionID, actions, onSelectAction }: ActionsGridProps)
 			logo = (
 				<div className='connection-actions__action-logo'>
 					<span style={{ position: 'relative', top: '3px' }}>
-						<LittleLogo code={formatConnector.code} />{' '}
+						<LittleLogo code={formatConnector.code} path={CONNECTORS_ASSETS_PATH} />{' '}
 					</span>
 				</div>
 			);

--- a/admin/src/components/routes/ConnectionActions/ConnectionActions.tsx
+++ b/admin/src/components/routes/ConnectionActions/ConnectionActions.tsx
@@ -16,6 +16,7 @@ import { isEventConnection } from '../../../lib/core/connection';
 import Section from '../../base/Section/Section';
 import { Snippet } from '../../base/Snippet/Snippet';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const ConnectionActions = () => {
 	const [isActionTypesDialogOpen, setIsActionTypesDialogOpen] = useState<boolean>(false);
@@ -136,7 +137,7 @@ const ConnectionActions = () => {
 							{connection.actionTypes.map((actionType) => (
 								<ListTile
 									key={actionType.name}
-									icon={<LittleLogo code={connection.connector.code} />}
+									icon={<LittleLogo code={connection.connector.code} path={CONNECTORS_ASSETS_PATH} />}
 									name={actionType.name}
 									description={actionType.description}
 									className={`connection-actions__action-type connection-actions__action-type--${actionType.target.toLowerCase()}`}
@@ -187,7 +188,7 @@ const ConnectionActions = () => {
 				setIsOpen={setIsActionTypesDialogOpen}
 				actionTypes={connection.actionTypes!}
 				connection={connection}
-				connectionLogo={<LittleLogo code={connection.connector.code} />}
+				connectionLogo={<LittleLogo code={connection.connector.code} path={CONNECTORS_ASSETS_PATH} />}
 				onSelectActionType={onSelectActionType}
 			/>
 			<Outlet context={{ setIsActionOpen }} />

--- a/admin/src/components/routes/ConnectionWrapper/ConnectionTabs.tsx
+++ b/admin/src/components/routes/ConnectionWrapper/ConnectionTabs.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import TransformedConnection from '../../../lib/core/connection';
 import { Link } from '../../base/Link/Link';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 interface ConnectionTabsProps {
 	connection: TransformedConnection;
@@ -14,7 +15,7 @@ const ConnectionTabs = ({ connection }: ConnectionTabsProps) => {
 	const fragments = location.pathname.split('/');
 	const tab = fragments[fragments.length - 1];
 
-	const connectorLogo = <LittleLogo code={connection.connector.code} />;
+	const connectorLogo = <LittleLogo code={connection.connector.code} path={CONNECTORS_ASSETS_PATH} />;
 
 	return (
 		<div className='connection-wrapper__tabs'>

--- a/admin/src/components/routes/ConnectionsList/ConnectionsList.tsx
+++ b/admin/src/components/routes/ConnectionsList/ConnectionsList.tsx
@@ -10,6 +10,7 @@ import { ConnectionRole } from '../../../lib/api/types/connection';
 import TransformedConnection from '../../../lib/core/connection';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
 import { Link } from '../../base/Link/Link';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const ConnectionsList = () => {
 	const [connectionsRows, setConnectionsRows] = useState<GridRow[]>();
@@ -77,7 +78,7 @@ const ConnectionsList = () => {
 		for (const c of roleConnections) {
 			const cells = [
 				<div className='connections-list__name-cell'>
-					<LittleLogo code={c.connector.code} /> {c.name}
+					<LittleLogo code={c.connector.code} path={CONNECTORS_ASSETS_PATH} /> {c.name}
 				</div>,
 				c.connector.type,
 				c.connector.label,
@@ -106,7 +107,9 @@ const ConnectionsList = () => {
 					});
 					const connectionLogos: ReactNode[] = [];
 					for (const ec of fullEventConnections) {
-						connectionLogos.push(<LittleLogo key={String(ec.id)} code={ec.connector.code} />);
+						connectionLogos.push(
+							<LittleLogo key={String(ec.id)} code={ec.connector.code} path={CONNECTORS_ASSETS_PATH} />,
+						);
 					}
 					cells.push(<div className='connections-list__event-connections-cell'>{connectionLogos}</div>);
 				} else {

--- a/admin/src/components/routes/ConnectionsMap/ConnectionBlock.tsx
+++ b/admin/src/components/routes/ConnectionsMap/ConnectionBlock.tsx
@@ -8,6 +8,7 @@ import { Link } from '../../base/Link/Link';
 import connectionMapContext from '../../../context/ConnectionMapContext';
 import appContext from '../../../context/AppContext';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 interface ConnectionBlockProps {
 	connection: TransformedConnection;
@@ -106,7 +107,7 @@ const ConnectionBlock = ({ connection: c, isNew }: ConnectionBlockProps) => {
 				>
 					<div className='connection-block__content'>
 						<Flex alignItems='center' gap={10}>
-							<LittleLogo code={c.connector.code} />
+							<LittleLogo code={c.connector.code} path={CONNECTORS_ASSETS_PATH} />
 							<div className='connection-block__name'>{c.name}</div>
 						</Flex>
 						<StatusDot status={c.status} />

--- a/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
+++ b/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
@@ -19,6 +19,7 @@ import ConnectorFieldInterface, { ConnectorButton } from '../../../lib/api/types
 import { validateConnectorSettings } from '../../../lib/core/connectorSettings';
 import * as icons from '../../../constants/icons';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const hasStrategy = (connectionRole: ConnectionRole, c: TransformedConnector): boolean => {
 	return connectionRole === 'Source' && c.strategies;
@@ -79,7 +80,7 @@ const ConnectorSettings = () => {
 			setTitle(
 				<Flex alignItems='baseline' gap={10}>
 					<span style={{ position: 'relative', top: '3px' }}>
-						<LittleLogo code={connector.code} />
+						<LittleLogo code={connector.code} path={CONNECTORS_ASSETS_PATH} />
 					</span>
 					<span>
 						Add {connectionRole.toLowerCase()} connection for {connector.label}

--- a/admin/src/components/routes/ConnectorsList/ConnectorsList.tsx
+++ b/admin/src/components/routes/ConnectorsList/ConnectorsList.tsx
@@ -15,7 +15,7 @@ import * as marked from 'marked';
 import { potentialConnectors } from '../../../lib/api/potentialConnectors';
 import { PotentialConnector } from '../../../lib/api/types/connector';
 import { ADD_CONNECTION_ROLE_KEY, ADD_CONNECTOR_CODE_KEY } from '../../../constants/storage';
-import { UI_BASE_PATH } from '../../../constants/paths';
+import { CONNECTORS_ASSETS_PATH, UI_BASE_PATH } from '../../../constants/paths';
 import { ExternalLogo } from '../ExternalLogo/ExternalLogo';
 
 const ConnectorsList = () => {
@@ -320,7 +320,7 @@ const ConnectorCard = ({ connector, potentialConnector, onClick, role }: Connect
 				<div className='connectors-list__card-beta-label'>Beta</div>
 				<div className='connectors-list__card-top'>
 					<div className='connectors-list__card-logo'>
-						<ExternalLogo code={connector.code} />
+						<ExternalLogo code={connector.code} path={CONNECTORS_ASSETS_PATH} />
 					</div>
 					<div className='connectors-list__card-label'>{connector.label}</div>
 					{connector.categories.map((category, index) => (
@@ -360,7 +360,7 @@ const ConnectorCard = ({ connector, potentialConnector, onClick, role }: Connect
 				) : null}
 				<div className='connectors-list__card-top'>
 					<div className='connectors-list__card-logo'>
-						<ExternalLogo code={potentialConnector.code} />
+						<ExternalLogo code={potentialConnector.code} path={CONNECTORS_ASSETS_PATH} />
 					</div>
 					<div className='connectors-list__card-label'>{potentialConnector.label}</div>
 					{potentialConnector.categories.map((category, index) => (

--- a/admin/src/components/routes/DataWarehouse/DataWarehouse.tsx
+++ b/admin/src/components/routes/DataWarehouse/DataWarehouse.tsx
@@ -11,6 +11,7 @@ import Section from '../../base/Section/Section';
 import DataWarehouseSettings from './DataWarehouseSettings';
 import SlButton from '@shoelace-style/shoelace/dist/react/button/index.js';
 import SlSpinner from '@shoelace-style/shoelace/dist/react/spinner/index.js';
+import { WAREHOUSES_ASSETS_PATH } from '../../../constants/paths';
 
 const DataWarehouse = () => {
 	const [connectedWarehouse, setConnectedWarehouse] = useState<string>();
@@ -171,7 +172,7 @@ const WarehouseInfo = ({
 			<div className='warehouse-info__info'>
 				<div className='warehouse-info__title'>
 					<div className='warehouse-info__icon'>
-						<LittleLogo code={warehouse.code} />
+						<LittleLogo code={warehouse.code} path={WAREHOUSES_ASSETS_PATH} />
 					</div>
 					<div className='warehouse-info__name'>{warehouse.name}</div>
 				</div>

--- a/admin/src/components/routes/DataWarehouse/DataWarehouseSettings.tsx
+++ b/admin/src/components/routes/DataWarehouse/DataWarehouseSettings.tsx
@@ -13,6 +13,7 @@ import { PostgreSQLSettings } from '../../base/PostgreSQLSettings/PostgreSQLSett
 import { SnowflakeSettings } from '../../base/SnowflakeSettings/SnowflakeSettings';
 import Section from '../../base/Section/Section';
 import { warehouseSectionTexts } from './DataWarehouse';
+import { WAREHOUSES_ASSETS_PATH } from '../../../constants/paths';
 
 interface DataWarehouseSettingsProps {
 	selectedWarehouse: Warehouse;
@@ -120,7 +121,7 @@ const DataWarehouseSettings = ({
 		<div className='warehouse-settings'>
 			<div className='warehouse-settings__info'>
 				<div className='warehouse-settings__icon'>
-					<LittleLogo code={selectedWarehouse.code} />
+					<LittleLogo code={selectedWarehouse.code} path={WAREHOUSES_ASSETS_PATH} />
 				</div>
 				<p className='warehouse-settings__name'>{selectedWarehouse.name}</p>
 			</div>

--- a/admin/src/components/routes/ExternalLogo/ExternalLogo.tsx
+++ b/admin/src/components/routes/ExternalLogo/ExternalLogo.tsx
@@ -5,12 +5,13 @@ import UnknownLogo from '../../base/UnknownLogo/UnknownLogo';
 
 interface ExternalLogoProps {
 	code: string | null;
+	path: string;
 	slot?: string;
 }
 
 const okSrcCache = new Map<string, string | null>();
 
-const ExternalLogo = ({ code, slot }: ExternalLogoProps) => {
+const ExternalLogo = ({ code, path, slot }: ExternalLogoProps) => {
 	const [src, setSrc] = useState<string | null>(null);
 
 	const { publicMetadata } = useContext(AppContext);
@@ -20,7 +21,14 @@ const ExternalLogo = ({ code, slot }: ExternalLogoProps) => {
 
 		let sources = [];
 		if (code != null) {
-			sources = publicMetadata.externalAssetsURLs.map((url: string) => `${url}${code}.svg`);
+			sources = publicMetadata.externalAssetsURLs.map((url: string) => {
+				let source = url + 'admin/';
+				if (path !== '') {
+					source += `${path}/`;
+				}
+				source += `${code}.svg`;
+				return source;
+			});
 		}
 
 		if (!code || sources.length === 0) {

--- a/admin/src/components/routes/FileConnector/FileConnector.tsx
+++ b/admin/src/components/routes/FileConnector/FileConnector.tsx
@@ -10,6 +10,7 @@ import TransformedConnection from '../../../lib/core/connection';
 import ListTile from '../../base/ListTile/ListTile';
 import { Link } from '../../base/Link/Link';
 import { startsWithVowelSound } from '../../../utils/startsWithVowelSound';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const FileConnector = () => {
 	const [selectedStorage, setSelectedStorage] = useState<number>();
@@ -78,13 +79,14 @@ const FileConnector = () => {
 									<div className='file-connector__storage-logo' slot='prefix'>
 										<LittleLogo
 											code={storages.find((s) => s.id === selectedStorage).connector.code}
+											path={CONNECTORS_ASSETS_PATH}
 										/>
 									</div>
 								)}
 								{storages.map((s) => (
 									<SlOption key={s.id} value={String(s.id)}>
 										<div slot='prefix'>
-											<LittleLogo code={s.connector.code} />
+											<LittleLogo code={s.connector.code} path={CONNECTORS_ASSETS_PATH} />
 										</div>
 										{s.name}
 									</SlOption>
@@ -107,7 +109,7 @@ const FileConnector = () => {
 						<div className='file-connector__action-types'>
 							<ListTile
 								key={'users-action-type'}
-								icon={<LittleLogo code={file.code} />}
+								icon={<LittleLogo code={file.code} path={CONNECTORS_ASSETS_PATH} />}
 								name={`${role === 'Source' ? 'Import' : 'Export'} users`}
 								description={
 									role === 'Source'

--- a/admin/src/components/routes/SchemaEdit/PropertyDialog.tsx
+++ b/admin/src/components/routes/SchemaEdit/PropertyDialog.tsx
@@ -27,6 +27,7 @@ import { PrimarySources } from '../../../lib/api/types/workspace';
 import { TypeIcon } from '../../base/TypeIcon/TypeIcon';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
 import { toMeergoStringType } from '../../helpers/types';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const TYPE_KINDS: TypeKind[] = [
 	'text',
@@ -771,6 +772,7 @@ const PropertyDialog = ({
 									{primarySource && (
 										<LittleLogo
 											code={sourceConnections.find((c) => c.id === primarySource).connector.code}
+											path={CONNECTORS_ASSETS_PATH}
 										/>
 									)}
 								</div>
@@ -778,7 +780,7 @@ const PropertyDialog = ({
 								{sourceConnections.map((c) => (
 									<SlOption key={c.id} value={String(c.id)}>
 										<div slot='prefix'>
-											<LittleLogo code={c.connector.code} />
+											<LittleLogo code={c.connector.code} path={CONNECTORS_ASSETS_PATH} />
 										</div>
 										{c.name}
 									</SlOption>

--- a/admin/src/components/routes/SchemaEdit/useSchemaEdit.tsx
+++ b/admin/src/components/routes/SchemaEdit/useSchemaEdit.tsx
@@ -13,6 +13,7 @@ import { PrimarySources } from '../../../lib/api/types/workspace';
 import { SchemaContext } from '../../../context/SchemaContext';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
 import { toMeergoStringType } from '../../helpers/types';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const SCHEMA_COLUMNS: GridColumn[] = [
 	{ name: 'Name' },
@@ -536,7 +537,7 @@ const buildRow = (
 		if (primarySourceConnection) {
 			primarySourceCell = (
 				<div className='schema-edit__primary-source'>
-					<LittleLogo code={primarySourceConnection.connector.code} />
+					<LittleLogo code={primarySourceConnection.connector.code} path={CONNECTORS_ASSETS_PATH} />
 					{primarySourceConnection.name}
 				</div>
 			);

--- a/admin/src/components/routes/SchemaGrid/useSchemaGrid.tsx
+++ b/admin/src/components/routes/SchemaGrid/useSchemaGrid.tsx
@@ -7,6 +7,7 @@ import { TransformedMapping, TransformedProperty, flattenSchema } from '../../..
 import { PrimarySources } from '../../../lib/api/types/workspace';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
 import { toMeergoStringType } from '../../helpers/types';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 const SCHEMA_COLUMNS: GridColumn[] = [{ name: 'Name' }, { name: 'Type' }, { name: 'Primary source' }];
 
@@ -74,7 +75,7 @@ const buildRow = (property: TransformedProperty, primarySource?: TransformedConn
 		if (primarySource) {
 			primarySourceCell = (
 				<div className='schema-grid__primary-source'>
-					<LittleLogo code={primarySource.connector.code} />
+					<LittleLogo code={primarySource.connector.code} path={CONNECTORS_ASSETS_PATH} />
 					{primarySource.name}
 				</div>
 			);

--- a/admin/src/components/routes/Users/UserDrawer.tsx
+++ b/admin/src/components/routes/Users/UserDrawer.tsx
@@ -17,6 +17,7 @@ import toJSDate from '../../../utils/toJSDate';
 import { Link } from '../../base/Link/Link';
 import { USERS_EXPANDED_TRAITS_KEY, USERS_TAB_KEY } from '../../../constants/storage';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
+import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
 
 interface UserDrawerProps {
 	selectedUser: string;
@@ -216,7 +217,7 @@ const UserDrawer = ({ selectedUser, setSelectedUser }: UserDrawerProps) => {
 						) : events && events.length > 0 ? (
 							events.map((event) => {
 								const source = connections.find((c) => c.id === event.connectionId);
-								const logo = <LittleLogo code={source?.connector.code} />;
+								const logo = <LittleLogo code={source?.connector.code} path={CONNECTORS_ASSETS_PATH} />;
 								return (
 									<div className='user-drawer__event' key={event.sentAt}>
 										<div className='user-drawer__event-head'>
@@ -245,7 +246,9 @@ const UserDrawer = ({ selectedUser, setSelectedUser }: UserDrawerProps) => {
 						) : identities && identities.length > 0 ? (
 							identities.map((identity) => {
 								const connection = connections.find((c) => c.id === identity.connection);
-								const logo = <LittleLogo code={connection?.connector.code} />;
+								const logo = (
+									<LittleLogo code={connection?.connector.code} path={CONNECTORS_ASSETS_PATH} />
+								);
 								return (
 									<div className='user-drawer__identity' key={identity.lastChangeTime}>
 										<div className='user-drawer__identity-head'>

--- a/admin/src/components/routes/WorkspaceCreate/WorkspaceCreate.tsx
+++ b/admin/src/components/routes/WorkspaceCreate/WorkspaceCreate.tsx
@@ -14,10 +14,11 @@ import InitialSchema from './InitialSchema.json';
 import * as icons from '../../../constants/icons';
 import { IS_DOCKER_KEY } from '../../../constants/storage';
 import { ExternalLogo } from '../ExternalLogo/ExternalLogo';
+import { WAREHOUSES_ASSETS_PATH } from '../../../constants/paths';
 
-const postgresqlIcon = <ExternalLogo slot='prefix' code='postgresql' />;
+const postgresqlIcon = <ExternalLogo slot='prefix' code='postgresql' path={WAREHOUSES_ASSETS_PATH} />;
 
-const snowflakeIcon = <ExternalLogo slot='prefix' code='snowflake' />;
+const snowflakeIcon = <ExternalLogo slot='prefix' code='snowflake' path={WAREHOUSES_ASSETS_PATH} />;
 
 const WorkspaceCreate = () => {
 	const [name, setName] = useState<string>('');

--- a/admin/src/constants/paths.ts
+++ b/admin/src/constants/paths.ts
@@ -14,5 +14,14 @@ const FULLSCREEN_PATHS = [
 	`${UI_BASE_PATH}connections/:id/actions/add/:actionTarget`,
 	`${UI_BASE_PATH}schema/edit`,
 ];
+const CONNECTORS_ASSETS_PATH = 'connectors';
+const WAREHOUSES_ASSETS_PATH = 'warehouses';
 
-export { UI_BASE_PATH, SIGN_UP_PATH, RESET_PASSWORD_PATH, FULLSCREEN_PATHS };
+export {
+	UI_BASE_PATH,
+	SIGN_UP_PATH,
+	RESET_PASSWORD_PATH,
+	FULLSCREEN_PATHS,
+	CONNECTORS_ASSETS_PATH,
+	WAREHOUSES_ASSETS_PATH,
+};

--- a/admin/src/lib/api/potentialConnectors.ts
+++ b/admin/src/lib/api/potentialConnectors.ts
@@ -1,7 +1,6 @@
 import { PotentialConnector, ConnectorType, ConnectorImplementation } from './types/connector';
 
-const potentialConnectorsURL =
-	'https://cdn.jsdelivr.net/gh/meergo/external-assets-cdn@main/potential-connectors/catalog.json';
+const potentialConnectorsURL = 'https://assets.meergo.com/admin/connectors/potentials.json';
 const POTENTIAL_CONNECTORS_TIMEOUT_MS = 2000; // in milliseconds
 const CONNECTOR_CODE_REGEX = /^[a-z0-9-]+$/;
 const ALLOWED_CONNECTOR_TYPES: ReadonlyArray<ConnectorType> = [

--- a/cmd/meergo/meergo.example.env
+++ b/cmd/meergo/meergo.example.env
@@ -13,7 +13,7 @@ MEERGO_JAVASCRIPT_SDK_URL=""
 
 # List of base URLs (comma-separated) from which Meergo retrieves external
 # assets (as icons) related to connector and data warehouse brands.
-MEERGO_EXTERNAL_ASSETS_URLS="https://cdn.jsdelivr.net/gh/meergo/external-assets-cdn@main/"
+MEERGO_EXTERNAL_ASSETS_URLS="https://assets.meergo.com/"
 
 # Sets the telemetry level in Meergo. You can set this to "none" to disable
 # telemetry. Default is "all". See the environment variables documentation for

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,7 +11,7 @@ services:
 
       # List of base URLs (comma-separated) from which Meergo retrieves external
       # assets (as icons) related to connector and data warehouse brands.
-      MEERGO_EXTERNAL_ASSETS_URLS: https://cdn.jsdelivr.net/gh/meergo/external-assets-cdn@main/
+      MEERGO_EXTERNAL_ASSETS_URLS: https://assets.meergo.com/
 
       # HubSpot.
       # Set these environment variables to connect to your HubSpot app when

--- a/test/meergotester/meergotester.go
+++ b/test/meergotester/meergotester.go
@@ -308,7 +308,7 @@ func (c *Meergo) Start() {
 		// in running Meergo if certain system environment variables are not
 		// provided (this for example gives errors on Windows).
 		env := append(os.Environ(), []string{
-			"MEERGO_EXTERNAL_ASSETS_URLS=https://cdn.jsdelivr.net/gh/meergo/external-assets-cdn@main/",
+			"MEERGO_EXTERNAL_ASSETS_URLS=https://assets.meergo.com/",
 			"MEERGO_TELEMETRY_LEVEL=none",
 			"MEERGO_HTTP_HOST=" + testsSettings.HTTP.Host,
 			"MEERGO_HTTP_PORT=" + strconv.Itoa(testsSettings.HTTP.Port),
@@ -342,7 +342,7 @@ func (c *Meergo) Start() {
 		setts := cmd.Settings{}
 		setts.JavaScriptSDKURL = "https://cdn.meergo.com/meergo.min.js"
 		setts.SentryTelemetryLevel = core.TelemetryLevelNone
-		setts.ExternalAssetsURLs = []string{"https://cdn.jsdelivr.net/gh/meergo/external-assets-cdn@main/"}
+		setts.ExternalAssetsURLs = []string{"https://assets.meergo.com/"}
 		setts.HTTP.Host = testsSettings.HTTP.Host
 		setts.HTTP.Port = testsSettings.HTTP.Port
 		setts.HTTP.ExternalURL = fmt.Sprintf("http://%s:%d/", setts.HTTP.Host, setts.HTTP.Port)


### PR DESCRIPTION
Refer #1996.

## Commit message

```
all: update external assets retrieval logic

This commit:

1. Enables Admin to support the new external assets structure, where
   content is divided into directories (no longer all at the top level).

2. References the actual CDN instead of the one we've decided to
   discontinue. Further changes will follow.

For #1996.
```