### PR TITLE
core/internal/datastore/diffschemas: improve validations on rePaths

### DIFF
--- a/core/internal/datastore/diffschemas/diffschemas.go
+++ b/core/internal/datastore/diffschemas/diffschemas.go
@@ -100,10 +100,17 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 	// Iterate over AddedNames.
 	for _, addedName := range addedNames {
 
+		newPath := appendPath(path, addedName)
+
+		// Since newPath is an added name, the rePaths cannot indicate that it
+		// has been created with the same name of an already existent property.
+		if v, ok := rePaths[newPath]; ok && v == nil {
+			return nil, fmt.Errorf("rePaths cannot contain {..., %q: null, ...}, as there are no properties named %q in the old schema", newPath, newPath)
+		}
+
 		// Renamed properties, whose new name did not already exist in the
 		// schema. They appear in "rePaths" (the key is the new name, the
 		// value is the old name).
-		newPath := appendPath(path, addedName)
 		if oldPath, ok := rePaths[newPath].(string); ok {
 			oldName := propPathToName(oldPath)
 			oldProp, _ := oldProperties.ByName(oldName)
@@ -157,12 +164,19 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 	// Iterate over DroppedNames.
 	for _, droppedName := range droppedNames {
 
+		droppedPath := appendPath(path, droppedName)
+
+		// Since the path no longer exists in the new schema, in any case
+		// rePaths can contain it.
+		if _, ok := rePaths[droppedPath]; ok {
+			return nil, fmt.Errorf("rePaths cannot contain %q, as this property no longer exists in the new schema", droppedPath)
+		}
+
 		// Renamed properties, whose old name has not been reused by any
 		// property. They appear in "rePaths" (the key is the new name, the
 		// value is the old name).
 		// They have been already handled by the code above.
 		alreadyHandled := false
-		droppedPath := appendPath(path, droppedName)
 		for _, v := range rePaths {
 			if v == droppedPath {
 				alreadyHandled = true
@@ -198,14 +212,15 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 		newProp, _ := newProperties.ByName(keptName)
 		keptPath := appendPath(path, keptName)
 
-		if v, ok := rePaths[keptPath]; ok && v == nil {
-			var renamed bool
-			for _, v := range rePaths {
-				if v == keptPath {
-					renamed = true
-					break
-				}
+		var renamed bool
+		for _, v := range rePaths {
+			if v == keptPath {
+				renamed = true
+				break
 			}
+		}
+
+		if v, ok := rePaths[keptPath]; ok && v == nil {
 			if renamed {
 				// New properties with the same name of a renamed property. They
 				// appear in "rePaths" (the key is the name of the created
@@ -274,6 +289,10 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 				})
 			}
 			continue
+		}
+
+		if renamed {
+
 		}
 
 		// Unchanged properties, that are properties that have not been

--- a/core/internal/datastore/diffschemas/diffschemas.go
+++ b/core/internal/datastore/diffschemas/diffschemas.go
@@ -20,8 +20,8 @@ import (
 // the new property path and its value is the old property path. In case of new
 // properties created with the same name of already existent properties, the
 // value must be the untyped nil. rePaths cannot contain keys with the same path
-// as their value. Any property path which does not refer to changed properties
-// is ignored.
+// as their value. Any property paths referenced in rePaths that do not refer to
+// properties in schemas are ignored.
 //
 // The Diff function assumes that both the oldSchema and newSchema comply with
 // the requirements of data warehouse schemas and that they do not contain

--- a/core/internal/datastore/diffschemas/diffschemas.go
+++ b/core/internal/datastore/diffschemas/diffschemas.go
@@ -220,6 +220,20 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 			}
 		}
 
+		// If a property "bar" was renamed to "foo" (that is, if the rePaths
+		// contain {..., "foo": "bar", ...}) and "bar" was retained in the new
+		// schema, the possibilities are:
+		//
+		// 1) "bar" comes from a property that was renamed
+		// 2) "bar" is a new property
+		//
+		// In both cases, "bar" must appear in the rePaths, otherwise there is
+		// some kind of inconsistency.
+		if _, ok := rePaths[keptPath]; !ok && renamed {
+			return nil, fmt.Errorf("property %q has been renamed and still appears in the new schema,"+
+				" so it means that it must be declared in rePaths (as a renamed property, or as a new property)", keptPath)
+		}
+
 		if v, ok := rePaths[keptPath]; ok && v == nil {
 			if renamed {
 				// New properties with the same name of a renamed property. They
@@ -289,10 +303,6 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 				})
 			}
 			continue
-		}
-
-		if renamed {
-
 		}
 
 		// Unchanged properties, that are properties that have not been

--- a/core/internal/datastore/diffschemas/diffschemas_test.go
+++ b/core/internal/datastore/diffschemas/diffschemas_test.go
@@ -770,6 +770,24 @@ func TestDiff(t *testing.T) {
 			rePaths:     map[string]any{"x2": "x", "x2.a2": "x.a"},
 			expectedErr: "it is not possible to rename an object property (\"x\", renamed to \"x2\") and simultaneously make changes to its descendant properties",
 		},
+		{
+			name: "Property renamed and added again with the same name and same type, but the repaths are invalid",
+			fromSchema: types.Object([]types.Property{
+				{Name: "bar", Type: types.Int(64), Nullable: true},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "foo", Type: types.Int(64), Nullable: true},
+				{Name: "bar", Type: types.Int(64), Nullable: true},
+			}),
+			rePaths: map[string]any{
+				"foo": "bar",
+				// "a":  nil, -> commented on purpose: the test must verify that an error is returned when it is missing.
+			},
+			expectedOps: []warehouses.AlterOperation{
+				{Operation: warehouses.OperationRenameColumn, Column: "bar", NewColumn: "foo"},
+				{Operation: warehouses.OperationAddColumn, Column: "bar", Type: types.Int(64)},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/internal/datastore/diffschemas/diffschemas_test.go
+++ b/core/internal/datastore/diffschemas/diffschemas_test.go
@@ -770,24 +770,6 @@ func TestDiff(t *testing.T) {
 			rePaths:     map[string]any{"x2": "x", "x2.a2": "x.a"},
 			expectedErr: "it is not possible to rename an object property (\"x\", renamed to \"x2\") and simultaneously make changes to its descendant properties",
 		},
-		// {
-		// 	name: "Property renamed and added again with the same name and same type, but the rePaths are invalid",
-		// 	fromSchema: types.Object([]types.Property{
-		// 		{Name: "bar", Type: types.Int(64), Nullable: true},
-		// 	}),
-		// 	toSchema: types.Object([]types.Property{
-		// 		{Name: "foo", Type: types.Int(64), Nullable: true},
-		// 		{Name: "bar", Type: types.Int(64), Nullable: true},
-		// 	}),
-		// 	rePaths: map[string]any{
-		// 		"foo": "bar",
-		// 		// "a":  nil, -> commented on purpose: the test must verify that an error is returned when it is missing.
-		// 	},
-		// 	expectedOps: []warehouses.AlterOperation{
-		// 		{Operation: warehouses.OperationRenameColumn, Column: "bar", NewColumn: "foo"},
-		// 		{Operation: warehouses.OperationAddColumn, Column: "bar", Type: types.Int(64)},
-		// 	},
-		// },
 		{
 			name: "One property added at first level (type string), but rePaths are invalid",
 			fromSchema: types.Object([]types.Property{
@@ -817,6 +799,21 @@ func TestDiff(t *testing.T) {
 			}),
 			rePaths:     map[string]any{"x.c": nil},
 			expectedErr: "rePaths cannot contain \"x.c\", as this property no longer exists in the new schema",
+		},
+		{
+			name: "Property renamed and added again with the same name and same type, but the rePaths are invalid",
+			fromSchema: types.Object([]types.Property{
+				{Name: "bar", Type: types.Int(64), Nullable: true},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "foo", Type: types.Int(64), Nullable: true},
+				{Name: "bar", Type: types.Int(64), Nullable: true},
+			}),
+			rePaths: map[string]any{
+				"foo": "bar",
+				// "a":  nil, -> commented on purpose: the test must verify that an error is returned when it is missing.
+			},
+			expectedErr: "property \"bar\" has been renamed and still appears in the new schema, so it means that it must be declared in rePaths (as a renamed property, or as a new property)",
 		},
 	}
 

--- a/core/internal/datastore/diffschemas/diffschemas_test.go
+++ b/core/internal/datastore/diffschemas/diffschemas_test.go
@@ -811,7 +811,7 @@ func TestDiff(t *testing.T) {
 			}),
 			rePaths: map[string]any{
 				"foo": "bar",
-				// "a":  nil, -> commented on purpose: the test must verify that an error is returned when it is missing.
+				// "a":  nil, -> commented on purpose: the test must verify that an error is returned when this is missing.
 			},
 			expectedErr: "property \"bar\" has been renamed and still appears in the new schema, so it means that it must be declared in rePaths (as a renamed property, or as a new property)",
 		},

--- a/core/internal/datastore/diffschemas/diffschemas_test.go
+++ b/core/internal/datastore/diffschemas/diffschemas_test.go
@@ -770,23 +770,53 @@ func TestDiff(t *testing.T) {
 			rePaths:     map[string]any{"x2": "x", "x2.a2": "x.a"},
 			expectedErr: "it is not possible to rename an object property (\"x\", renamed to \"x2\") and simultaneously make changes to its descendant properties",
 		},
+		// {
+		// 	name: "Property renamed and added again with the same name and same type, but the rePaths are invalid",
+		// 	fromSchema: types.Object([]types.Property{
+		// 		{Name: "bar", Type: types.Int(64), Nullable: true},
+		// 	}),
+		// 	toSchema: types.Object([]types.Property{
+		// 		{Name: "foo", Type: types.Int(64), Nullable: true},
+		// 		{Name: "bar", Type: types.Int(64), Nullable: true},
+		// 	}),
+		// 	rePaths: map[string]any{
+		// 		"foo": "bar",
+		// 		// "a":  nil, -> commented on purpose: the test must verify that an error is returned when it is missing.
+		// 	},
+		// 	expectedOps: []warehouses.AlterOperation{
+		// 		{Operation: warehouses.OperationRenameColumn, Column: "bar", NewColumn: "foo"},
+		// 		{Operation: warehouses.OperationAddColumn, Column: "bar", Type: types.Int(64)},
+		// 	},
+		// },
 		{
-			name: "Property renamed and added again with the same name and same type, but the repaths are invalid",
+			name: "One property added at first level (type string), but rePaths are invalid",
 			fromSchema: types.Object([]types.Property{
-				{Name: "bar", Type: types.Int(64), Nullable: true},
+				{Name: "a", Type: types.String(), Nullable: true},
 			}),
 			toSchema: types.Object([]types.Property{
-				{Name: "foo", Type: types.Int(64), Nullable: true},
-				{Name: "bar", Type: types.Int(64), Nullable: true},
+				{Name: "a", Type: types.String(), Nullable: true},
+				{Name: "b", Type: types.String(), Nullable: true},
 			}),
-			rePaths: map[string]any{
-				"foo": "bar",
-				// "a":  nil, -> commented on purpose: the test must verify that an error is returned when it is missing.
-			},
-			expectedOps: []warehouses.AlterOperation{
-				{Operation: warehouses.OperationRenameColumn, Column: "bar", NewColumn: "foo"},
-				{Operation: warehouses.OperationAddColumn, Column: "bar", Type: types.Int(64)},
-			},
+			rePaths:     map[string]any{"b": nil},
+			expectedErr: "rePaths cannot contain {..., \"b\": null, ...}, as there are no properties named \"b\" in the old schema",
+		},
+		{
+			name: "One property dropped at second level, but the rePaths are invalid",
+			fromSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "a", Type: types.String(), Nullable: true},
+					{Name: "b", Type: types.String(), Nullable: true},
+					{Name: "c", Type: types.String(), Nullable: true},
+				})},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "a", Type: types.String(), Nullable: true},
+					{Name: "b", Type: types.String(), Nullable: true},
+				})},
+			}),
+			rePaths:     map[string]any{"x.c": nil},
+			expectedErr: "rePaths cannot contain \"x.c\", as this property no longer exists in the new schema",
 		},
 	}
 

--- a/test/change_user_schema_test.go
+++ b/test/change_user_schema_test.go
@@ -188,7 +188,7 @@ func TestChangeProfileSchema(t *testing.T) {
 	if !slices.Equal(expectedQueries, queries) {
 		t.Fatalf("expected queries %#v, got %#v", expectedQueries, queries)
 	}
-	c.AlterProfileSchema(schema, nil, rePaths)
+	c.AlterProfileSchema(schema, nil, nil)
 
 	ws = c.Workspace()
 	if n := ws.ProfileSchema.Properties().Len(); n != 10 {


### PR DESCRIPTION
For #2026.

## Commit message

```
core/internal/datastore/diffschemas: improve validations on rePaths

Currently, the function that diffs two schemas accepts cases where the
rePaths indicate inconsistent information with respect to the properties
of the old and new schemas.

This can lead to inconsistencies, which in turn generate inconsistent
queries. See issue #2026.

For this reason, this commit handles such inconsistencies by returning
errors that indicate the problem. It also adds tests on these cases.

Resolves #2026.
```