### PR TITLE
core: rework `EventWriter` flushing to balance throughput and latency

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -127,7 +127,7 @@ func Run(ctx context.Context, settings *Settings, assetsFS fs.FS, initDBIfEmpty,
 	if err != nil {
 		return err
 	}
-	defer core.Close()
+	defer core.Close(ctx)
 
 	// Destroy the NATS private key.
 	for i := range config.NATS.NKey {

--- a/core/core.go
+++ b/core/core.go
@@ -350,7 +350,7 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 	}
 	defer func() {
 		if err != nil {
-			core.collector.Close()
+			core.collector.Close(context.Background())
 		}
 	}()
 
@@ -540,7 +540,7 @@ func (core *Core) ChangeMemberPasswordByToken(ctx context.Context, token string,
 // Close closes the Core. When Close is called, no other calls to Core's methods
 // should be in progress and no other shall be made.
 // It panics if it has already been called.
-func (core *Core) Close() {
+func (core *Core) Close(ctx context.Context) {
 	if core.closed.Swap(true) {
 		panic("core already closed")
 	}
@@ -562,7 +562,7 @@ func (core *Core) Close() {
 		}
 	}
 	// Close event collector, metrics, datastore, and state.
-	core.collector.Close()
+	core.collector.Close(ctx)
 	core.metrics.Close(context.Background())
 	core.datastore.Close()
 	core.state.Close()

--- a/core/internal/collector/collector.go
+++ b/core/internal/collector/collector.go
@@ -129,7 +129,7 @@ func New(db *db.DB, sc streams.Connection, st *state.State, ds *datastore.Datast
 // Close closes the collector. When Close is called, no other calls to
 // collector's methods should be in progress and no other shall be made.
 // It panics if it has already been called.
-func (c *Collector) Close() {
+func (c *Collector) Close(ctx context.Context) {
 	if c.closed.Swap(true) {
 		panic("core/events/collector already closed")
 	}
@@ -138,7 +138,7 @@ func (c *Collector) Close() {
 	}
 	c.workers.Wait()
 	c.eventWriters.Range(func(_, ew any) bool {
-		ew.(*datastore.EventWriter).Close()
+		_ = ew.(*datastore.EventWriter).Close(ctx)
 		return true
 	})
 }
@@ -287,7 +287,10 @@ func (c *Collector) onDeleteWorkspace(n state.DeleteWorkspace) {
 		}
 	}
 	ew, _ := c.eventWriters.LoadAndDelete(ws.ID)
-	ew.(*datastore.EventWriter).Close()
+	// Close using a canceled context to abort any in-flight flush.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = ew.(*datastore.EventWriter).Close(ctx)
 }
 
 // onLinkConnection is called when two unlinked connections are linked.
@@ -405,7 +408,7 @@ func (c *Collector) processWarehouseEvents(ctx context.Context, w *datastore.Eve
 			if !ok {
 				panic("consumer channel was closed before the worker terminated")
 			}
-			w.Write(event, pipeline)
+			_ = w.Write(ctx, event, pipeline)
 		case <-done:
 			consumer.Close()
 			return

--- a/core/internal/datastore/eventwriter.go
+++ b/core/internal/datastore/eventwriter.go
@@ -7,54 +7,83 @@ package datastore
 import (
 	"context"
 	"log/slog"
+	"math"
 	"math/rand/v2"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/meergo/meergo/core/internal/streams"
+	"github.com/meergo/meergo/tools/backoff"
 	"github.com/meergo/meergo/tools/metrics"
 )
 
+// eventFlusherTuning configures an EventWriter.
+type eventFlusherTuning struct {
+
+	// QueueSize is the size of the internal channel used to queue incoming events.
+	// A larger buffer can absorb short slowdowns in flush() without blocking writers.
+	QueueSize int
+
+	// BatchSize is the preferred number of events per flush.
+	// When the buffer reaches this size, EventWriter flushes as soon as possible.
+	BatchSize int
+
+	// MaxBatchSize is the maximum number of buffered events before forcing a flush.
+	// When the buffer reaches this size, EventWriter flushes immediately.
+	MaxBatchSize int
+
+	// MinFlushInterval is the smallest delay used by the adaptive scheduler.
+	// It avoids flushing too often when events arrive slowly but continuously.
+	MinFlushInterval time.Duration
+
+	// MaxFlushLatency is the longest time an event is allowed to wait in the buffer.
+	// Even if the batch is not full, EventWriter will flush within this time.
+	MaxFlushLatency time.Duration
+
+	// IdleFlushDelay triggers a flush when no new events arrive for this duration,
+	// as long as there are buffered events to write.
+	IdleFlushDelay time.Duration
+
+	// RateAlpha is the EWMA smoothing factor for the event rate estimate.
+	// Valid range is [0, 1]. Higher means more weight to recent observations.
+	RateAlpha float64
+}
+
+type eventRow struct {
+	pipeline int
+	row      []any
+	ack      streams.Ack
+}
+
 type EventWriter struct {
-	store     *Store
-	mu        sync.Mutex // for 'rows' and 'pipelines' fields
-	rows      [][]any
-	pipelines []int
-	acks      []streams.Ack
-	close     struct {
-		ctx       context.Context
-		cancelCtx context.CancelFunc
-	}
+	events  chan<- eventRow
+	flusher *eventFlusher
+	closed  atomic.Bool
 }
 
+// newEventWriter constructs and starts a EventWriter.
+// The returned EventWriter is ready to use.
 func newEventWriter(store *Store) *EventWriter {
-	ew := &EventWriter{
-		store: store,
+	tuning := eventFlusherTuning{
+		QueueSize:        8192,
+		BatchSize:        5000,
+		MaxBatchSize:     25000,
+		MinFlushInterval: 250 * time.Millisecond,
+		MaxFlushLatency:  10 * time.Second,
+		IdleFlushDelay:   750 * time.Millisecond,
+		RateAlpha:        0.4,
 	}
-	ew.close.ctx, ew.close.cancelCtx = context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(flushEventsQueueTimeout)
-		done := ew.close.ctx.Done()
-		for {
-			select {
-			case <-ticker.C:
-				ew.flush()
-			case <-done:
-				ticker.Stop()
-				return
-			}
-		}
-	}()
-	return ew
+
+	events := make(chan eventRow, tuning.QueueSize)
+	flusher := newEventFlusher(store, events, tuning)
+	flusher.Start()
+
+	return &EventWriter{events: events, flusher: flusher}
 }
 
-// Close closes the event writer.
-func (ew *EventWriter) Close() {
-	ew.close.cancelCtx()
-}
-
-// Write writes an event to the store.
-func (ew *EventWriter) Write(event streams.Event, pipeline int) {
+// Write persists an event to the store.
+// It returns an error only if the context is canceled.
+func (w *EventWriter) Write(ctx context.Context, event streams.Event, pipeline int) error {
 
 	row := make([]any, 66)
 
@@ -215,62 +244,283 @@ func (ew *EventWriter) Write(event streams.Event, pipeline int) {
 	// userId
 	row[65] = event.Attributes["userId"]
 
-	ew.mu.Lock()
-	ew.rows = append(ew.rows, row)
-	ew.pipelines = append(ew.pipelines, pipeline)
-	ew.acks = append(ew.acks, event.Ack)
-	ew.mu.Unlock()
+	select {
+	case w.events <- eventRow{pipeline: pipeline, row: row, ack: event.Ack}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 }
 
-func (ew *EventWriter) flush() {
+// Close closes the EventWriter. It panics if it has been already closed.
+//
+// When Close is called, no other calls to EventWriter's methods should be in
+// progress and no other shall be made.
+func (w *EventWriter) Close(ctx context.Context) error {
+	if w.closed.Swap(true) {
+		panic("EventWriter already closed")
+	}
+	return w.flusher.Close(ctx)
+}
+
+type eventFlusher struct {
+	store  *Store
+	tuning eventFlusherTuning
+
+	events <-chan eventRow
+
+	// stop and done are used to stop the loop and wait a flush termination.
+	stop chan struct{}
+	done chan struct{}
+
+	// flushCtx is canceled when any Close's ctx is canceled.
+	// This allows an in-flight flush to be interrupted by Close's ctx.
+	flushCtx    context.Context
+	cancelFlush context.CancelFunc
+}
+
+func newEventFlusher(store *Store, events <-chan eventRow, tuning eventFlusherTuning) *eventFlusher {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &eventFlusher{
+		store:       store,
+		events:      events,
+		tuning:      tuning,
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+		flushCtx:    ctx,
+		cancelFlush: cancel,
+	}
+}
+
+// Start returns immediately and begins the loop in a goroutine.
+func (f *eventFlusher) Start() {
+	go f.loop()
+}
+
+// Close interrupts scheduling of any new flush and terminates the loop.
+// If a flush is in progress, Close waits for it to finish unless ctx is
+// canceled, in which case the in-flight flush context is canceled and Close
+// returns ctx.Err().
+func (f *eventFlusher) Close(ctx context.Context) error {
+	close(f.stop)
+	select {
+	case <-f.done:
+		f.cancelFlush() // ensure resources associated with the flush context are released
+		return nil
+	case <-ctx.Done():
+		f.cancelFlush() // abort an in-flight flush, is any
+		<-f.done
+		return ctx.Err()
+	}
+}
+
+func (f *eventFlusher) loop() {
+
+	defer close(f.done)
+
+	tuning := f.tuning
+
+	// firstBuffered is the time when the first event was buffered.
+	var firstBuffered time.Time
+
+	var lastArrival time.Time
+
+	var rate float64 // events/sec (EWMA)
+
+	// idleTimer keeps latency low at low traffic and makes tests faster.
+	//
+	// Reset: on each incoming event
+	// Stop:  when the events are flushed
+	idleTimer := time.NewTimer(time.Hour) // <- tuning.IdleFlushDelay (750ms)
+
+	// adaptiveTimer schedules a flush while events keep arriving (so idleTimer may not fire).
+	// It estimates how fast events arrive (EWMA) and sets the timer to roughly when we should reach
+	// tuning.BatchSize events in the buffer (kept within [tuning.MinFlushInterval, tuning.MaxFlushLatency]
+	// and not later than maxTimer).
+	//
+	// Reset: on each incoming event (after updating the rate estimate)
+	// Stop:  when the events are flushed
+	adaptiveTimer := time.NewTimer(time.Hour)
+
+	// maxTimer guarantees the oldest buffered event waits at most tuning.MaxFlushLatency.
+	//
+	// Reset: once the first event is buffered
+	// Stop:  when the events are flushed
+	maxTimer := time.NewTimer(time.Hour) // <- tuning.MaxFlushLatency (5s)
+
+	stopTimers := func() {
+		idleTimer.Stop()
+		adaptiveTimer.Stop()
+		maxTimer.Stop()
+	}
+
+	// Since events is empty, stop all timers.
+	stopTimers()
+
+	events := make([]eventRow, 0, tuning.BatchSize)
+
+	flush := func() {
+
+		stopTimers()
+
+		if len(events) == 0 {
+			firstBuffered = time.Time{}
+			return
+		}
+
+		var flushCtx context.Context
+
+		bo := backoff.New(1000)
+		bo.SetCap(10 * time.Second)
+
+		for bo.Next(f.flushCtx) {
+			ctx, done, err := f.store.mc.StartOperation(f.flushCtx, normalMode)
+			if err != nil {
+				continue
+			}
+			flushCtx = ctx
+			defer done()
+			break
+		}
+		if err := f.flushCtx.Err(); err != nil {
+			return
+		}
+
+		// Flush buffered events. If the flush is interrupted (Close canceled the context),
+		// return and let the main loop exit without starting another flush.
+		err := f.flush(flushCtx, events)
+		if err != nil {
+			return
+		}
+
+		if cap(events) > tuning.MaxBatchSize {
+			events = make([]eventRow, 0, tuning.BatchSize)
+		} else {
+			events = events[:0]
+		}
+		firstBuffered = time.Time{}
+	}
+
+	for {
+
+		select {
+
+		case event := <-f.events:
+
+			// EWMA rate estimate from inter-arrival time.
+			now := time.Now()
+			if !lastArrival.IsZero() {
+				dt := now.Sub(lastArrival).Seconds()
+				if dt > 0 {
+					inst := 1.0 / dt
+					if rate == 0 {
+						rate = inst
+					} else {
+						alpha := tuning.RateAlpha
+						rate = alpha*inst + (1-alpha)*rate
+					}
+				}
+			}
+
+			events = append(events, event)
+
+			if len(events) == tuning.MaxBatchSize {
+				flush()
+				continue
+			}
+
+			idleTimer.Reset(tuning.IdleFlushDelay)
+			if len(events) == 1 {
+				firstBuffered = now
+				maxTimer.Reset(tuning.MaxFlushLatency)
+			}
+			lastArrival = now
+
+			// Adaptive schedule: expected time to reach BatchSize.
+			if rate > 0 {
+				remaining := float64(tuning.BatchSize - len(events))
+				if remaining < 0 {
+					remaining = 0
+				}
+				sec := remaining / rate
+				if math.IsNaN(sec) || math.IsInf(sec, 0) || sec < 0 {
+					sec = float64(tuning.MaxFlushLatency / time.Second)
+				}
+				d := time.Duration(sec * float64(time.Second))
+				if d < tuning.MinFlushInterval {
+					d = tuning.MinFlushInterval
+				}
+				if d > tuning.MaxFlushLatency {
+					d = tuning.MaxFlushLatency
+				}
+				// Respect max-latency deadline.
+				if !firstBuffered.IsZero() {
+					deadline := firstBuffered.Add(tuning.MaxFlushLatency)
+					until := time.Until(deadline)
+					if until < d {
+						d = until
+						if d < 0 {
+							d = 0
+						}
+					}
+				}
+				adaptiveTimer.Reset(d)
+			}
+
+		case <-idleTimer.C:
+			flush()
+
+		case <-adaptiveTimer.C:
+			flush()
+
+		case <-maxTimer.C:
+			flush()
+
+		case <-f.stop:
+			stopTimers()
+			return
+
+		}
+
+		if len(events) == 0 {
+			stopTimers()
+		}
+
+	}
+}
+
+// flush writes the given events.
+// It returns ctx.Err() on context cancellation.
+func (f *eventFlusher) flush(ctx context.Context, events []eventRow) error {
 
 	metrics.Increment("EventWriter.flush.calls", 1)
 
-	ew.mu.Lock()
-	rows, pipelines, acks := ew.rows, ew.pipelines, ew.acks
-	ew.rows, ew.pipelines, ew.acks = nil, nil, nil
-	ew.mu.Unlock()
-
-	if rows == nil {
-		return
+	rows := make([][]any, len(events))
+	for i, event := range events {
+		rows[i] = event.row
 	}
-
-	ctx, done, err := ew.store.mc.StartOperation(ew.close.ctx, normalMode)
-	if err != nil {
-		// Warehouse mode is not normal: discard events.
-		for _, ack := range acks {
-			ack()
-		}
-		for i := range rows {
-			ew.store.ds.metrics.FinalizeFailed(pipelines[i], 1, err.Error())
-		}
-		return
-	}
-	defer done()
 
 	for {
 		metrics.Increment("EventWriter.flush.for_loop_iterations", 1)
-		err = ew.store.warehouse().Merge(ctx, eventsMergeTable, rows, nil)
+		err := f.store.warehouse().Merge(ctx, eventsMergeTable, rows, nil)
 		if err != nil {
-			if ctx.Err() != nil {
-				return
+			if err := ctx.Err(); err != nil {
+				return err
 			}
 			slog.Error("core/datastore: cannot flush the event queue", "error", err)
 			select {
 			case <-time.After(time.Duration(rand.IntN(2000)) * time.Millisecond):
 			case <-ctx.Done():
-				return
+				return ctx.Err()
 			}
 			continue
 		}
-		for _, ack := range acks {
-			ack()
+		for _, event := range events {
+			event.ack()
+			f.store.ds.metrics.FinalizePassed(event.pipeline, 1)
 		}
-		for i := range rows {
-			ew.store.ds.metrics.FinalizePassed(pipelines[i], 1)
-		}
-		return
+		return nil
 	}
 
 }

--- a/core/internal/datastore/store.go
+++ b/core/internal/datastore/store.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/meergo/meergo/core/internal/schemas"
 	"github.com/meergo/meergo/core/internal/state"
@@ -21,8 +20,6 @@ import (
 	"github.com/meergo/meergo/tools/types"
 	"github.com/meergo/meergo/warehouses"
 )
-
-const flushEventsQueueTimeout = 1 * time.Second // interval to flush queued events the data warehouse
 
 // ErrDifferentWarehouse is an error indicating that the data warehouse being
 // attempted to connect to, during the change of the warehouse settings, is a
@@ -586,7 +583,6 @@ func (store *Store) UnsetIdentityProperties(ctx context.Context, pipeline int, p
 }
 
 // close closes the store.
-// It flushes the events and closes the data warehouse.
 // It panics if it has already been called.
 func (store *Store) close() error {
 	if store.closed.Swap(true) {


### PR DESCRIPTION
```
core: rework `EventWriter` flushing to balance throughput and latency

The previous writer had the following issues:

- it flushed on a fixed 1s interval regardless of queue size, which
  caused many small flushes or batches with no upper bound
- the in‑memory queue was unbounded, so it could grow without limit when
  flushes fell behind
- if the warehouse mode was incompatible with the flush, events were 
  discarded

The redesign fixes those issues:

- flushes now consider both time and backlog: an idle timeout keeps
  latency low when traffic is sparse (e.g. tests), an adaptive timer 
  follows the observed arrival rate to target batch size, and a hard
  max forces an immediate flush
- the in‑memory queue is now bounded to avoid unbounded growth
- when a flush cannot start, it retries indefinitely with exponential
  backoff, and flush failures are retried while the flush context is
  still alive
```