### PR TITLE
core: rework `EventIdentityWriter` flushing to match `EventWriter`

### DIFF
--- a/core/internal/collector/identitywriter.go
+++ b/core/internal/collector/identitywriter.go
@@ -159,7 +159,7 @@ func (iw *identityWriter) transformAndWrite(events []streams.Event) {
 		event := events[i]
 		id, _ := event.Attributes["userId"].(string)
 		// Write the identity on the data warehouse.
-		err = iw.writer.Write(datastore.Identity{
+		err = iw.writer.Write(ctx, datastore.Identity{
 			ID:          id,
 			AnonymousID: event.Attributes["anonymousId"].(string),
 			Attributes:  record.Attributes,
@@ -173,7 +173,7 @@ func (iw *identityWriter) transformAndWrite(events []streams.Event) {
 // writeDirect writes the identity without performing any transformation.
 func (iw *identityWriter) writeDirect(event streams.Event) error {
 	id, _ := event.Attributes["userId"].(string)
-	return iw.writer.Write(datastore.Identity{
+	return iw.writer.Write(context.Background(), datastore.Identity{
 		ID:          id,
 		AnonymousID: event.Attributes["anonymousId"].(string),
 		Attributes:  map[string]any{},

--- a/core/internal/datastore/event_identitywriter.go
+++ b/core/internal/datastore/event_identitywriter.go
@@ -102,12 +102,13 @@ func newEventIdentityWriter(store *Store, pipelineID int) *EventIdentityWriter {
 
 // Close closes the EventWriter. It panics if it has been already closed.
 //
-// When Close is called, no other calls to EventWriter's methods should be in
-// progress and no other shall be made.
+// When Close is called, no other calls to EventIdentityWriter's methods should
+// be in progress and no other shall be made.
 func (w *EventIdentityWriter) Close(ctx context.Context) error {
 	if w.closed.Swap(true) {
 		panic("EventIdentityWriter already closed")
 	}
+	// Close the flusher.
 	err := w.flusher.Close(ctx)
 	w.store.mu.Lock()
 	delete(w.store.eventIdentityWriters, w.pipeline)

--- a/core/internal/datastore/event_identitywriter.go
+++ b/core/internal/datastore/event_identitywriter.go
@@ -85,13 +85,13 @@ func newEventIdentityWriter(store *Store, pipelineID int) *EventIdentityWriter {
 
 	// Start the flusher.
 	conf := flusherConf{
-		QueueSize:        8192,
-		BatchSize:        5000,
-		MaxBatchSize:     25000,
-		MinFlushInterval: 250 * time.Millisecond,
-		MaxFlushLatency:  10 * time.Second,
-		IdleFlushDelay:   750 * time.Millisecond,
-		RateAlpha:        0.4,
+		QueueSize:        32768,
+		BatchSize:        20000,
+		MaxBatchSize:     100000,
+		MinFlushInterval: 500 * time.Millisecond,
+		MaxFlushLatency:  15 * time.Second,
+		IdleFlushDelay:   2 * time.Second,
+		RateAlpha:        0.3,
 	}
 	identities := make(chan flusherRow[map[string]any], conf.QueueSize)
 	w.identities = identities

--- a/core/internal/datastore/event_identitywriter.go
+++ b/core/internal/datastore/event_identitywriter.go
@@ -13,7 +13,6 @@ import (
 	"github.com/meergo/meergo/core/internal/schemas"
 	"github.com/meergo/meergo/core/internal/state"
 	"github.com/meergo/meergo/core/internal/streams"
-	"github.com/meergo/meergo/tools/metrics"
 	"github.com/meergo/meergo/tools/types"
 	"github.com/meergo/meergo/warehouses"
 )
@@ -27,22 +26,15 @@ type EventIdentityWriter struct {
 	pipeline   int
 	connection int
 	columns    []warehouses.Column
+	identities chan<- flusherRow[map[string]any]
+	flusher    *flusher[map[string]any]
 
 	mu        sync.Mutex
 	pipelines map[int]struct{} // pipelines of the pipeline's connection. Access using 'mu'. If nil, it means that the pipeline does not exist anymore.
 	aligned   bool             // indicates if the pipeline's output schema is aligned with the profile schema. access using 'mu'.
 	flatter   *flatter         // access using 'mu'. nil for pipelines that import identities from events with no transformations.
-	index     map[identityKey]int
-	rows      []map[string]any
-	acks      []streams.Ack
-	timer     *time.Timer
 
-	close struct {
-		ctx    context.Context
-		cancel context.CancelFunc
-		atomic.Bool
-		sync.WaitGroup
-	}
+	closed atomic.Bool
 }
 
 // newEventIdentityWriter returns an identity writer for writing user
@@ -53,111 +45,84 @@ type EventIdentityWriter struct {
 func newEventIdentityWriter(store *Store, pipelineID int) *EventIdentityWriter {
 
 	// Initialize the EventIdentityWriter.
-	iw := &EventIdentityWriter{
+	w := &EventIdentityWriter{
 		store:     store,
 		pipeline:  pipelineID,
-		index:     map[identityKey]int{},
 		pipelines: map[int]struct{}{},
 	}
 
 	pipeline, _ := store.ds.state.Pipeline(pipelineID)
 	connection := pipeline.Connection()
-	iw.connection = connection.ID
+	w.connection = connection.ID
 	if pipeline.OutSchema.Valid() {
 		workspace := connection.Workspace()
 		err := schemas.CheckAlignment(pipeline.OutSchema, workspace.ProfileSchema, nil)
 		if err == nil {
-			iw.aligned = true
-			iw.flatter = newFlatter(pipeline.OutSchema, store.identityColumnByProperty())
+			w.aligned = true
+			w.flatter = newFlatter(pipeline.OutSchema, store.identityColumnByProperty())
 		}
 	} else {
 		// The pipeline's out schema is invalid when importing identities from
 		// events without any transformation in the pipeline.
-		iw.aligned = true
+		w.aligned = true
 	}
 	for _, p := range connection.Pipelines() {
-		iw.pipelines[p.ID] = struct{}{}
+		w.pipelines[p.ID] = struct{}{}
 	}
 	store.mu.Lock()
-	store.eventIdentityWriters[pipeline.ID] = iw
+	store.eventIdentityWriters[pipeline.ID] = w
 	store.mu.Unlock()
 
-	iw.columns = make([]warehouses.Column, 7)
-	iw.columns[0] = warehouses.Column{Name: "_pipeline", Type: types.Int(32)}
-	iw.columns[1] = warehouses.Column{Name: "_is_anonymous", Type: types.Boolean()}
-	iw.columns[2] = warehouses.Column{Name: "_identity_id", Type: types.String()}
-	iw.columns[3] = warehouses.Column{Name: "_connection", Type: types.Int(32)}
-	iw.columns[4] = warehouses.Column{Name: "_anonymous_ids", Type: types.Array(types.String()), Nullable: true}
-	iw.columns[5] = warehouses.Column{Name: "_updated_at", Type: types.DateTime()}
-	iw.columns[6] = warehouses.Column{Name: "_run", Type: types.Int(32), Nullable: true}
-	iw.columns = appendColumnsFromProperties(iw.columns, pipeline.Transformation.OutPaths, store.profileColumnByProperty())
+	w.columns = make([]warehouses.Column, 7)
+	w.columns[0] = warehouses.Column{Name: "_pipeline", Type: types.Int(32)}
+	w.columns[1] = warehouses.Column{Name: "_is_anonymous", Type: types.Boolean()}
+	w.columns[2] = warehouses.Column{Name: "_identity_id", Type: types.String()}
+	w.columns[3] = warehouses.Column{Name: "_connection", Type: types.Int(32)}
+	w.columns[4] = warehouses.Column{Name: "_anonymous_ids", Type: types.Array(types.String()), Nullable: true}
+	w.columns[5] = warehouses.Column{Name: "_updated_at", Type: types.DateTime()}
+	w.columns[6] = warehouses.Column{Name: "_run", Type: types.Int(32), Nullable: true}
+	w.columns = appendColumnsFromProperties(w.columns, pipeline.Transformation.OutPaths, store.profileColumnByProperty())
 
-	iw.close.ctx, iw.close.cancel = context.WithCancel(context.Background())
+	// Start the flusher.
+	conf := flusherConf{
+		QueueSize:        8192,
+		BatchSize:        5000,
+		MaxBatchSize:     25000,
+		MinFlushInterval: 250 * time.Millisecond,
+		MaxFlushLatency:  10 * time.Second,
+		IdleFlushDelay:   750 * time.Millisecond,
+		RateAlpha:        0.4,
+	}
+	identities := make(chan flusherRow[map[string]any], conf.QueueSize)
+	w.identities = identities
+	w.flusher = newFlusher(store, identities, w.flush, conf)
 
-	return iw
+	return w
 }
 
-// Close closes the Writer, ensuring the completion of all pending or ongoing
-// write operations. In the event of a canceled context, it interrupts ongoing
-// writes, discards pending ones, and returns.
+// Close closes the EventWriter. It panics if it has been already closed.
 //
-// If the writer is already closed, it does nothing and returns immediately.
-//
-// If the data warehouse is in inspection mode, it returns the ErrInspectionMode
-// error. If it is in maintenance mode, it returns the ErrMaintenanceMode error.
-// If an error occurs with the data warehouse, it returns a
-// *datastore.UnavailableError error.
-//
-// TODO(Gianluca): if these errors returned from Close seem strange, it's
-// because we still need to discuss the issue
-// https://github.com/meergo/meergo/issues/1224 and understand precisely what
-// model we want to implement for the operations and compatible methods.
-//
-// It must be called on a frozen state.
-func (iw *EventIdentityWriter) Close(ctx context.Context) error {
-	if iw.close.Load() {
-		return nil
+// When Close is called, no other calls to EventWriter's methods should be in
+// progress and no other shall be made.
+func (w *EventIdentityWriter) Close(ctx context.Context) error {
+	if w.closed.Swap(true) {
+		panic("EventIdentityWriter already closed")
 	}
-	ctx, done, err := iw.store.mc.StartOperation(ctx, normalMode)
-	if err != nil {
-		return err
-	}
-	defer done()
-	// Mark as closed and return if it was already closed in the meantime.
-	if iw.close.Swap(true) {
-		return nil
-	}
-	iw.store.mu.Lock()
-	delete(iw.store.eventIdentityWriters, iw.pipeline)
-	iw.store.mu.Unlock()
-	// Cancel the flushes if the context is canceled.
-	stop := context.AfterFunc(ctx, func() { iw.close.cancel() })
-	defer stop()
-	// Wait for the flushes and method calls to terminate.
-	iw.close.Wait()
-	// Perform a final flush.
-	iw.mu.Lock()
-	iw.flush()
-	iw.mu.Unlock()
-	iw.close.Wait()
-	return nil
+	err := w.flusher.Close(ctx)
+	w.store.mu.Lock()
+	delete(w.store.eventIdentityWriters, w.pipeline)
+	w.store.mu.Unlock()
+	return err
 }
 
 // Write writes an identity. If a valid profile schema has been provided, the
 // attributes must comply with it. It returns immediately, deferring the
 // validation of the attributes and the actual write operation to a later time.
 //
-// If the pipeline of iw does not exist anymore, returns an error.
-//
-// It panics if called on a closed writer.
-func (iw *EventIdentityWriter) Write(identity Identity, ack streams.Ack) error {
-	if iw.close.Load() {
-		panic("call Write on a closed identity writer")
-	}
+// If the pipeline of w does not exist anymore, returns an error.
+func (w *EventIdentityWriter) Write(ctx context.Context, identity Identity, ack streams.Ack) error {
 
-	metrics.Increment("EventIdentityWriter.Write.calls", 1)
-
-	key := identityKey{pipeline: iw.pipeline}
+	key := identityKey{pipeline: w.pipeline}
 	if identity.ID == "" {
 		key.isAnonymous = true
 		key.identityID = identity.AnonymousID
@@ -165,11 +130,11 @@ func (iw *EventIdentityWriter) Write(identity Identity, ack streams.Ack) error {
 		key.identityID = identity.ID
 	}
 
-	iw.mu.Lock()
-	pipelines := iw.pipelines
-	aligned := iw.aligned
-	flatter := iw.flatter
-	iw.mu.Unlock()
+	w.mu.Lock()
+	pipelines := w.pipelines
+	aligned := w.aligned
+	flatter := w.flatter
+	w.mu.Unlock()
 
 	if pipelines == nil {
 		return ErrPipelineNotExist
@@ -194,10 +159,15 @@ func (iw *EventIdentityWriter) Write(identity Identity, ack streams.Ack) error {
 				"_pipeline":     key.pipeline,
 				"_is_anonymous": true,
 				"_identity_id":  key.identityID,
-				"_connection":   iw.connection,
+				"_connection":   w.connection,
 				"_updated_at":   identity.UpdatedAt,
 			}
-			iw.appendRow(key, row, nil)
+			select {
+			case w.identities <- flusherRow[map[string]any]{key: key, pipeline: w.pipeline, row: row}:
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 	}
 
@@ -211,121 +181,68 @@ func (iw *EventIdentityWriter) Write(identity Identity, ack streams.Ack) error {
 	row["_pipeline"] = key.pipeline
 	row["_is_anonymous"] = key.isAnonymous
 	row["_identity_id"] = key.identityID
-	row["_connection"] = iw.connection
+	row["_connection"] = w.connection
 	if !key.isAnonymous {
 		row["_anonymous_ids"] = []any{identity.AnonymousID}
 	}
 	row["_updated_at"] = identity.UpdatedAt
 
-	iw.appendRow(key, row, ack)
+	select {
+	case w.identities <- flusherRow[map[string]any]{key: key, pipeline: w.pipeline, row: row, ack: ack}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
-	return nil
 }
 
-// appendRow appends a row to the rows or replaces an existing row with the same
-// key.
-func (iw *EventIdentityWriter) appendRow(key identityKey, row map[string]any, ack streams.Ack) {
-	iw.mu.Lock()
-	if ack != nil {
-		iw.acks = append(iw.acks, ack)
-	}
-	// If a row with the same key already exists, update that row rather than adding a duplicate.
-	if i, ok := iw.index[key]; ok {
-		iw.rows[i] = row
-		iw.mu.Unlock()
-		return
-	}
-	if len(iw.rows) == 0 {
-		iw.timer = time.AfterFunc(maxQueuedIdentityTime, func() {
-			iw.mu.Lock()
-			iw.flush()
-			iw.mu.Unlock()
-		})
-	}
-	iw.index[key] = len(iw.rows)
-	iw.rows = append(iw.rows, row)
-	if len(iw.rows) == maxQueuedIdentityRows {
-		iw.flush()
-	}
-	iw.mu.Unlock()
-}
-
-// flush flushes the rows, if any, into the data warehouse.
-// It must be called while holding the iw.mu mutex.
-func (iw *EventIdentityWriter) flush() {
-	metrics.Increment("EventIdentityWriter.flush.calls", 1)
-	if iw.rows == nil {
-		return
-	}
-	rows := iw.rows
-	iw.rows = nil
-	acks := iw.acks
-	iw.acks = nil
-	clear(iw.index)
-	iw.timer = nil
-	iw.close.Go(func() {
-		defer func() {
-			for _, ack := range acks {
-				ack()
-			}
-		}()
-		ctx, done, err := iw.store.mc.StartOperation(iw.close.ctx, normalMode)
-		if err != nil {
-			// Warehouse mode is not normal: discard identities.
-			iw.store.ds.metrics.FinalizeFailed(iw.pipeline, len(acks), err.Error())
-			return
-		}
-		defer done()
-		err = iw.store.warehouse().MergeIdentities(ctx, iw.columns, rows)
-		if err != nil {
-			iw.store.ds.metrics.FinalizeFailed(iw.pipeline, len(acks), err.Error())
-			return
-		}
-		iw.store.ds.metrics.FinalizePassed(iw.pipeline, len(acks))
-	})
+// flush writes the given identities.
+// It returns ctx.Err() on context cancellation.
+func (w *EventIdentityWriter) flush(ctx context.Context, identities []map[string]any) error {
+	return w.store.warehouse().MergeIdentities(ctx, w.columns, identities)
 }
 
 // onCreatePipeline is called when a pipeline of the connection of iw's pipeline
 // is created.
 //
 // The notification is propagated by the Store.onCreatePipeline method.
-func (iw *EventIdentityWriter) onCreatePipeline(n state.CreatePipeline) {
-	iw.mu.Lock()
-	if iw.pipelines != nil {
-		iw.pipelines[n.ID] = struct{}{}
+func (w *EventIdentityWriter) onCreatePipeline(n state.CreatePipeline) {
+	w.mu.Lock()
+	if w.pipelines != nil {
+		w.pipelines[n.ID] = struct{}{}
 	}
-	iw.mu.Unlock()
+	w.mu.Unlock()
 }
 
 // onDeleteConnection is called the connection of the iw's pipeline is deleted.
 //
 // The notification is propagated by the Store.onDeleteConnection method.
-func (iw *EventIdentityWriter) onDeleteConnection(_ state.DeleteConnection) {
-	iw.mu.Lock()
-	iw.pipelines = nil
-	iw.mu.Unlock()
+func (w *EventIdentityWriter) onDeleteConnection(_ state.DeleteConnection) {
+	w.mu.Lock()
+	w.pipelines = nil
+	w.mu.Unlock()
 }
 
 // onDeletePipeline is called when a pipeline of the connection of iw's pipeline
 // is deleted.
 //
 // The notification is propagated by the Store.onDeletePipeline method.
-func (iw *EventIdentityWriter) onDeletePipeline(n state.DeletePipeline) {
-	iw.mu.Lock()
-	if n.ID == iw.pipeline {
-		iw.pipelines = nil
+func (w *EventIdentityWriter) onDeletePipeline(n state.DeletePipeline) {
+	w.mu.Lock()
+	if n.ID == w.pipeline {
+		w.pipelines = nil
 	} else {
-		delete(iw.pipelines, n.ID)
+		delete(w.pipelines, n.ID)
 	}
-	iw.mu.Unlock()
+	w.mu.Unlock()
 }
 
 // onEndAlterProfileSchema is called when the alter of the profile schema of a
 // workspace ends.
 //
 // This notification is propagated by the Store.onEndAlterProfileSchema method.
-func (iw *EventIdentityWriter) onEndAlterProfileSchema(_ state.EndAlterProfileSchema) {
-	pipeline, ok := iw.store.ds.state.Pipeline(iw.pipeline)
+func (w *EventIdentityWriter) onEndAlterProfileSchema(_ state.EndAlterProfileSchema) {
+	pipeline, ok := w.store.ds.state.Pipeline(w.pipeline)
 	if !ok {
 		return
 	}
@@ -336,43 +253,43 @@ func (iw *EventIdentityWriter) onEndAlterProfileSchema(_ state.EndAlterProfileSc
 		err := schemas.CheckAlignment(pipeline.OutSchema, workspace.ProfileSchema, nil)
 		if err == nil {
 			aligned = true
-			flatter = newFlatter(pipeline.OutSchema, iw.store.identityColumnByProperty())
+			flatter = newFlatter(pipeline.OutSchema, w.store.identityColumnByProperty())
 		}
 	} else {
 		// The pipeline's out schema is invalid when importing identities from
 		// events without any transformation in the pipeline.
 		aligned = true
 	}
-	iw.mu.Lock()
-	iw.aligned = aligned
-	iw.flatter = flatter
-	iw.mu.Unlock()
+	w.mu.Lock()
+	w.aligned = aligned
+	w.flatter = flatter
+	w.mu.Unlock()
 }
 
 // onUpdatePipeline is called when a pipeline of the connection of iw's pipeline
 // is updated.
 //
 // The notification is propagated by the Store.onUpdatePipeline method.
-func (iw *EventIdentityWriter) onUpdatePipeline(n state.UpdatePipeline) {
+func (w *EventIdentityWriter) onUpdatePipeline(n state.UpdatePipeline) {
 	var aligned bool
 	var flatter *flatter
 	if n.OutSchema.Valid() {
-		workspace, ok := iw.store.ds.state.Workspace(iw.store.workspace)
+		workspace, ok := w.store.ds.state.Workspace(w.store.workspace)
 		if !ok {
 			return
 		}
 		err := schemas.CheckAlignment(n.OutSchema, workspace.ProfileSchema, nil)
 		if err == nil {
 			aligned = true
-			flatter = newFlatter(n.OutSchema, iw.store.identityColumnByProperty())
+			flatter = newFlatter(n.OutSchema, w.store.identityColumnByProperty())
 		}
 	} else {
 		// The pipeline's out schema is invalid when importing identities from
 		// events without any transformation in the pipeline.
 		aligned = true
 	}
-	iw.mu.Lock()
-	iw.aligned = aligned
-	iw.flatter = flatter
-	iw.mu.Unlock()
+	w.mu.Lock()
+	w.aligned = aligned
+	w.flatter = flatter
+	w.mu.Unlock()
 }

--- a/core/internal/datastore/eventwriter.go
+++ b/core/internal/datastore/eventwriter.go
@@ -222,6 +222,7 @@ func (w *EventWriter) Close(ctx context.Context) error {
 	if w.closed.Swap(true) {
 		panic("EventWriter already closed")
 	}
+	// Close the flusher.
 	return w.flusher.Close(ctx)
 }
 

--- a/core/internal/datastore/eventwriter.go
+++ b/core/internal/datastore/eventwriter.go
@@ -6,65 +6,23 @@ package datastore
 
 import (
 	"context"
-	"log/slog"
-	"math"
-	"math/rand/v2"
 	"sync/atomic"
 	"time"
 
 	"github.com/meergo/meergo/core/internal/streams"
-	"github.com/meergo/meergo/tools/backoff"
-	"github.com/meergo/meergo/tools/metrics"
 )
 
-// eventFlusherTuning configures an EventWriter.
-type eventFlusherTuning struct {
-
-	// QueueSize is the size of the internal channel used to queue incoming events.
-	// A larger buffer can absorb short slowdowns in flush() without blocking writers.
-	QueueSize int
-
-	// BatchSize is the preferred number of events per flush.
-	// When the buffer reaches this size, EventWriter flushes as soon as possible.
-	BatchSize int
-
-	// MaxBatchSize is the maximum number of buffered events before forcing a flush.
-	// When the buffer reaches this size, EventWriter flushes immediately.
-	MaxBatchSize int
-
-	// MinFlushInterval is the smallest delay used by the adaptive scheduler.
-	// It avoids flushing too often when events arrive slowly but continuously.
-	MinFlushInterval time.Duration
-
-	// MaxFlushLatency is the longest time an event is allowed to wait in the buffer.
-	// Even if the batch is not full, EventWriter will flush within this time.
-	MaxFlushLatency time.Duration
-
-	// IdleFlushDelay triggers a flush when no new events arrive for this duration,
-	// as long as there are buffered events to write.
-	IdleFlushDelay time.Duration
-
-	// RateAlpha is the EWMA smoothing factor for the event rate estimate.
-	// Valid range is [0, 1]. Higher means more weight to recent observations.
-	RateAlpha float64
-}
-
-type eventRow struct {
-	pipeline int
-	row      []any
-	ack      streams.Ack
-}
-
 type EventWriter struct {
-	events  chan<- eventRow
-	flusher *eventFlusher
+	store   *Store
+	events  chan<- flusherRow[[]any]
+	flusher *flusher[[]any]
 	closed  atomic.Bool
 }
 
 // newEventWriter constructs and starts a EventWriter.
 // The returned EventWriter is ready to use.
 func newEventWriter(store *Store) *EventWriter {
-	tuning := eventFlusherTuning{
+	conf := flusherConf{
 		QueueSize:        8192,
 		BatchSize:        5000,
 		MaxBatchSize:     25000,
@@ -74,11 +32,14 @@ func newEventWriter(store *Store) *EventWriter {
 		RateAlpha:        0.4,
 	}
 
-	events := make(chan eventRow, tuning.QueueSize)
-	flusher := newEventFlusher(store, events, tuning)
-	flusher.Start()
+	events := make(chan flusherRow[[]any], conf.QueueSize)
+	w := &EventWriter{
+		store:  store,
+		events: events,
+	}
+	w.flusher = newFlusher(store, events, w.flush, conf)
 
-	return &EventWriter{events: events, flusher: flusher}
+	return w
 }
 
 // Write persists an event to the store.
@@ -245,7 +206,7 @@ func (w *EventWriter) Write(ctx context.Context, event streams.Event, pipeline i
 	row[65] = event.Attributes["userId"]
 
 	select {
-	case w.events <- eventRow{pipeline: pipeline, row: row, ack: event.Ack}:
+	case w.events <- flusherRow[[]any]{pipeline: pipeline, row: row, ack: event.Ack}:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -264,263 +225,8 @@ func (w *EventWriter) Close(ctx context.Context) error {
 	return w.flusher.Close(ctx)
 }
 
-type eventFlusher struct {
-	store  *Store
-	tuning eventFlusherTuning
-
-	events <-chan eventRow
-
-	// stop and done are used to stop the loop and wait a flush termination.
-	stop chan struct{}
-	done chan struct{}
-
-	// flushCtx is canceled when any Close's ctx is canceled.
-	// This allows an in-flight flush to be interrupted by Close's ctx.
-	flushCtx    context.Context
-	cancelFlush context.CancelFunc
-}
-
-func newEventFlusher(store *Store, events <-chan eventRow, tuning eventFlusherTuning) *eventFlusher {
-	ctx, cancel := context.WithCancel(context.Background())
-	return &eventFlusher{
-		store:       store,
-		events:      events,
-		tuning:      tuning,
-		stop:        make(chan struct{}),
-		done:        make(chan struct{}),
-		flushCtx:    ctx,
-		cancelFlush: cancel,
-	}
-}
-
-// Start returns immediately and begins the loop in a goroutine.
-func (f *eventFlusher) Start() {
-	go f.loop()
-}
-
-// Close interrupts scheduling of any new flush and terminates the loop.
-// If a flush is in progress, Close waits for it to finish unless ctx is
-// canceled, in which case the in-flight flush context is canceled and Close
-// returns ctx.Err().
-func (f *eventFlusher) Close(ctx context.Context) error {
-	close(f.stop)
-	select {
-	case <-f.done:
-		f.cancelFlush() // ensure resources associated with the flush context are released
-		return nil
-	case <-ctx.Done():
-		f.cancelFlush() // abort an in-flight flush, is any
-		<-f.done
-		return ctx.Err()
-	}
-}
-
-func (f *eventFlusher) loop() {
-
-	defer close(f.done)
-
-	tuning := f.tuning
-
-	// firstBuffered is the time when the first event was buffered.
-	var firstBuffered time.Time
-
-	var lastArrival time.Time
-
-	var rate float64 // events/sec (EWMA)
-
-	// idleTimer keeps latency low at low traffic and makes tests faster.
-	//
-	// Reset: on each incoming event
-	// Stop:  when the events are flushed
-	idleTimer := time.NewTimer(time.Hour) // <- tuning.IdleFlushDelay (750ms)
-
-	// adaptiveTimer schedules a flush while events keep arriving (so idleTimer may not fire).
-	// It estimates how fast events arrive (EWMA) and sets the timer to roughly when we should reach
-	// tuning.BatchSize events in the buffer (kept within [tuning.MinFlushInterval, tuning.MaxFlushLatency]
-	// and not later than maxTimer).
-	//
-	// Reset: on each incoming event (after updating the rate estimate)
-	// Stop:  when the events are flushed
-	adaptiveTimer := time.NewTimer(time.Hour)
-
-	// maxTimer guarantees the oldest buffered event waits at most tuning.MaxFlushLatency.
-	//
-	// Reset: once the first event is buffered
-	// Stop:  when the events are flushed
-	maxTimer := time.NewTimer(time.Hour) // <- tuning.MaxFlushLatency (5s)
-
-	stopTimers := func() {
-		idleTimer.Stop()
-		adaptiveTimer.Stop()
-		maxTimer.Stop()
-	}
-
-	// Since events is empty, stop all timers.
-	stopTimers()
-
-	events := make([]eventRow, 0, tuning.BatchSize)
-
-	flush := func() {
-
-		stopTimers()
-
-		if len(events) == 0 {
-			firstBuffered = time.Time{}
-			return
-		}
-
-		var flushCtx context.Context
-
-		bo := backoff.New(1000)
-		bo.SetCap(10 * time.Second)
-
-		for bo.Next(f.flushCtx) {
-			ctx, done, err := f.store.mc.StartOperation(f.flushCtx, normalMode)
-			if err != nil {
-				continue
-			}
-			flushCtx = ctx
-			defer done()
-			break
-		}
-		if err := f.flushCtx.Err(); err != nil {
-			return
-		}
-
-		// Flush buffered events. If the flush is interrupted (Close canceled the context),
-		// return and let the main loop exit without starting another flush.
-		err := f.flush(flushCtx, events)
-		if err != nil {
-			return
-		}
-
-		if cap(events) > tuning.MaxBatchSize {
-			events = make([]eventRow, 0, tuning.BatchSize)
-		} else {
-			events = events[:0]
-		}
-		firstBuffered = time.Time{}
-	}
-
-	for {
-
-		select {
-
-		case event := <-f.events:
-
-			// EWMA rate estimate from inter-arrival time.
-			now := time.Now()
-			if !lastArrival.IsZero() {
-				dt := now.Sub(lastArrival).Seconds()
-				if dt > 0 {
-					inst := 1.0 / dt
-					if rate == 0 {
-						rate = inst
-					} else {
-						alpha := tuning.RateAlpha
-						rate = alpha*inst + (1-alpha)*rate
-					}
-				}
-			}
-
-			events = append(events, event)
-
-			if len(events) == tuning.MaxBatchSize {
-				flush()
-				continue
-			}
-
-			idleTimer.Reset(tuning.IdleFlushDelay)
-			if len(events) == 1 {
-				firstBuffered = now
-				maxTimer.Reset(tuning.MaxFlushLatency)
-			}
-			lastArrival = now
-
-			// Adaptive schedule: expected time to reach BatchSize.
-			if rate > 0 {
-				remaining := float64(tuning.BatchSize - len(events))
-				if remaining < 0 {
-					remaining = 0
-				}
-				sec := remaining / rate
-				if math.IsNaN(sec) || math.IsInf(sec, 0) || sec < 0 {
-					sec = float64(tuning.MaxFlushLatency / time.Second)
-				}
-				d := time.Duration(sec * float64(time.Second))
-				if d < tuning.MinFlushInterval {
-					d = tuning.MinFlushInterval
-				}
-				if d > tuning.MaxFlushLatency {
-					d = tuning.MaxFlushLatency
-				}
-				// Respect max-latency deadline.
-				if !firstBuffered.IsZero() {
-					deadline := firstBuffered.Add(tuning.MaxFlushLatency)
-					until := time.Until(deadline)
-					if until < d {
-						d = until
-						if d < 0 {
-							d = 0
-						}
-					}
-				}
-				adaptiveTimer.Reset(d)
-			}
-
-		case <-idleTimer.C:
-			flush()
-
-		case <-adaptiveTimer.C:
-			flush()
-
-		case <-maxTimer.C:
-			flush()
-
-		case <-f.stop:
-			stopTimers()
-			return
-
-		}
-
-		if len(events) == 0 {
-			stopTimers()
-		}
-
-	}
-}
-
 // flush writes the given events.
 // It returns ctx.Err() on context cancellation.
-func (f *eventFlusher) flush(ctx context.Context, events []eventRow) error {
-
-	metrics.Increment("EventWriter.flush.calls", 1)
-
-	rows := make([][]any, len(events))
-	for i, event := range events {
-		rows[i] = event.row
-	}
-
-	for {
-		metrics.Increment("EventWriter.flush.for_loop_iterations", 1)
-		err := f.store.warehouse().Merge(ctx, eventsMergeTable, rows, nil)
-		if err != nil {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			slog.Error("core/datastore: cannot flush the event queue", "error", err)
-			select {
-			case <-time.After(time.Duration(rand.IntN(2000)) * time.Millisecond):
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-			continue
-		}
-		for _, event := range events {
-			event.ack()
-			f.store.ds.metrics.FinalizePassed(event.pipeline, 1)
-		}
-		return nil
-	}
-
+func (w *EventWriter) flush(ctx context.Context, events [][]any) error {
+	return w.store.warehouse().Merge(ctx, eventsMergeTable, events, nil)
 }

--- a/core/internal/datastore/flusher.go
+++ b/core/internal/datastore/flusher.go
@@ -1,0 +1,321 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by an Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package datastore
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/meergo/meergo/core/internal/streams"
+	"github.com/meergo/meergo/tools/backoff"
+)
+
+type flusherRow[T any] struct {
+	key      any
+	pipeline int
+	row      T
+	ack      streams.Ack
+}
+
+type flusher[T any] struct {
+	store *Store
+	conf  flusherConf
+
+	rows <-chan flusherRow[T]
+
+	flush func(context.Context, []T) error
+
+	// stop and done are used to stop the loop and wait a flush termination.
+	stop chan struct{}
+	done chan struct{}
+
+	// flushCtx is canceled when any Close's ctx is canceled.
+	// This allows an in-flight flush to be interrupted by Close's ctx.
+	flushCtx    context.Context
+	cancelFlush context.CancelFunc
+}
+
+func newFlusher[T any](store *Store, rows <-chan flusherRow[T], flush func(context.Context, []T) error, conf flusherConf) *flusher[T] {
+	ctx, cancel := context.WithCancel(context.Background())
+	f := &flusher[T]{
+		store:       store,
+		rows:        rows,
+		flush:       flush,
+		conf:        conf,
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+		flushCtx:    ctx,
+		cancelFlush: cancel,
+	}
+	go f.loop()
+	return f
+}
+
+// Close interrupts scheduling of any new flush and terminates the loop.
+// If a flush is in progress, Close waits for it to finish unless ctx is
+// canceled, in which case the in-flight flush context is canceled and Close
+// returns ctx.Err().
+func (f *flusher[T]) Close(ctx context.Context) error {
+	close(f.stop)
+	select {
+	case <-f.done:
+		f.cancelFlush() // ensure resources associated with the flush context are released
+		return nil
+	case <-ctx.Done():
+		f.cancelFlush() // abort an in-flight flush, if any
+		<-f.done
+		return ctx.Err()
+	}
+}
+
+func (f *flusher[T]) loop() {
+
+	defer close(f.done)
+
+	conf := f.conf
+
+	var (
+		dedup   = make(map[any]int, conf.BatchSize)
+		rows    = make([]T, 0, conf.BatchSize)
+		acks    = make([]streams.Ack, 0, conf.BatchSize)
+		metrics = make(map[int]int) // pipeline to count
+	)
+
+	// firstBuffered is the time when the first row was buffered.
+	var firstBuffered time.Time
+
+	var lastArrival time.Time
+
+	var rate float64 // rows/sec (EWMA)
+
+	// idleTimer keeps latency low at low traffic and makes tests faster.
+	//
+	// Reset: on each incoming row
+	// Stop:  when the rows are flushed
+	idleTimer := time.NewTimer(time.Hour) // <- conf.IdleFlushDelay (750ms)
+
+	// adaptiveTimer schedules a flush while rows keep arriving (so idleTimer may not fire).
+	// It estimates how fast rows arrive (EWMA) and sets the timer to roughly when we should reach
+	// conf.BatchSize rows in the buffer (kept within [conf.MinFlushInterval, conf.MaxFlushLatency]
+	// and not later than maxTimer).
+	//
+	// Reset: on each incoming row (after updating the rate estimate)
+	// Stop:  when the rows are flushed
+	adaptiveTimer := time.NewTimer(time.Hour)
+
+	// maxTimer guarantees the oldest buffered row waits at most conf.MaxFlushLatency.
+	//
+	// Reset: once the first row is buffered
+	// Stop:  when the rows are flushed
+	maxTimer := time.NewTimer(time.Hour) // <- conf.MaxFlushLatency (5s)
+
+	stopTimers := func() {
+		idleTimer.Stop()
+		adaptiveTimer.Stop()
+		maxTimer.Stop()
+	}
+
+	// Since rows is empty, stop all timers.
+	stopTimers()
+
+	flush := func() {
+
+		stopTimers()
+
+		if len(rows) == 0 {
+			firstBuffered = time.Time{}
+			return
+		}
+
+		var flushCtx context.Context
+
+		bo := backoff.New(1000)
+		bo.SetCap(10 * time.Second)
+
+		for bo.Next(f.flushCtx) {
+			ctx, done, err := f.store.mc.StartOperation(f.flushCtx, normalMode)
+			if err != nil {
+				continue
+			}
+			flushCtx = ctx
+			defer done()
+			break
+		}
+		if err := f.flushCtx.Err(); err != nil {
+			return
+		}
+
+		// Flush buffered rows. If the flush is interrupted (Close canceled the context),
+		// return and let the main loop exit without starting another flush.
+		bo = backoff.New(1000)
+		bo.SetCap(10 * time.Second)
+		for bo.Next(flushCtx) {
+			err := f.flush(flushCtx, rows)
+			if err != nil {
+				continue
+			}
+			break
+		}
+		if err := flushCtx.Err(); err != nil {
+			return
+		}
+		for _, ack := range acks {
+			ack()
+		}
+		for pipeline, count := range metrics {
+			f.store.ds.metrics.FinalizePassed(pipeline, count)
+		}
+
+		clear(dedup)
+		if cap(rows) > conf.MaxBatchSize {
+			rows = make([]T, 0, conf.BatchSize)
+		} else {
+			rows = rows[:0]
+		}
+		if cap(acks) > conf.MaxBatchSize {
+			acks = make([]streams.Ack, 0, conf.BatchSize)
+		} else {
+			acks = acks[:0]
+		}
+		clear(metrics)
+		firstBuffered = time.Time{}
+	}
+
+	for {
+
+		select {
+
+		case row := <-f.rows:
+
+			// EWMA rate estimate from inter-arrival time.
+			now := time.Now()
+			if !lastArrival.IsZero() {
+				dt := now.Sub(lastArrival).Seconds()
+				if dt > 0 {
+					inst := 1.0 / dt
+					if rate == 0 {
+						rate = inst
+					} else {
+						alpha := conf.RateAlpha
+						rate = alpha*inst + (1-alpha)*rate
+					}
+				}
+			}
+
+			if row.ack != nil {
+				acks = append(acks, row.ack)
+				metrics[row.pipeline]++
+			}
+
+			// Check if the row is duplicated.
+			var duplicated bool
+			if row.key != nil {
+				if i, ok := dedup[row.key]; ok {
+					rows[i] = row.row
+					duplicated = true
+				} else {
+					dedup[row.key] = len(rows)
+				}
+			}
+			if !duplicated {
+				rows = append(rows, row.row)
+				if len(rows) == conf.MaxBatchSize {
+					flush()
+					continue
+				}
+				if len(rows) == 1 {
+					firstBuffered = now
+					maxTimer.Reset(conf.MaxFlushLatency)
+				}
+			}
+
+			idleTimer.Reset(conf.IdleFlushDelay)
+			lastArrival = now
+
+			// Adaptive schedule: expected time to reach BatchSize.
+			if rate > 0 {
+				remaining := float64(conf.BatchSize - len(rows))
+				if remaining < 0 {
+					remaining = 0
+				}
+				sec := remaining / rate
+				if math.IsNaN(sec) || math.IsInf(sec, 0) || sec < 0 {
+					sec = float64(conf.MaxFlushLatency / time.Second)
+				}
+				d := time.Duration(sec * float64(time.Second))
+				if d < conf.MinFlushInterval {
+					d = conf.MinFlushInterval
+				}
+				if d > conf.MaxFlushLatency {
+					d = conf.MaxFlushLatency
+				}
+				// Respect max-latency deadline.
+				if !firstBuffered.IsZero() {
+					deadline := firstBuffered.Add(conf.MaxFlushLatency)
+					until := time.Until(deadline)
+					if until < d {
+						d = until
+						if d < 0 {
+							d = 0
+						}
+					}
+				}
+				adaptiveTimer.Reset(d)
+			}
+
+		case <-idleTimer.C:
+			flush()
+
+		case <-adaptiveTimer.C:
+			flush()
+
+		case <-maxTimer.C:
+			flush()
+
+		case <-f.stop:
+			stopTimers()
+			return
+
+		}
+
+		if len(rows) == 0 {
+			stopTimers()
+		}
+
+	}
+}
+
+// flusherConf configures a flusher.
+type flusherConf struct {
+
+	// QueueSize is the size of the internal channel used to queue incoming rows.
+	// A larger buffer can absorb short slowdowns in flush() without blocking writers.
+	QueueSize int
+
+	// BatchSize is the preferred number of rows per flush.
+	// When the buffer reaches this size, EventWriter flushes as soon as possible.
+	BatchSize int
+
+	// MaxBatchSize is the maximum number of buffered rows before forcing a flush.
+	// When the buffer reaches this size, EventWriter flushes immediately.
+	MaxBatchSize int
+
+	// MinFlushInterval is the smallest delay used by the adaptive scheduler.
+	// It avoids flushing too often when rows arrive slowly but continuously.
+	MinFlushInterval time.Duration
+
+	// MaxFlushLatency is the longest time a row is allowed to wait in the buffer.
+	// Even if the batch is not full, EventWriter will flush within this time.
+	MaxFlushLatency time.Duration
+
+	// IdleFlushDelay triggers a flush when no new rows arrive for this duration,
+	// as long as there are buffered rows to write.
+	IdleFlushDelay time.Duration
+
+	// RateAlpha is the EWMA smoothing factor for the row rate estimate.
+	// Valid range is [0, 1]. Higher means more weight to recent observations.
+	RateAlpha float64
+}


### PR DESCRIPTION
```
Rework the EventIdentityWriter to use the flusher used for the
EventWriter.

The previous implementation had several issues:
- flushing ran on a fixed 500ms interval or when the queue reached 1000 
  identities
- the in-memory queue was unbounded and could grow indefinitely when 
  flushes lagged
- identities were silently discarded when the warehouse mode was 
  incompatible.

This redesign addresses those problems:
- flushing now combines an idle timeout (to keep latency low under
  sparse traffic), an adaptive timer that tracks arrival rate to reach a
  target batch size, and a hard maximum that forces an immediate flush.
- the in-memory queue is bounded to prevent unbounded growth
- when a flush cannot start, it retries indefinitely with exponential 
  backoff, and flush failures are retried while the flush context
  remains alive.
```