### PR TITLE
core: rework `BatchIdentityWriter` flushing to match `EventWriter`

### DIFF
--- a/core/internal/datastore/batch_identitywriter.go
+++ b/core/internal/datastore/batch_identitywriter.go
@@ -8,13 +8,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
 	"github.com/meergo/meergo/core/internal/schemas"
 	"github.com/meergo/meergo/core/internal/state"
-	"github.com/meergo/meergo/tools/metrics"
 	"github.com/meergo/meergo/tools/types"
 	"github.com/meergo/meergo/warehouses"
 )
@@ -24,9 +23,6 @@ var ErrPipelineNotExist = errors.New("pipeline does not exist")
 // ErrPurgeSkipped is returned when the purge phase is skipped because some
 // records without known IDs encountered an error.
 var ErrPurgeSkipped = errors.New("purge skipped")
-
-var maxQueuedIdentityRows = 1000
-var maxQueuedIdentityTime = 500 * time.Millisecond
 
 // Identity is an identity
 type Identity struct {
@@ -54,21 +50,12 @@ type BatchIdentityWriter struct {
 	run        int
 	flatter    *flatter
 	columns    []warehouses.Column
+	identities chan<- flusherRow[map[string]any]
+	flusher    *flusher[map[string]any]
 	purge      bool
 	skipPurge  bool
 
-	mu           sync.Mutex
-	index        map[identityKey]int // Access using 'mu'.
-	rows         []map[string]any    // Access using 'mu'.
-	metricsCount int
-	timer        *time.Timer // Access using 'mu'.
-
-	close struct {
-		ctx    context.Context
-		cancel context.CancelFunc
-		atomic.Bool
-		sync.WaitGroup
-	}
+	closed atomic.Bool
 }
 
 // newBatchIdentityWriter returns an identity writer for writing identities in
@@ -92,47 +79,49 @@ func newBatchIdentityWriter(store *Store, pipeline *state.Pipeline, purge bool) 
 	if err != nil {
 		return nil, err
 	}
-	iw := BatchIdentityWriter{
+	w := BatchIdentityWriter{
 		store:      store,
 		pipeline:   pipeline.ID,
 		connection: connection.ID,
 		run:        run.ID,
 		flatter:    newFlatter(pipeline.OutSchema, store.identityColumnByProperty()),
-		index:      map[identityKey]int{},
 		purge:      purge,
 	}
-	iw.close.ctx, iw.close.cancel = context.WithCancel(context.Background())
 
-	iw.columns = make([]warehouses.Column, 7, 7+len(pipeline.Transformation.OutPaths))
-	iw.columns[0] = warehouses.Column{Name: "_pipeline", Type: types.Int(32)}
-	iw.columns[1] = warehouses.Column{Name: "_is_anonymous", Type: types.Boolean()}
-	iw.columns[2] = warehouses.Column{Name: "_identity_id", Type: types.String()}
-	iw.columns[3] = warehouses.Column{Name: "_connection", Type: types.Int(32)}
-	iw.columns[4] = warehouses.Column{Name: "_anonymous_ids", Type: types.Array(types.String()), Nullable: true}
-	iw.columns[5] = warehouses.Column{Name: "_updated_at", Type: types.DateTime()}
-	iw.columns[6] = warehouses.Column{Name: "_run", Type: types.Int(32), Nullable: true}
-	iw.columns = appendColumnsFromProperties(iw.columns, pipeline.Transformation.OutPaths, store.profileColumnByProperty())
+	w.columns = make([]warehouses.Column, 7, 7+len(pipeline.Transformation.OutPaths))
+	w.columns[0] = warehouses.Column{Name: "_pipeline", Type: types.Int(32)}
+	w.columns[1] = warehouses.Column{Name: "_is_anonymous", Type: types.Boolean()}
+	w.columns[2] = warehouses.Column{Name: "_identity_id", Type: types.String()}
+	w.columns[3] = warehouses.Column{Name: "_connection", Type: types.Int(32)}
+	w.columns[4] = warehouses.Column{Name: "_anonymous_ids", Type: types.Array(types.String()), Nullable: true}
+	w.columns[5] = warehouses.Column{Name: "_updated_at", Type: types.DateTime()}
+	w.columns[6] = warehouses.Column{Name: "_run", Type: types.Int(32), Nullable: true}
+	w.columns = appendColumnsFromProperties(w.columns, pipeline.Transformation.OutPaths, store.profileColumnByProperty())
 
-	return &iw, nil
-}
-
-// Cancel cancels the writer, ensuring that the ongoing write operations are
-// completed, while discarding the pending ones, and skipping the purge
-// operation if was required.
-//
-// If the writer is already closed, it does nothing.
-func (iw *BatchIdentityWriter) Cancel(ctx context.Context) {
-	if iw.close.Swap(true) {
-		return
+	// Start the flusher.
+	opts := flusherOptions{
+		QueueSize:        32768,
+		BatchSize:        20000,
+		MaxBatchSize:     100000,
+		MinFlushInterval: 500 * time.Millisecond,
+		MaxFlushLatency:  15 * time.Second,
+		IdleFlushDelay:   2 * time.Second,
+		RateAlpha:        0.3,
 	}
-	// Cancel the flushes if the context is canceled.
-	stop := context.AfterFunc(ctx, func() { iw.close.cancel() })
-	defer stop()
-	// Wait for the flushes to terminate.
-	iw.close.Wait()
+	workspaceID := workspace.ID
+	connectionID := connection.ID
+	pipelineID := pipeline.ID
+	w.flusher = newFlusher(store, opts, func(ctx context.Context, identities []map[string]any) error {
+		return store.warehouse().MergeIdentities(ctx, w.columns, identities)
+	}, func(err error) {
+		slog.Warn("cannot flush batch identities to the data warehouse; retrying.", "workspace", workspaceID, "connection", connectionID, "pipeline", pipelineID, "error", err)
+	})
+	w.identities = w.flusher.Ch()
+
+	return &w, nil
 }
 
-// Close closes the writer, ensuring the completion of all pending or ongoing
+// Close closes the writer, ensuring the completion of all flushed
 // write operations. In the event of a canceled context, it interrupts ongoing
 // writes, discards pending ones, and returns.
 //
@@ -141,58 +130,28 @@ func (iw *BatchIdentityWriter) Cancel(ctx context.Context) {
 // called with an empty identifier, the purge is skipped and ErrPurgeSkipped is
 // returned.
 //
-// If the writer is already closed, it does nothing and returns immediately.
+// When Close is called, no other calls to EventIdentityWriter's methods should
+// be in progress and no other shall be made.
 //
-// If the data warehouse is in inspection mode, it returns the ErrInspectionMode
-// error. If it is in maintenance mode, it returns the ErrMaintenanceMode error.
-// If an error occurs with the data warehouse, it returns a
-// *datastore.UnavailableError error.
-//
-// TODO(Gianluca): if these errors returned from Close seem strange, it's
-// because we still need to discuss the issue
-// https://github.com/meergo/meergo/issues/1224 and understand precisely what
-// model we want to implement for the operations and compatible methods.
-func (iw *BatchIdentityWriter) Close(ctx context.Context) error {
-	if iw.close.Load() {
+// After Close is called, subsequent calls to Close or Stop do nothing.
+func (w *BatchIdentityWriter) Close(ctx context.Context) error {
+	if w.closed.Swap(true) {
 		return nil
 	}
-	ctx, done, err := iw.store.mc.StartOperation(ctx, normalMode)
-	if err != nil {
-		return err
-	}
-	defer done()
-	// Mark as closed and return if it was already closed in the meantime.
-	if iw.close.Swap(true) {
-		return nil
-	}
-	// Cancel the flushes if the context is canceled.
-	stop := context.AfterFunc(ctx, func() { iw.close.cancel() })
-	defer stop()
-	// Wait for the flushes to terminate.
-	iw.close.Wait()
-	// Perform a final flush.
-	iw.mu.Lock()
-	iw.flush()
-	iw.mu.Unlock()
-	iw.close.Wait()
+	// Close the flusher.
+	err := w.flusher.Close(ctx)
 	// Purge identities.
-	if iw.purge {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if iw.skipPurge {
+	if err == nil && w.purge {
+		if w.skipPurge {
 			return ErrPurgeSkipped
 		}
 		where := warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
-			warehouses.NewBaseExpr(warehouses.Column{Name: "_pipeline", Type: types.Int(32)}, warehouses.OpIs, iw.pipeline),
-			warehouses.NewBaseExpr(warehouses.Column{Name: "_run", Type: types.Int(32)}, warehouses.OpIsNot, iw.run),
+			warehouses.NewBaseExpr(warehouses.Column{Name: "_pipeline", Type: types.Int(32)}, warehouses.OpIs, w.pipeline),
+			warehouses.NewBaseExpr(warehouses.Column{Name: "_run", Type: types.Int(32)}, warehouses.OpIsNot, w.run),
 		})
-		err := iw.store.warehouse().Delete(ctx, "meergo_identities", where)
-		if err != nil {
-			return err
-		}
+		err = w.store.warehouse().Delete(ctx, "meergo_identities", where)
 	}
-	return nil
+	return err
 }
 
 // Keep keeps the identity with the identifier id. Use Keep instead of Write
@@ -201,96 +160,64 @@ func (iw *BatchIdentityWriter) Close(ctx context.Context) error {
 //
 // If id is empty, the purge will be skipped because it would be impossible to
 // determine which unimported records failed due to an error.
-func (iw *BatchIdentityWriter) Keep(id string) {
-	if iw.close.Load() {
-		panic("call Keep on a closed identity writer")
-	}
-	if !iw.purge || iw.skipPurge {
-		return
+func (w *BatchIdentityWriter) Keep(ctx context.Context, id string) error {
+	if !w.purge || w.skipPurge {
+		return nil
 	}
 	if id == "" {
-		iw.skipPurge = true
-		return
+		w.skipPurge = true
+		return nil
 	}
-	key := identityKey{pipeline: iw.pipeline, identityID: id}
+	key := identityKey{pipeline: w.pipeline, identityID: id}
 	row := map[string]any{
 		"$purge":        false,
 		"_pipeline":     key.pipeline,
 		"_is_anonymous": false,
 		"_identity_id":  key.identityID,
-		"_connection":   iw.connection,
-		"_run":          iw.run,
+		"_connection":   w.connection,
+		"_run":          w.run,
 	}
-	iw.appendRow(key, row, false)
+	select {
+	case w.identities <- flusherRow[map[string]any]{key: key, pipeline: w.pipeline, row: row}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Stop stops the writer, ensuring that the ongoing write operations are
+// completed, while discarding the pending ones, and skipping the purge
+// operation if was required.
+//
+// When Stop is called, no other calls to EventIdentityWriter's methods should
+// be in progress and no other shall be made.
+//
+// After Stop is called, subsequent calls to Stop or Close do nothing.
+func (w *BatchIdentityWriter) Stop(ctx context.Context) error {
+	if w.closed.Swap(true) {
+		return nil
+	}
+	// Stop the flusher.
+	return w.flusher.Stop(ctx)
 }
 
 // Write writes an identity. If a valid profile schema has been provided, the
 // attributes must comply with it. It returns immediately, deferring the
 // validation of the attributes and the actual write operation to a later time.
-//
-// It panics if called on a closed writer.
-func (iw *BatchIdentityWriter) Write(identity Identity) {
-	if iw.close.Load() {
-		panic("call Write on a closed identity writer")
-	}
-	key := identityKey{pipeline: iw.pipeline, identityID: identity.ID}
+func (w *BatchIdentityWriter) Write(ctx context.Context, identity Identity) error {
+	key := identityKey{pipeline: w.pipeline, identityID: identity.ID}
 	row := identity.Attributes
-	iw.flatter.flat(row)
+	w.flatter.flat(row)
 	row["_pipeline"] = key.pipeline
 	row["_is_anonymous"] = false
 	row["_identity_id"] = key.identityID
-	row["_connection"] = iw.connection
+	row["_connection"] = w.connection
 	row["_updated_at"] = identity.UpdatedAt
-	row["_run"] = iw.run
-	iw.appendRow(key, row, true)
-}
-
-// appendRow appends a row to the rows or replaces an existing row with the same key.
-func (iw *BatchIdentityWriter) appendRow(key identityKey, row map[string]any, includeInMetrics bool) {
-	iw.mu.Lock()
-	if includeInMetrics {
-		iw.metricsCount++
+	row["_run"] = w.run
+	select {
+	case w.identities <- flusherRow[map[string]any]{key: key, pipeline: w.pipeline, row: row}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-	// If a row with the same key already exists, update that row rather than adding a duplicate.
-	if i, ok := iw.index[key]; ok {
-		iw.rows[i] = row
-		iw.mu.Unlock()
-		return
-	}
-	if len(iw.rows) == 0 {
-		iw.timer = time.AfterFunc(maxQueuedIdentityTime, func() {
-			iw.mu.Lock()
-			iw.flush()
-			iw.mu.Unlock()
-		})
-	}
-	iw.index[key] = len(iw.rows)
-	iw.rows = append(iw.rows, row)
-	if len(iw.rows) == maxQueuedIdentityRows {
-		iw.flush()
-	}
-	iw.mu.Unlock()
-}
-
-// flush flushes the rows, if any, into the data warehouse.
-// It must be called while holding the iw.mu mutex.
-func (iw *BatchIdentityWriter) flush() {
-	metrics.Increment("BatchIdentityWriter.flush.calls", 1)
-	if iw.rows == nil {
-		return
-	}
-	rows := iw.rows
-	iw.rows = nil
-	count := iw.metricsCount
-	iw.metricsCount = 0
-	clear(iw.index)
-	iw.timer = nil
-	iw.close.Go(func() {
-		err := iw.store.warehouse().MergeIdentities(iw.close.ctx, iw.columns, rows)
-		if err != nil {
-			iw.store.ds.metrics.FinalizeFailed(iw.pipeline, count, err.Error())
-			return
-		}
-		iw.store.ds.metrics.FinalizePassed(iw.pipeline, count)
-	})
 }

--- a/core/internal/datastore/event_identitywriter.go
+++ b/core/internal/datastore/event_identitywriter.go
@@ -170,7 +170,7 @@ func (w *EventIdentityWriter) Write(ctx context.Context, identity Identity, ack 
 				"_updated_at":   identity.UpdatedAt,
 			}
 			select {
-			case w.identities <- flusherRow[map[string]any]{key: key, pipeline: w.pipeline, row: row}:
+			case w.identities <- flusherRow[map[string]any]{key: key, row: row}:
 				continue
 			case <-ctx.Done():
 				return ctx.Err()

--- a/core/internal/datastore/event_identitywriter.go
+++ b/core/internal/datastore/event_identitywriter.go
@@ -6,6 +6,7 @@ package datastore
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -53,9 +54,9 @@ func newEventIdentityWriter(store *Store, pipelineID int) *EventIdentityWriter {
 
 	pipeline, _ := store.ds.state.Pipeline(pipelineID)
 	connection := pipeline.Connection()
+	workspace := connection.Workspace()
 	w.connection = connection.ID
 	if pipeline.OutSchema.Valid() {
-		workspace := connection.Workspace()
 		err := schemas.CheckAlignment(pipeline.OutSchema, workspace.ProfileSchema, nil)
 		if err == nil {
 			w.aligned = true
@@ -84,7 +85,7 @@ func newEventIdentityWriter(store *Store, pipelineID int) *EventIdentityWriter {
 	w.columns = appendColumnsFromProperties(w.columns, pipeline.Transformation.OutPaths, store.profileColumnByProperty())
 
 	// Start the flusher.
-	conf := flusherConf{
+	opts := flusherOptions{
 		QueueSize:        32768,
 		BatchSize:        20000,
 		MaxBatchSize:     100000,
@@ -93,9 +94,14 @@ func newEventIdentityWriter(store *Store, pipelineID int) *EventIdentityWriter {
 		IdleFlushDelay:   2 * time.Second,
 		RateAlpha:        0.3,
 	}
-	identities := make(chan flusherRow[map[string]any], conf.QueueSize)
-	w.identities = identities
-	w.flusher = newFlusher(store, identities, w.flush, conf)
+	workspaceID := workspace.ID
+	connectionID := connection.ID
+	w.flusher = newFlusher(store, opts, func(ctx context.Context, identities []map[string]any) error {
+		return store.warehouse().MergeIdentities(ctx, w.columns, identities)
+	}, func(err error) {
+		slog.Warn("cannot flush event identities to the data warehouse; retrying.", "workspace", workspaceID, "connection", connectionID, "pipeline", pipelineID, "error", err)
+	})
+	w.identities = w.flusher.Ch()
 
 	return w
 }
@@ -195,12 +201,6 @@ func (w *EventIdentityWriter) Write(ctx context.Context, identity Identity, ack 
 		return ctx.Err()
 	}
 
-}
-
-// flush writes the given identities.
-// It returns ctx.Err() on context cancellation.
-func (w *EventIdentityWriter) flush(ctx context.Context, identities []map[string]any) error {
-	return w.store.warehouse().MergeIdentities(ctx, w.columns, identities)
 }
 
 // onCreatePipeline is called when a pipeline of the connection of iw's pipeline

--- a/core/internal/datastore/eventwriter.go
+++ b/core/internal/datastore/eventwriter.go
@@ -6,6 +6,7 @@ package datastore
 
 import (
 	"context"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 )
 
 type EventWriter struct {
-	store   *Store
 	events  chan<- flusherRow[[]any]
 	flusher *flusher[[]any]
 	closed  atomic.Bool
@@ -22,7 +22,7 @@ type EventWriter struct {
 // newEventWriter constructs and starts a EventWriter.
 // The returned EventWriter is ready to use.
 func newEventWriter(store *Store) *EventWriter {
-	conf := flusherConf{
+	opts := flusherOptions{
 		QueueSize:        8192,
 		BatchSize:        5000,
 		MaxBatchSize:     25000,
@@ -32,12 +32,14 @@ func newEventWriter(store *Store) *EventWriter {
 		RateAlpha:        0.4,
 	}
 
-	events := make(chan flusherRow[[]any], conf.QueueSize)
-	w := &EventWriter{
-		store:  store,
-		events: events,
-	}
-	w.flusher = newFlusher(store, events, w.flush, conf)
+	w := &EventWriter{}
+	workspaceID := store.workspace
+	w.flusher = newFlusher(store, opts, func(ctx context.Context, events [][]any) error {
+		return store.warehouse().Merge(ctx, eventsMergeTable, events, nil)
+	}, func(err error) {
+		slog.Warn("cannot flush events to the data warehouse; retrying.", "workspace", workspaceID, "error", err)
+	})
+	w.events = w.flusher.Ch()
 
 	return w
 }
@@ -224,10 +226,4 @@ func (w *EventWriter) Close(ctx context.Context) error {
 	}
 	// Close the flusher.
 	return w.flusher.Close(ctx)
-}
-
-// flush writes the given events.
-// It returns ctx.Err() on context cancellation.
-func (w *EventWriter) flush(ctx context.Context, events [][]any) error {
-	return w.store.warehouse().Merge(ctx, eventsMergeTable, events, nil)
 }

--- a/core/internal/datastore/flusher.go
+++ b/core/internal/datastore/flusher.go
@@ -7,6 +7,7 @@ package datastore
 import (
 	"context"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/meergo/meergo/core/internal/streams"
@@ -14,73 +15,93 @@ import (
 )
 
 type flusherRow[T any] struct {
-	key      any
-	pipeline int
-	row      T
-	ack      streams.Ack
+	pipeline int         // pipeline identifier; if 0, no metrics are recorded
+	key      any         // deduplication key; if nil, deduplication is disabled
+	row      T           // row to be flushed
+	ack      streams.Ack // ack callback; if nil, it is not invoked
 }
 
 type flusher[T any] struct {
-	store *Store
-	conf  flusherConf
-
-	rows <-chan flusherRow[T]
-
-	flush func(context.Context, []T) error
-
-	// stop and done are used to stop the loop and wait a flush termination.
-	stop chan struct{}
-	done chan struct{}
-
-	// flushCtx is canceled when any Close's ctx is canceled.
-	// This allows an in-flight flush to be interrupted by Close's ctx.
-	flushCtx    context.Context
-	cancelFlush context.CancelFunc
+	store    *Store
+	rows     chan flusherRow[T]
+	flush    func(context.Context, []T) error
+	logError func(err error)
+	close    struct {
+		atomic.Bool                    // true if Close or Stop has been called
+		stop        chan bool          // signals the loop to stop; the value indicates whether to drain
+		ctx         context.Context    // context passed to the flush function; canceled by close's cancel
+		cancel      context.CancelFunc // cancels an in-flight flush
+		done        chan struct{}      // closed once the loop has terminated
+	}
 }
 
-func newFlusher[T any](store *Store, rows <-chan flusherRow[T], flush func(context.Context, []T) error, conf flusherConf) *flusher[T] {
+func newFlusher[T any](store *Store, opts flusherOptions, flush func(context.Context, []T) error, logError func(err error)) *flusher[T] {
 	ctx, cancel := context.WithCancel(context.Background())
 	f := &flusher[T]{
-		store:       store,
-		rows:        rows,
-		flush:       flush,
-		conf:        conf,
-		stop:        make(chan struct{}),
-		done:        make(chan struct{}),
-		flushCtx:    ctx,
-		cancelFlush: cancel,
+		store:    store,
+		rows:     make(chan flusherRow[T], opts.QueueSize),
+		flush:    flush,
+		logError: logError,
 	}
-	go f.loop()
+	f.close.stop = make(chan bool, 1)
+	f.close.done = make(chan struct{})
+	f.close.ctx = ctx
+	f.close.cancel = cancel
+	go f.loop(opts)
 	return f
 }
 
-// Close interrupts scheduling of any new flush and terminates the loop.
-// If a flush is in progress, Close waits for it to finish unless ctx is
-// canceled, in which case the in-flight flush context is canceled and Close
-// returns ctx.Err().
+// Ch returns the channel.
+func (f *flusher[T]) Ch() chan<- flusherRow[T] {
+	return f.rows
+}
+
+// Close closes the flusher and waits for all pending rows to be flushed.
+// If ctx is canceled or expires, the current flush is aborted and no
+// additional rows are flushed; Close returns ctx.Err().
+//
+// After Close is called, subsequent calls to Close or Stop do nothing.
 func (f *flusher[T]) Close(ctx context.Context) error {
-	close(f.stop)
+	return f.stop(ctx, true)
+}
+
+// Stop stops and closes the flusher, waiting only for any in-flight flush to
+// complete and not flushing any additional rows. If ctx is canceled or expires,
+// the current flush is aborted and Stop returns ctx.Err().
+//
+// After Stop is called, subsequent calls to Stop or Close do nothing.
+func (f *flusher[T]) Stop(ctx context.Context) error {
+	return f.stop(ctx, false)
+}
+
+// close closes the flusher.
+// If drain is true, all pending rows are flushed before returning.
+func (f *flusher[T]) stop(ctx context.Context, drain bool) error {
+	if f.close.Swap(true) {
+		return nil
+	}
+	// Signals the loop to stop.
+	f.close.stop <- drain
+	close(f.close.stop)
+	close(f.rows)
+	// Waits until the loop terminates or the context is canceled.
 	select {
-	case <-f.done:
-		f.cancelFlush() // ensure resources associated with the flush context are released
+	case <-f.close.done:
+		f.close.cancel() // ensure resources associated with the context are released
 		return nil
 	case <-ctx.Done():
-		f.cancelFlush() // abort an in-flight flush, if any
-		<-f.done
+		f.close.cancel() // abort an in-flight flush, if any
+		<-f.close.done
 		return ctx.Err()
 	}
 }
 
-func (f *flusher[T]) loop() {
-
-	defer close(f.done)
-
-	conf := f.conf
+func (f *flusher[T]) loop(opts flusherOptions) {
 
 	var (
-		dedup   = make(map[any]int, conf.BatchSize)
-		rows    = make([]T, 0, conf.BatchSize)
-		acks    = make([]streams.Ack, 0, conf.BatchSize)
+		dedup   = make(map[any]int, opts.BatchSize)
+		rows    = make([]T, 0, opts.BatchSize)
+		acks    = make([]streams.Ack, 0, opts.BatchSize)
 		metrics = make(map[int]int) // pipeline to count
 	)
 
@@ -95,22 +116,22 @@ func (f *flusher[T]) loop() {
 	//
 	// Reset: on each incoming row
 	// Stop:  when the rows are flushed
-	idleTimer := time.NewTimer(time.Hour) // <- conf.IdleFlushDelay (750ms)
+	idleTimer := time.NewTimer(time.Hour) // <- opts.IdleFlushDelay (750ms)
 
 	// adaptiveTimer schedules a flush while rows keep arriving (so idleTimer may not fire).
 	// It estimates how fast rows arrive (EWMA) and sets the timer to roughly when we should reach
-	// conf.BatchSize rows in the buffer (kept within [conf.MinFlushInterval, conf.MaxFlushLatency]
+	// opts.BatchSize rows in the buffer (kept within [opts.MinFlushInterval, opts.MaxFlushLatency]
 	// and not later than maxTimer).
 	//
 	// Reset: on each incoming row (after updating the rate estimate)
 	// Stop:  when the rows are flushed
 	adaptiveTimer := time.NewTimer(time.Hour)
 
-	// maxTimer guarantees the oldest buffered row waits at most conf.MaxFlushLatency.
+	// maxTimer guarantees the oldest buffered row waits at most opts.MaxFlushLatency.
 	//
 	// Reset: once the first row is buffered
 	// Stop:  when the rows are flushed
-	maxTimer := time.NewTimer(time.Hour) // <- conf.MaxFlushLatency (5s)
+	maxTimer := time.NewTimer(time.Hour) // <- opts.MaxFlushLatency (5s)
 
 	stopTimers := func() {
 		idleTimer.Stop()
@@ -118,15 +139,20 @@ func (f *flusher[T]) loop() {
 		maxTimer.Stop()
 	}
 
+	defer func() {
+		stopTimers()
+		close(f.close.done)
+	}()
+
 	// Since rows is empty, stop all timers.
 	stopTimers()
 
 	flush := func() {
 
 		stopTimers()
+		firstBuffered = time.Time{}
 
 		if len(rows) == 0 {
-			firstBuffered = time.Time{}
 			return
 		}
 
@@ -135,8 +161,8 @@ func (f *flusher[T]) loop() {
 		bo := backoff.New(1000)
 		bo.SetCap(10 * time.Second)
 
-		for bo.Next(f.flushCtx) {
-			ctx, done, err := f.store.mc.StartOperation(f.flushCtx, normalMode)
+		for bo.Next(f.close.ctx) {
+			ctx, done, err := f.store.mc.StartOperation(f.close.ctx, normalMode)
 			if err != nil {
 				continue
 			}
@@ -144,17 +170,22 @@ func (f *flusher[T]) loop() {
 			defer done()
 			break
 		}
-		if err := f.flushCtx.Err(); err != nil {
+		if err := f.close.ctx.Err(); err != nil {
 			return
 		}
 
 		// Flush buffered rows. If the flush is interrupted (Close canceled the context),
 		// return and let the main loop exit without starting another flush.
+		var latestErrorMsg string
 		bo = backoff.New(1000)
 		bo.SetCap(10 * time.Second)
 		for bo.Next(flushCtx) {
 			err := f.flush(flushCtx, rows)
 			if err != nil {
+				if msg := err.Error(); msg != latestErrorMsg {
+					f.logError(err)
+					latestErrorMsg = msg
+				}
 				continue
 			}
 			break
@@ -170,43 +201,48 @@ func (f *flusher[T]) loop() {
 		}
 
 		clear(dedup)
-		if cap(rows) > conf.MaxBatchSize {
-			rows = make([]T, 0, conf.BatchSize)
+		if cap(rows) > opts.MaxBatchSize {
+			rows = make([]T, 0, opts.BatchSize)
 		} else {
 			rows = rows[:0]
 		}
-		if cap(acks) > conf.MaxBatchSize {
-			acks = make([]streams.Ack, 0, conf.BatchSize)
+		if cap(acks) > opts.MaxBatchSize {
+			acks = make([]streams.Ack, 0, opts.BatchSize)
 		} else {
 			acks = acks[:0]
 		}
 		clear(metrics)
-		firstBuffered = time.Time{}
 	}
+
+	var stop bool  // indicates that processing must stop
+	var drain bool // if stopping, specifies whether to drain remaining data
 
 	for {
 
 		select {
 
-		case row := <-f.rows:
-
-			// EWMA rate estimate from inter-arrival time.
-			now := time.Now()
-			if !lastArrival.IsZero() {
-				dt := now.Sub(lastArrival).Seconds()
-				if dt > 0 {
-					inst := 1.0 / dt
-					if rate == 0 {
-						rate = inst
-					} else {
-						alpha := conf.RateAlpha
-						rate = alpha*inst + (1-alpha)*rate
-					}
+		case row, ok := <-f.rows:
+			// Return and optionally drain when there are no more rows.
+			if !ok {
+				if drain || <-f.close.stop {
+					flush()
 				}
+				return
+			}
+			// Return immediately if processing must stop without draining.
+			if stop && !drain {
+				return
+			}
+
+			var now time.Time
+			if !stop {
+				now = time.Now()
 			}
 
 			if row.ack != nil {
 				acks = append(acks, row.ack)
+			}
+			if row.pipeline != 0 {
 				metrics[row.pipeline]++
 			}
 
@@ -220,47 +256,74 @@ func (f *flusher[T]) loop() {
 					dedup[row.key] = len(rows)
 				}
 			}
+			// Append the row.
 			if !duplicated {
 				rows = append(rows, row.row)
-				if len(rows) == conf.MaxBatchSize {
+				if len(rows) == opts.MaxBatchSize {
 					flush()
-					continue
-				}
-				if len(rows) == 1 {
-					firstBuffered = now
-					maxTimer.Reset(conf.MaxFlushLatency)
 				}
 			}
 
-			idleTimer.Reset(conf.IdleFlushDelay)
+			// Skip ... if the flusher is stopped.
+			if stop {
+				continue
+			}
+
+			// EWMA rate estimate from inter-arrival time.
+			if !lastArrival.IsZero() {
+				dt := now.Sub(lastArrival).Seconds()
+				if dt > 0 {
+					inst := 1.0 / dt
+					if rate == 0 {
+						rate = inst
+					} else {
+						alpha := opts.RateAlpha
+						rate = alpha*inst + (1-alpha)*rate
+					}
+				}
+			}
+
+			// Continue if there are no pending rows.
+			if len(rows) == 0 {
+				continue
+			}
+
+			if !duplicated && len(rows) == 1 {
+				firstBuffered = now
+				maxTimer.Reset(opts.MaxFlushLatency)
+			}
+
+			idleTimer.Reset(opts.IdleFlushDelay)
 			lastArrival = now
 
 			// Adaptive schedule: expected time to reach BatchSize.
 			if rate > 0 {
-				remaining := float64(conf.BatchSize - len(rows))
+				remaining := float64(opts.BatchSize - len(rows))
 				if remaining < 0 {
 					remaining = 0
 				}
 				sec := remaining / rate
 				if math.IsNaN(sec) || math.IsInf(sec, 0) || sec < 0 {
-					sec = float64(conf.MaxFlushLatency / time.Second)
+					sec = float64(opts.MaxFlushLatency / time.Second)
 				}
 				d := time.Duration(sec * float64(time.Second))
-				if d < conf.MinFlushInterval {
-					d = conf.MinFlushInterval
+				if d < opts.MinFlushInterval {
+					d = opts.MinFlushInterval
 				}
-				if d > conf.MaxFlushLatency {
-					d = conf.MaxFlushLatency
+				if d > opts.MaxFlushLatency {
+					d = opts.MaxFlushLatency
 				}
 				// Respect max-latency deadline.
 				if !firstBuffered.IsZero() {
-					deadline := firstBuffered.Add(conf.MaxFlushLatency)
+					deadline := firstBuffered.Add(opts.MaxFlushLatency)
 					until := time.Until(deadline)
+					if until <= 0 {
+						// Deadline already exceeded: flush immediately instead of Reset(0).
+						flush()
+						continue
+					}
 					if until < d {
 						d = until
-						if d < 0 {
-							d = 0
-						}
 					}
 				}
 				adaptiveTimer.Reset(d)
@@ -275,21 +338,18 @@ func (f *flusher[T]) loop() {
 		case <-maxTimer.C:
 			flush()
 
-		case <-f.stop:
-			stopTimers()
-			return
-
-		}
-
-		if len(rows) == 0 {
-			stopTimers()
+		case d, ok := <-f.close.stop:
+			if ok {
+				stop = true
+				drain = d
+			}
 		}
 
 	}
 }
 
-// flusherConf configures a flusher.
-type flusherConf struct {
+// flusherOptions contains the options used to configure the flusher.
+type flusherOptions struct {
 
 	// QueueSize is the size of the internal channel used to queue incoming rows.
 	// A larger buffer can absorb short slowdowns in flush() without blocking writers.

--- a/core/internal/datastore/flusher.go
+++ b/core/internal/datastore/flusher.go
@@ -264,7 +264,7 @@ func (f *flusher[T]) loop(opts flusherOptions) {
 				}
 			}
 
-			// Skip ... if the flusher is stopped.
+			// Skip scheduling and rate updates if the flusher is stopped.
 			if stop {
 				continue
 			}

--- a/core/run_import.go
+++ b/core/run_import.go
@@ -98,8 +98,8 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 		}
 		return err
 	}
-	// Cancel the writer, or does nothing if it is already closed.
-	defer iw.Cancel(ctx)
+	// Stop the writer without draining the channel; no-op if already closed.
+	defer iw.Stop(ctx)
 
 	users := make([]connections.Record, 0, 100)
 	transformationRecords := make([]transformers.Record, 0, 100)
@@ -110,7 +110,7 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 	for user := range records.All(ctx) {
 
 		if user.Err != nil {
-			iw.Keep(user.ID)
+			_ = iw.Keep(ctx, user.ID)
 			if err, ok := user.Err.(connections.InputValidationError); ok {
 				this.core.metrics.ReceivePassed(pipeline.ID, 1)
 				this.core.metrics.InputValidationFailed(pipeline.ID, 1, err.Error())
@@ -167,13 +167,13 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 						this.core.metrics.TransformationPassed(pipeline.ID, 1)
 						this.core.metrics.OutputValidationFailed(pipeline.ID, 1, err.Error())
 					}
-					iw.Keep(user.ID)
+					_ = iw.Keep(ctx, user.ID)
 					continue
 				}
 				user.Attributes = record.Attributes
 				this.core.metrics.TransformationPassed(pipeline.ID, 1)
 				this.core.metrics.OutputValidationPassed(pipeline.ID, 1)
-				iw.Write(datastore.Identity{
+				_ = iw.Write(ctx, datastore.Identity{
 					ID:         user.ID,
 					Attributes: user.Attributes,
 					UpdatedAt:  user.UpdatedAt,


### PR DESCRIPTION
```
core: rework `BatchIdentityWriter` flushing to match `EventWriter`

Refactor BatchIdentityWriter to use the same flushing mechanism adopted
by EventWriter and EventIdentityWriter.

This change improves consistency across writers and brings the same
benefits introduced in commit 38b08df, addressing the limitations of
the previous approach.
```