### PR TITLE
Do some experiments with Docker and Playwright

### DIFF
--- a/test/admin_test.go
+++ b/test/admin_test.go
@@ -37,7 +37,7 @@ func TestAdmin(t *testing.T) {
 
 	// TODO: Playwright is not supported on Fedora, and this appears to cause
 	// problems. See https://github.com/meergo/meergo/issues/2116.
-	t.Skip()
+	// t.Skip()
 
 	fsTempDir := meergotester.NewTempStorage(t)
 
@@ -126,7 +126,7 @@ func TestAdmin(t *testing.T) {
 
 	// Write the "test-config.json" file.
 	testConfig := map[string]any{
-		"baseURL":     "http://" + c.Addr(),
+		"baseURL":     "http://host.docker.internal:2023", // TODO: the port must be configurable?
 		"workspaceID": c.WorkspaceID(),
 		"dbHost":      dbHost,
 		"dbPort":      dbPort,
@@ -152,15 +152,44 @@ func TestAdmin(t *testing.T) {
 
 	// Prepare and run the Admin tests.
 	adminDir := filepath.Join("..", "admin")
-	run(t, "npm", []string{"install"}, adminDir, fsTempDir.Root())
-	run(t, "npx", []string{"playwright", "install", "chromium"}, adminDir, fsTempDir.Root())
+	// run(t, "npm", []string{"install"}, adminDir, fsTempDir.Root())
+
+	// run(t, "npx", []string{"playwright", "install", "chromium"}, adminDir, fsTempDir.Root())
+
+	absAdminDir, err := filepath.Abs(adminDir)
+	if err != nil {
+		panic(err)
+	}
+
 	if passUIFlagToPlaywright {
-		run(t, "npx", []string{"playwright", "test", "--ui"}, adminDir, fsTempDir.Root())
-		t.Fatal("The Admin test was run with the constant 'passUIFlagToPlaywright' set to true," +
-			" so the test is considered to have failed as a precaution." +
-			" For more details, see the documentation for the constant 'passUIFlagToPlaywright'.")
+		// run(t, "npx", []string{"playwright", "test", "--ui"}, adminDir, fsTempDir.Root())
+		// t.Fatal("The Admin test was run with the constant 'passUIFlagToPlaywright' set to true," +
+		// 	" so the test is considered to have failed as a precaution." +
+		// 	" For more details, see the documentation for the constant 'passUIFlagToPlaywright'.")
 	} else {
-		run(t, "npx", []string{"playwright", "test"}, adminDir, fsTempDir.Root())
+		// run(t, "npx", []string{"playwright", "test"}, adminDir, fsTempDir.Root())
+
+		run(t, "docker", []string{
+			"run",
+			"--rm",
+			"--ipc=host",
+			"-v",
+			absAdminDir + ":/work",
+			"-w",
+			"/work",
+			"-p",
+			"9323:9323",
+			"--add-host=host.docker.internal:host-gateway",
+			"mcr.microsoft.com/playwright:v1.56.1",
+			"npx",
+			"playwright@1.56.1",
+			"test",
+			"--ui",
+			"--ui-host",
+			"0.0.0.0",
+			"--ui-port",
+			"9323",
+		}, adminDir, fsTempDir.Root())
 	}
 
 	// The tests have been run, so the temporary directory used by File System

--- a/test/admin_test.go
+++ b/test/admin_test.go
@@ -177,6 +177,8 @@ func TestAdmin(t *testing.T) {
 			absAdminDir + ":/work",
 			"-w",
 			"/work",
+			"-e",
+			"MEERGO_TEST_FS_TEMP_DIR=" + fsTempDir.Root(),
 			"-p",
 			"9323:9323",
 			"--add-host=host.docker.internal:host-gateway",
@@ -202,7 +204,9 @@ func run(t *testing.T, name string, args []string, directory, fsTempDir string) 
 	cmd.Dir = directory
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(), "MEERGO_TEST_FS_TEMP_DIR="+fsTempDir)
+	if fsTempDir != "" { // TODO: serve ancora?
+		cmd.Env = append(os.Environ(), "MEERGO_TEST_FS_TEMP_DIR="+fsTempDir)
+	}
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("error while executing %s: %s", name, err)

--- a/test/meergotester/meergotester.go
+++ b/test/meergotester/meergotester.go
@@ -334,6 +334,7 @@ func (c *Meergo) Start() {
 			"MEERGO_EXTERNAL_ASSETS_URLS=https://assets.meergo.com/",
 			"MEERGO_POTENTIAL_CONNECTORS_URL=https://assets.meergo.com/admin/connectors/potentials.json",
 			"MEERGO_TELEMETRY_LEVEL=none",
+			"MEERGO_HTTP_EXTERNAL_URL=http://host.docker.internal:2023", // TODO: per ora codificato così, ovviamente va distinto in base al test, alla porta, etc...
 			"MEERGO_PROMETHEUS_METRICS_ENABLED=true",
 			"MEERGO_HTTP_HOST=" + testsSettings.HTTP.Host,
 			"MEERGO_HTTP_PORT=" + strconv.Itoa(testsSettings.HTTP.Port),

--- a/test/meergotester/settings.go
+++ b/test/meergotester/settings.go
@@ -65,7 +65,7 @@ var testsSettingsMu sync.Mutex
 func init() {
 	testsSettings = &TestsSettings{
 		HTTP: &HTTPSettings{
-			Host: "127.0.0.1",
+			Host: "0.0.0.0",
 			Port: 2023,
 		},
 		Database: &DBSettings{


### PR DESCRIPTION
For #2116.

## TODO

* [x] Far sì che si riesca in qualche modo a far passare anche solo un test lanciato da dentro Docker
* [ ] Capire come eseguire i test senza doverli per forza avviare dall'UI di Playwright
* [ ] Mantenere il fatto che sia possibile passare il flag --ui per avviare l'UI di Playwright
* [ ] Risolvere il problema della variabile d'ambiente e del filesystem temporaneo (a cosa serve?) a cui devono accedere i test, che è in comune alla parte in Go del test
* [ ] Capire come passare la configurazione del connettore Filesystem
* [ ] Capire come far accedere il container a PostgreSQL avviato esternamente
* [ ] Capire se si riesce a togliere di mezzo il comando `docker` e usare testcontainer (anche per ripulire il container, etc...)
* [ ] Capire come configurare i test affinché anche gli altri test in Go passino
* [ ] Verificare se e come far passare tutti i test sia su Linux che su Windows