### PR TITLE
all: disable setting MCP credentials when creating a workspace

### DIFF
--- a/admin/src/components/routes/WorkspaceCreate/WorkspaceCreate.tsx
+++ b/admin/src/components/routes/WorkspaceCreate/WorkspaceCreate.tsx
@@ -2,6 +2,7 @@ import React, { useState, useContext, useRef, useEffect } from 'react';
 import './WorkspaceCreate.css';
 import { ObjectType } from '../../../lib/api/types/types';
 import { UIPreferences } from '../../../lib/api/types/workspace';
+import API from '../../../lib/api/api';
 import appContext from '../../../context/AppContext';
 import SlInput from '@shoelace-style/shoelace/dist/react/input/index.js';
 import SlButton from '@shoelace-style/shoelace/dist/react/button/index.js';
@@ -142,11 +143,12 @@ const WorkspaceCreate = () => {
 				handleError(err);
 				return;
 			}
-			// TODO: è giusto questo codice?
+			// TODO(Gianluca): this call was written just to work and is just a
+			// prototype, which needs to be reviewed.
 			try {
-				await api.workspaces.updateWarehouse(name, 'Normal', settings, mcpSettings, false);
+				const newApi = new API(window.location.origin, id);
+				await newApi.workspaces.updateWarehouse(name, 'Normal', settings, mcpSettings, false);
 			} catch (err) {
-				setIsCreatingWorkspace(false);
 				handleError(err);
 				return;
 			}

--- a/admin/src/components/routes/WorkspaceCreate/WorkspaceCreate.tsx
+++ b/admin/src/components/routes/WorkspaceCreate/WorkspaceCreate.tsx
@@ -108,7 +108,6 @@ const WorkspaceCreate = () => {
 					warehouse,
 					'Normal',
 					settings,
-					mcpSettings,
 					uiProperties,
 				);
 			} catch (err) {
@@ -135,10 +134,17 @@ const WorkspaceCreate = () => {
 					warehouse,
 					'Normal',
 					settings,
-					mcpSettings,
 					uiProperties,
 				);
 				id = res.id;
+			} catch (err) {
+				setIsCreatingWorkspace(false);
+				handleError(err);
+				return;
+			}
+			// TODO: è giusto questo codice?
+			try {
+				await api.workspaces.updateWarehouse(name, 'Normal', settings, mcpSettings, false);
 			} catch (err) {
 				setIsCreatingWorkspace(false);
 				handleError(err);

--- a/admin/src/lib/api/api.ts
+++ b/admin/src/lib/api/api.ts
@@ -726,7 +726,6 @@ class Workspaces {
 		warehousePlatform: string,
 		warehouseMode: WarehouseMode,
 		warehouseSettings: WarehouseSettings,
-		warehouseMCPSettings: WarehouseSettings | null,
 		uiPreferences: UIPreferences,
 	): Promise<CreateWorkspaceResponse> => {
 		return await call(`${this.apiURL}/workspaces`, http.POST, this.workspaceID, {
@@ -736,7 +735,6 @@ class Workspaces {
 				platform: warehousePlatform,
 				mode: warehouseMode,
 				settings: warehouseSettings,
-				mcpSettings: warehouseMCPSettings,
 			},
 			uiPreferences: uiPreferences,
 		});
@@ -748,7 +746,6 @@ class Workspaces {
 		warehousePlatform: string,
 		warehouseMode: WarehouseMode,
 		warehouseSettings: WarehouseSettings,
-		mcpWarehouseSettings: WarehouseSettings | null,
 		uiPreferences: UIPreferences,
 	): Promise<void> => {
 		return await call(`${this.apiURL}/workspaces/test`, http.POST, this.workspaceID, {
@@ -758,7 +755,6 @@ class Workspaces {
 				platform: warehousePlatform,
 				mode: warehouseMode,
 				settings: warehouseSettings,
-				mcpSettings: mcpWarehouseSettings,
 			},
 			uiPreferences: uiPreferences,
 		});

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -144,9 +144,6 @@ func (organization organization) CreateWorkspace(_ http.ResponseWriter, r *http.
 	if err != nil {
 		return nil, errors.BadRequest("%s", err)
 	}
-	if body.Warehouse.MCPSettings != nil && body.Warehouse.MCPSettings.IsNull() {
-		body.Warehouse.MCPSettings = nil
-	}
 	id, err := org.CreateWorkspace(r.Context(), body.Name, body.ProfileSchema, body.Warehouse, body.UIPreferences)
 	if err != nil {
 		if err2, ok := err.(*errors.UnprocessableError); ok && err2.Code == core.OrganizationNotExist {
@@ -253,9 +250,6 @@ func (organization organization) TestWorkspaceCreation(_ http.ResponseWriter, r 
 	err = json.Decode(r.Body, &body)
 	if err != nil {
 		return nil, errors.BadRequest("%s", err)
-	}
-	if body.Warehouse.MCPSettings != nil && body.Warehouse.MCPSettings.IsNull() {
-		body.Warehouse.MCPSettings = nil
 	}
 	err = org.TestWorkspaceCreation(r.Context(), body.Name, body.ProfileSchema, body.Warehouse, body.UIPreferences)
 	return nil, err

--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -532,10 +532,9 @@ type CreateWorkspace struct {
 	ProfileSchema                  types.Type
 	ResolveIdentitiesOnBatchImport bool
 	Warehouse                      struct {
-		Platform    string
-		Mode        WarehouseMode
-		Settings    json.Value
-		MCPSettings json.Value
+		Platform string
+		Mode     WarehouseMode
+		Settings json.Value
 	}
 	UIPreferences UIPreferences
 }
@@ -559,10 +558,12 @@ func (state *State) createWorkspace(n notification) uuid.UUID {
 		accounts:                       map[int]*Account{},
 		ResolveIdentitiesOnBatchImport: e.ResolveIdentitiesOnBatchImport,
 		Identifiers:                    []string{},
-		Warehouse:                      e.Warehouse,
 		UIPreferences:                  e.UIPreferences,
 		pipelinesToPurge:               []int{},
 	}
+	ws.Warehouse.Platform = e.Warehouse.Platform
+	ws.Warehouse.Mode = e.Warehouse.Mode
+	ws.Warehouse.Settings = e.Warehouse.Settings
 	state.mu.Lock()
 	state.workspaces[e.ID] = &ws
 	state.mu.Unlock()

--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -546,12 +546,6 @@ func (state *State) createWorkspace(n notification) uuid.UUID {
 	if !decodeNotification(n, &e) {
 		return uuid.Nil
 	}
-	// json.Value(nil) is marshaled into "null", but when it is
-	// deserialized it becomes json.Value("null"), so this code converts it
-	// back to json.Value(nil).
-	if e.Warehouse.MCPSettings.IsNull() {
-		e.Warehouse.MCPSettings = nil
-	}
 	organization := state.organizations[e.Organization]
 	ws := Workspace{
 		mu:                             &sync.Mutex{},

--- a/core/organization.go
+++ b/core/organization.go
@@ -350,16 +350,14 @@ func (this *Organization) CreateAccessKey(ctx context.Context, name string, work
 
 // Warehouse represents a data warehouse.
 type Warehouse struct {
-	Platform    string        `json:"platform"`
-	Mode        WarehouseMode `json:"mode"`
-	Settings    json.Value    `json:"settings"`
-	MCPSettings json.Value    `json:"mcpSettings"`
+	Platform string        `json:"platform"`
+	Mode     WarehouseMode `json:"mode"`
+	Settings json.Value    `json:"settings"`
 }
 
 // CreateWorkspace creates a workspace with the given name, profile schema and
-// displayed properties, and connects to a data warehouse of the given platform,
-// settings and MCP settings (which can be nil, meaning that they are not
-// configured for the workspace).
+// displayed properties, and connects to a data warehouse of the given platform
+// and settings.
 // Returns the identifier of the workspace that has been created.
 // name must be between 1 and 100 runes long.
 //
@@ -368,8 +366,6 @@ type Warehouse struct {
 // It returns an errors.UnprocessableError error with code:
 //
 //   - InvalidWarehouseSettings, if the warehouse settings are not valid.
-//   - NotReadOnlyMCPSettings, if the MCP settings do not grant access to a
-//     read-only user on the data warehouse.
 //   - OrganizationNotExist, if the organization does not exist.
 //   - WarehousePlatformNotExist, if a warehouse platform does not exist.
 //   - WarehouseNotInitializable, if the warehouse is not initializable.
@@ -377,7 +373,7 @@ func (this *Organization) CreateWorkspace(ctx context.Context, name string, prof
 
 	this.core.mustBeOpen()
 
-	settings, mcpSettings, err := this.validateWorkspaceCreation(ctx, name, profileSchema, warehouse, uiPreferences)
+	settings, err := this.validateWorkspaceCreation(ctx, name, profileSchema, warehouse, uiPreferences)
 	if err != nil {
 		return 0, err
 	}
@@ -401,7 +397,6 @@ func (this *Organization) CreateWorkspace(ctx context.Context, name string, prof
 	n.Warehouse.Platform = warehouse.Platform
 	n.Warehouse.Mode = state.WarehouseMode(warehouse.Mode)
 	n.Warehouse.Settings = settings
-	n.Warehouse.MCPSettings = mcpSettings
 
 	// Generate the identifier.
 	n.ID, err = generateRandomID()
@@ -425,8 +420,8 @@ func (this *Organization) CreateWorkspace(ctx context.Context, name string, prof
 		_, err := tx.Exec(ctx, "INSERT INTO workspaces (id, organization, name,"+
 			" profile_schema, resolve_identities_on_batch_import, ui_profile_image, ui_profile_first_name, "+
 			" ui_profile_last_name, ui_profile_extra, warehouse_name, "+
-			"warehouse_mode, warehouse_settings, warehouse_mcp_settings)"+
-			" VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+			"warehouse_mode, warehouse_settings)"+
+			" VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
 			n.ID, n.Organization, n.Name, encodedProfileSchema, n.ResolveIdentitiesOnBatchImport,
 			n.UIPreferences.Profile.Image, n.UIPreferences.Profile.FirstName,
 			n.UIPreferences.Profile.LastName, n.UIPreferences.Profile.Extra,
@@ -672,20 +667,17 @@ func (this *Organization) SendMemberPasswordReset(ctx context.Context, email str
 }
 
 // TestWorkspaceCreation tests a workspace creation. It tests that a warehouse
-// with the provided platform, settings and MCP settings (which can be nil) can
-// be initialized.
+// with the provided platform and settings can be initialized.
 //
 // It returns an errors.UnprocessableError error with code:
 //
 //   - InvalidWarehouseSettings, if the warehouse settings are not valid.
-//   - NotReadOnlyMCPSettings, if the MCP settings do not grant access to a
-//     read-only user on the data warehouse.
 //   - WarehousePlatformNotExist, if a warehouse platform does not exist.
 //   - WarehouseNotInitializable, if the warehouse intended for connection is
 //     not initializable.
 func (this *Organization) TestWorkspaceCreation(ctx context.Context, name string, profileSchema types.Type, warehouse Warehouse, uiPreferences UIPreferences) error {
 	this.core.mustBeOpen()
-	_, _, err := this.validateWorkspaceCreation(ctx, name, profileSchema, warehouse, uiPreferences)
+	_, err := this.validateWorkspaceCreation(ctx, name, profileSchema, warehouse, uiPreferences)
 	return err
 }
 
@@ -828,103 +820,69 @@ func (this *Organization) Workspaces() []*Workspace {
 }
 
 // validateWorkspaceCreation validates the arguments for a workspace creation.
-// It tests that a warehouse with the provided platform, settings and MCP
-// settings (which can be nil) can be initialized, and returns an error if the
-// arguments are not valid.
+// It tests that a warehouse with the provided platform and settings can be
+// initialized, and returns an error if the arguments are not valid.
 //
 // It returns an errors.UnprocessableError error with code:
 //
 //   - InvalidWarehouseSettings, if the warehouse settings are not valid.
-//   - NotReadOnlyMCPSettings, if the MCP settings do not grant access to a
-//     read-only user on the data warehouse.
 //   - WarehousePlatformNotExist, if a warehouse platform does not exist.
 //   - WarehouseNotInitializable, if the warehouse intended for connection is
 //     not initializable.
-func (this *Organization) validateWorkspaceCreation(ctx context.Context, name string, profileSchema types.Type, warehouse Warehouse, uiPreferences UIPreferences) (json.Value, json.Value, error) {
+func (this *Organization) validateWorkspaceCreation(ctx context.Context, name string, profileSchema types.Type, warehouse Warehouse, uiPreferences UIPreferences) (json.Value, error) {
 
 	// Validate the parameters.
 	if err := util.ValidateStringField("name", name, 100); err != nil {
-		return nil, nil, errors.BadRequest("%s", err)
+		return nil, errors.BadRequest("%s", err)
 	}
 	if !profileSchema.Valid() {
-		return nil, nil, errors.BadRequest("profile schema is invalid")
+		return nil, errors.BadRequest("profile schema is invalid")
 	}
 	if err := validateUIPreferences(uiPreferences); err != nil {
-		return nil, nil, errors.BadRequest("%s", err)
+		return nil, errors.BadRequest("%s", err)
 	}
 	if warehouse.Platform == "" {
-		return nil, nil, errors.BadRequest("warehouse platform is empty")
+		return nil, errors.BadRequest("warehouse platform is empty")
 	}
 	switch warehouse.Mode {
 	case Normal, Inspection, Maintenance:
 	default:
-		return nil, nil, errors.BadRequest("warehouse mode is not valid")
+		return nil, errors.BadRequest("warehouse mode is not valid")
 	}
 
 	// Perform additional checks on the compliance of the profile schema.
 	if err := checkAllowedPropertyProfileSchema(profileSchema); err != nil {
-		return nil, nil, errors.BadRequest("%s", err)
+		return nil, errors.BadRequest("%s", err)
 	}
 	if err := datastore.CheckConflictingProperties("profile", profileSchema); err != nil {
-		return nil, nil, errors.BadRequest("%s", err)
+		return nil, errors.BadRequest("%s", err)
 	}
 
 	// Normalize the warehouse settings.
 	settings, err := this.core.datastore.NormalizeWarehouseSettings(warehouse.Platform, warehouse.Settings)
 	if err != nil {
 		if err == datastore.ErrWarehousePlatformNotExist {
-			return nil, nil, errors.Unprocessable(WarehousePlatformNotExist, "warehouse platform %s does not exist", warehouse.Platform)
+			return nil, errors.Unprocessable(WarehousePlatformNotExist, "warehouse platform %s does not exist", warehouse.Platform)
 		}
 		if err, ok := err.(*warehouses.SettingsError); ok {
-			return nil, nil, errors.Unprocessable(InvalidWarehouseSettings, "data warehouse settings are not valid: %w", err.Err)
+			return nil, errors.Unprocessable(InvalidWarehouseSettings, "data warehouse settings are not valid: %w", err.Err)
 		}
-		return nil, nil, err
-	}
-
-	// Normalize the warehouse MCP settings, if provided.
-	var mcpSettings json.Value
-	if warehouse.MCPSettings != nil {
-		// TODO(Gianluca): for https://github.com/meergo/meergo/issues/1833.
-		if warehouse.Platform == "Snowflake" {
-			return nil, nil, errors.BadRequest("MCP feature data is currently not supported for workspaces connected to a Snowflake warehouse")
-		}
-		var err error
-		mcpSettings, err = this.core.datastore.NormalizeWarehouseSettings(warehouse.Platform, warehouse.MCPSettings)
-		if err != nil {
-			if err, ok := err.(*warehouses.SettingsError); ok {
-				return nil, nil, errors.Unprocessable(InvalidWarehouseSettings, "data warehouse MCP settings are not valid: %w", err.Err)
-			}
-			return nil, nil, err
-		}
-		if bytes.Equal(settings, mcpSettings) {
-			return nil, nil, errors.Unprocessable(InvalidWarehouseSettings, "the MCP settings must be different from the data warehouse settings")
-		}
-		// TODO: see https://github.com/meergo/meergo/issues/2129.
-		// err = this.core.datastore.CheckMCPSettings(ctx, warehouse.Platform, mcpSettings)
-		// if err != nil {
-		// 	if err, ok := err.(*warehouses.SettingsNotReadOnly); ok {
-		// 		return nil, nil, errors.Unprocessable(NotReadOnlyMCPSettings, "invalid MCP settings: %s", err)
-		// 	}
-		// 	if err, ok := err.(*datastore.UnavailableError); ok {
-		// 		return nil, nil, errors.Unavailable("%s", err)
-		// 	}
-		// 	return nil, nil, err
-		// }
+		return nil, err
 	}
 
 	// Check if the warehouse is initializable.
 	err = this.core.datastore.CanInitialize(ctx, warehouse.Platform, settings)
 	if err != nil {
 		if err, ok := err.(*warehouses.NonInitializableError); ok {
-			return nil, nil, errors.Unprocessable(WarehouseNotInitializable, "data warehouse is not initializable: %w", err.Err)
+			return nil, errors.Unprocessable(WarehouseNotInitializable, "data warehouse is not initializable: %w", err.Err)
 		}
 		if err, ok := err.(*datastore.UnavailableError); ok {
-			return nil, nil, errors.Unavailable("%s", err)
+			return nil, errors.Unavailable("%s", err)
 		}
-		return nil, nil, err
+		return nil, err
 	}
 
-	return settings, mcpSettings, nil
+	return settings, nil
 }
 
 const base62alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"

--- a/core/organization.go
+++ b/core/organization.go
@@ -410,12 +410,6 @@ func (this *Organization) CreateWorkspace(ctx context.Context, name string, prof
 		return 0, err
 	}
 
-	var mcp string
-	if n.Warehouse.MCPSettings != nil {
-		mcp = string(n.Warehouse.MCPSettings)
-	} else {
-		mcp = "null"
-	}
 	err = this.core.state.Transaction(ctx, func(tx *db.Tx) (any, error) {
 		_, err := tx.Exec(ctx, "INSERT INTO workspaces (id, organization, name,"+
 			" profile_schema, resolve_identities_on_batch_import, ui_profile_image, ui_profile_first_name, "+
@@ -425,7 +419,7 @@ func (this *Organization) CreateWorkspace(ctx context.Context, name string, prof
 			n.ID, n.Organization, n.Name, encodedProfileSchema, n.ResolveIdentitiesOnBatchImport,
 			n.UIPreferences.Profile.Image, n.UIPreferences.Profile.FirstName,
 			n.UIPreferences.Profile.LastName, n.UIPreferences.Profile.Extra,
-			n.Warehouse.Platform, n.Warehouse.Mode, n.Warehouse.Settings, mcp)
+			n.Warehouse.Platform, n.Warehouse.Mode, n.Warehouse.Settings)
 		if err != nil {
 			if db.IsForeignKeyViolation(err) {
 				if db.ErrConstraintName(err) == "workspaces_organization_fkey" {


### PR DESCRIPTION
Resolves #2129.

## Commit message

```
all: disable setting MCP credentials when creating a workspace

The ability to set MCP credentials when creating a workspace is
conceptually flawed, because the way we currently test MCP credentials
verifies that the Meergo tables in the warehouse are read-only, but
those tables don't yet exist, and so the test always returns an error.

So, this commit:

1. Makes the workspace creation method no longer accept the option to
   set MCP credentials.

2. Consistently removes this option from the method that tests workspace
   creation.

3. Modifies the Admin so that, when creating the workspace connected to
   Docker, it sets the MCP credentials in a separate call. This code
   will need to be revised later and is only a prototype.

Resolves #2129.
```