### PR TITLE
admin: add doc links when adding connection or creating file pipeline

### DIFF
--- a/admin/src/components/base/ConnectorUI/ConnectorUI.css
+++ b/admin/src/components/base/ConnectorUI/ConnectorUI.css
@@ -27,6 +27,7 @@
 	display: flex;
 	justify-content: center;
 	gap: 30px;
+	flex-wrap: wrap;
 }
 
 .connector-ui__buttons sl-button {

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -1,10 +1,17 @@
 .documentation-links {
 	display: flex;
 	flex-direction: column;
-	align-items: end;
 	gap: 0.25rem;
 	margin-top: 1rem;
 	flex-basis: 100%;
+}
+
+.documentation-links--end {
+	align-items: end;
+}
+
+.documentation-links--start {
+	align-items: start;
 }
 
 .documentation-links a,
@@ -22,8 +29,3 @@
 	padding-right: 3px;
 }
 
-@media (max-width: 1200px) {
-	.documentation-links {
-		align-items: end;
-	}
-}

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -1,8 +1,8 @@
 .documentation-links {
 	display: flex;
 	flex-direction: column;
-	gap: 0.25rem;
-	margin-top: 1rem;
+	gap: 0.75rem;
+	margin-top: -1.6rem;
 	flex-basis: 100%;
 }
 
@@ -29,10 +29,18 @@
 
 .documentation-links a,
 .documentation-links a:visited {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35rem;
 	color: var(--sl-color-primary-600);
 	text-decoration: none;
 	font-size: 13px;
-	line-height: 1.57;
+	line-height: 1;
+}
+
+.documentation-links a sl-icon {
+	font-size: 14px;
+	flex-shrink: 0;
 }
 
 .documentation-links a[target='_blank']::after {

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -14,6 +14,19 @@
 	align-items: start;
 }
 
+.documentation-links--fade {
+	animation: documentation-links-fade-in 0.4s ease-in 0.15s both;
+}
+
+@keyframes documentation-links-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
 .documentation-links a,
 .documentation-links a:visited {
 	color: var(--sl-color-primary-600);

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -2,7 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 0.75rem;
-	margin-top: -1.6rem;
+	margin-top: 0.75rem;
 	flex-basis: 100%;
 }
 

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -1,17 +1,10 @@
 .documentation-links {
 	display: flex;
 	flex-direction: column;
+	align-items: start;
 	gap: 0.75rem;
 	margin-top: 0.75rem;
 	flex-basis: 100%;
-}
-
-.documentation-links--end {
-	align-items: end;
-}
-
-.documentation-links--start {
-	align-items: start;
 }
 
 .documentation-links--fade {

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	align-items: center;
 	gap: 0.25rem;
-	margin-top: 0;
+	margin-top: 1rem;
 	flex-basis: 100%;
 }
 
@@ -20,4 +20,10 @@
 	font-size: 0.8em;
 	margin-right: 2px;
 	padding-right: 3px;
+}
+
+@media (max-width: 1200px) {
+	.documentation-links {
+		align-items: start;
+	}
 }

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -1,0 +1,23 @@
+.documentation-links {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.25rem;
+	margin-top: 0;
+	flex-basis: 100%;
+}
+
+.documentation-links a,
+.documentation-links a:visited {
+	color: var(--sl-color-primary-600);
+	text-decoration: none;
+	font-size: 13px;
+	line-height: 1.57;
+}
+
+.documentation-links a[target='_blank']::after {
+	content: '\00a0↗';
+	font-size: 0.8em;
+	margin-right: 2px;
+	padding-right: 3px;
+}

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -1,7 +1,7 @@
 .documentation-links {
 	display: flex;
 	flex-direction: column;
-	align-items: center;
+	align-items: start;
 	gap: 0.25rem;
 	margin-top: 1rem;
 	flex-basis: 100%;

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -1,7 +1,7 @@
 .documentation-links {
 	display: flex;
 	flex-direction: column;
-	align-items: start;
+	align-items: end;
 	gap: 0.25rem;
 	margin-top: 1rem;
 	flex-basis: 100%;
@@ -24,6 +24,6 @@
 
 @media (max-width: 1200px) {
 	.documentation-links {
-		align-items: start;
+		align-items: end;
 	}
 }

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.css
@@ -42,4 +42,3 @@
 	margin-right: 2px;
 	padding-right: 3px;
 }
-

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import SlIcon from '@shoelace-style/shoelace/dist/react/icon/index.js';
 import './DocumentationLinks.css';
 
 // Mapping: connectorCode -> role -> links
@@ -196,6 +197,7 @@ interface DocumentationLinksProps {
 	connectorLabel?: string;
 	align?: 'start' | 'end';
 	fade?: boolean;
+	showIcon?: boolean;
 }
 
 const DocumentationLinks = ({
@@ -205,6 +207,7 @@ const DocumentationLinks = ({
 	connectorLabel,
 	align = 'end',
 	fade = false,
+	showIcon = false,
 }: DocumentationLinksProps) => {
 	let links: { label: string; url: string }[];
 
@@ -224,6 +227,7 @@ const DocumentationLinks = ({
 		<div className={`documentation-links documentation-links--${align}${fade ? ' documentation-links--fade' : ''}`}>
 			{links.map((link) => (
 				<a key={link.url} href={link.url} target='_blank' rel='noopener'>
+					{showIcon && <SlIcon name='question-circle' />}
 					{link.label}
 				</a>
 			))}

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -195,6 +195,7 @@ interface DocumentationLinksProps {
 	storageCode?: string;
 	connectorLabel?: string;
 	align?: 'start' | 'end';
+	fade?: boolean;
 }
 
 const DocumentationLinks = ({
@@ -203,6 +204,7 @@ const DocumentationLinks = ({
 	storageCode,
 	connectorLabel,
 	align = 'end',
+	fade = false,
 }: DocumentationLinksProps) => {
 	let links: { label: string; url: string }[];
 
@@ -219,7 +221,7 @@ const DocumentationLinks = ({
 	if (!links || links.length === 0) return null;
 
 	return (
-		<div className={`documentation-links documentation-links--${align}`}>
+		<div className={`documentation-links documentation-links--${align}${fade ? ' documentation-links--fade' : ''}`}>
 			{links.map((link) => (
 				<a key={link.url} href={link.url} target='_blank' rel='noopener'>
 					{link.label}

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import './DocumentationLinks.css';
+
+// Mapping: connectorCode -> role -> links
+const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: string }[]>> = {
+	klaviyo: {
+		Destination: [
+			{
+				label: 'Activate profiles on Klaviyo',
+				url: 'https://www.meergo.com/docs/activate-profiles/klaviyo',
+			},
+			{
+				label: 'Activate events on Klaviyo',
+				url: 'https://www.meergo.com/docs/activate-events/klaviyo',
+			},
+		],
+	},
+	'http-get': {
+		Source: [
+			{
+				label: 'Learn how to ingest users from HTTP GET',
+				url: 'https://www.meergo.com/docs/ingest-users/files?storage=http#panel-storage-http-get',
+			},
+		],
+	},
+	postgresql: {
+		Source: [{ label: 'How to configure PostgreSQL as a source', url: 'https://docs.example.com/postgres-source' }],
+		Destination: [{ label: 'PostgreSQL destination setup', url: 'https://docs.example.com/postgres-dest' }],
+	},
+};
+
+interface DocumentationLinksProps {
+	connectorCode: string;
+	role: string;
+}
+
+const DocumentationLinks = ({ connectorCode, role }: DocumentationLinksProps) => {
+	const links = DOCUMENTATION_LINKS[connectorCode]?.[role];
+	if (!links || links.length === 0) return null;
+
+	return (
+		<div className='documentation-links'>
+			{links.map((link) => (
+				<a key={link.url} href={link.url} target='_blank' rel='noopener'>
+					{link.label}
+				</a>
+			))}
+		</div>
+	);
+};
+
+export default DocumentationLinks;

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -167,44 +167,86 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 	// SDKs
 	javascript: {
 		Source: [
-			{ label: 'Collect events with JavaScript SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=javascript#1-connect-an-application' },
-			{ label: 'Ingest users with JavaScript SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=javascript#1-connect-an-application' },
+			{
+				label: 'Collect events with JavaScript SDK',
+				url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=javascript#1-connect-an-application',
+			},
+			{
+				label: 'Ingest users with JavaScript SDK',
+				url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=javascript#1-connect-an-application',
+			},
 		],
 	},
 	android: {
 		Source: [
-			{ label: 'Collect events with Android SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=android#1-connect-an-application' },
-			{ label: 'Ingest users with Android SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=android#1-connect-an-application' },
+			{
+				label: 'Collect events with Android SDK',
+				url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=android#1-connect-an-application',
+			},
+			{
+				label: 'Ingest users with Android SDK',
+				url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=android#1-connect-an-application',
+			},
 		],
 	},
 	nodejs: {
 		Source: [
-			{ label: 'Collect events with Node.js SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=nodejs#1-connect-an-application' },
-			{ label: 'Ingest users with Node.js SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=nodejs#1-connect-an-application' },
+			{
+				label: 'Collect events with Node.js SDK',
+				url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=nodejs#1-connect-an-application',
+			},
+			{
+				label: 'Ingest users with Node.js SDK',
+				url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=nodejs#1-connect-an-application',
+			},
 		],
 	},
 	python: {
 		Source: [
-			{ label: 'Collect events with Python SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=python#1-connect-an-application' },
-			{ label: 'Ingest users with Python SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=python#1-connect-an-application' },
+			{
+				label: 'Collect events with Python SDK',
+				url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=python#1-connect-an-application',
+			},
+			{
+				label: 'Ingest users with Python SDK',
+				url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=python#1-connect-an-application',
+			},
 		],
 	},
 	go: {
 		Source: [
-			{ label: 'Collect events with Go SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=go#1-connect-an-application' },
-			{ label: 'Ingest users with Go SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=go#1-connect-an-application' },
+			{
+				label: 'Collect events with Go SDK',
+				url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=go#1-connect-an-application',
+			},
+			{
+				label: 'Ingest users with Go SDK',
+				url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=go#1-connect-an-application',
+			},
 		],
 	},
 	java: {
 		Source: [
-			{ label: 'Collect events with Java SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=java#1-connect-an-application' },
-			{ label: 'Ingest users with Java SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=java#1-connect-an-application' },
+			{
+				label: 'Collect events with Java SDK',
+				url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=java#1-connect-an-application',
+			},
+			{
+				label: 'Ingest users with Java SDK',
+				url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=java#1-connect-an-application',
+			},
 		],
 	},
 	dotnet: {
 		Source: [
-			{ label: 'Collect events with .NET SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=net#1-connect-an-application' },
-			{ label: 'Ingest users with .NET SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=net#1-connect-an-application' },
+			{
+				label: 'Collect events with .NET SDK',
+				url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=net#1-connect-an-application',
+			},
+			{
+				label: 'Ingest users with .NET SDK',
+				url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=net#1-connect-an-application',
+			},
 		],
 	},
 };
@@ -214,7 +256,6 @@ interface DocumentationLinksProps {
 	role: string;
 	storageCode?: string;
 	connectorLabel?: string;
-	align?: 'start' | 'end';
 	fade?: boolean;
 	showIcon?: boolean;
 }
@@ -224,7 +265,6 @@ const DocumentationLinks = ({
 	role,
 	storageCode,
 	connectorLabel,
-	align = 'end',
 	fade = false,
 	showIcon = false,
 }: DocumentationLinksProps) => {
@@ -232,7 +272,9 @@ const DocumentationLinks = ({
 
 	if (storageCode != null && connectorLabel != null) {
 		const isSource = role === 'Source';
-		const label = isSource ? `Import users from ${connectorLabel}` : `Export users to ${connectorLabel}`;
+		const label = isSource
+			? `How to import users from ${connectorLabel}`
+			: `How to export users to ${connectorLabel}`;
 		const basePath = isSource ? 'ingest-users' : 'activate-users';
 		const url = `https://www.meergo.com/docs/${basePath}/files?storage=${storageCode}&format=${connectorCode}#4-enter-file-settings`;
 		links = [{ label, url }];
@@ -243,7 +285,7 @@ const DocumentationLinks = ({
 	if (!links || links.length === 0) return null;
 
 	return (
-		<div className={`documentation-links documentation-links--${align}${fade ? ' documentation-links--fade' : ''}`}>
+		<div className={`documentation-links${fade ? ' documentation-links--fade' : ''}`}>
 			{links.map((link) => (
 				<a key={link.url} href={link.url} target='_blank' rel='noopener'>
 					{showIcon && <SlIcon name='question-circle' />}

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -23,6 +23,14 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 			},
 		],
 	},
+	parquet: {
+		Source: [
+			{
+				label: 'Import users from Parquet',
+				url: 'https://example.com',
+			},
+		],
+	},
 	postgresql: {
 		Source: [{ label: 'How to configure PostgreSQL as a source', url: 'https://docs.example.com/postgres-source' }],
 		Destination: [{ label: 'PostgreSQL destination setup', url: 'https://docs.example.com/postgres-dest' }],

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -5,35 +5,33 @@ import './DocumentationLinks.css';
 const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: string }[]>> = {
 	// Databases
 	postgresql: {
-		Source: [
-			{ label: 'Ingest users from PostgreSQL', url: 'https://www.meergo.com/docs/ingest-users/databases' },
-		],
+		Source: [{ label: 'Ingest users from PostgreSQL', url: 'https://www.meergo.com/docs/ingest-users/databases' }],
 		Destination: [
-			{ label: 'Activate profiles to PostgreSQL', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
+			{
+				label: 'Activate profiles to PostgreSQL',
+				url: 'https://www.meergo.com/docs/activate-profiles/databases',
+			},
 		],
 	},
 	mysql: {
-		Source: [
-			{ label: 'Ingest users from MySQL', url: 'https://www.meergo.com/docs/ingest-users/databases' },
-		],
+		Source: [{ label: 'Ingest users from MySQL', url: 'https://www.meergo.com/docs/ingest-users/databases' }],
 		Destination: [
 			{ label: 'Activate profiles to MySQL', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
 		],
 	},
 	snowflake: {
-		Source: [
-			{ label: 'Ingest users from Snowflake', url: 'https://www.meergo.com/docs/ingest-users/databases' },
-		],
+		Source: [{ label: 'Ingest users from Snowflake', url: 'https://www.meergo.com/docs/ingest-users/databases' }],
 		Destination: [
 			{ label: 'Activate profiles to Snowflake', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
 		],
 	},
 	clickhouse: {
-		Source: [
-			{ label: 'Ingest users from ClickHouse', url: 'https://www.meergo.com/docs/ingest-users/databases' },
-		],
+		Source: [{ label: 'Ingest users from ClickHouse', url: 'https://www.meergo.com/docs/ingest-users/databases' }],
 		Destination: [
-			{ label: 'Activate profiles to ClickHouse', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
+			{
+				label: 'Activate profiles to ClickHouse',
+				url: 'https://www.meergo.com/docs/activate-profiles/databases',
+			},
 		],
 	},
 	// SaaS apps (Source + Destination)
@@ -64,7 +62,10 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 	},
 	mailchimp: {
 		Source: [
-			{ label: 'Ingest users from Mailchimp', url: 'https://www.meergo.com/docs/ingest-users/saas-apps/mailchimp' },
+			{
+				label: 'Ingest users from Mailchimp',
+				url: 'https://www.meergo.com/docs/ingest-users/saas-apps/mailchimp',
+			},
 		],
 		Destination: [
 			{ label: 'Activate profiles on Mailchimp', url: 'https://www.meergo.com/docs/activate-profiles/mailchimp' },
@@ -78,7 +79,10 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 	},
 	'google-analytics': {
 		Destination: [
-			{ label: 'Activate events on Google Analytics', url: 'https://www.meergo.com/docs/activate-events/google-analytics' },
+			{
+				label: 'Activate events on Google Analytics',
+				url: 'https://www.meergo.com/docs/activate-events/google-analytics',
+			},
 		],
 	},
 	posthog: {
@@ -94,42 +98,69 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 	},
 	rudderstack: {
 		Source: [
-			{ label: 'Ingest users from RudderStack', url: 'https://www.meergo.com/docs/ingest-users/saas-apps/rudderstack' },
+			{
+				label: 'Ingest users from RudderStack',
+				url: 'https://www.meergo.com/docs/ingest-users/saas-apps/rudderstack',
+			},
 		],
 	},
 	// File storages
 	s3: {
 		Source: [
-			{ label: 'Ingest users from files on S3', url: 'https://www.meergo.com/docs/ingest-users/files?storage=s3' },
+			{
+				label: 'Ingest users from files on S3',
+				url: 'https://www.meergo.com/docs/ingest-users/files?storage=s3',
+			},
 		],
 		Destination: [
-			{ label: 'Activate profiles to files on S3', url: 'https://www.meergo.com/docs/activate-profiles/files?storage=s3' },
+			{
+				label: 'Activate profiles to files on S3',
+				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=s3',
+			},
 		],
 	},
 	sftp: {
 		Source: [
-			{ label: 'Ingest users from files on SFTP', url: 'https://www.meergo.com/docs/ingest-users/files?storage=sftp' },
+			{
+				label: 'Ingest users from files on SFTP',
+				url: 'https://www.meergo.com/docs/ingest-users/files?storage=sftp',
+			},
 		],
 		Destination: [
-			{ label: 'Activate profiles to files on SFTP', url: 'https://www.meergo.com/docs/activate-profiles/files?storage=sftp' },
+			{
+				label: 'Activate profiles to files on SFTP',
+				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=sftp',
+			},
 		],
 	},
 	filesystem: {
 		Source: [
-			{ label: 'Ingest users from files on File System', url: 'https://www.meergo.com/docs/ingest-users/files?storage=filesystem' },
+			{
+				label: 'Ingest users from files on File System',
+				url: 'https://www.meergo.com/docs/ingest-users/files?storage=filesystem',
+			},
 		],
 		Destination: [
-			{ label: 'Activate profiles to files on File System', url: 'https://www.meergo.com/docs/activate-profiles/files?storage=filesystem' },
+			{
+				label: 'Activate profiles to files on File System',
+				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=filesystem',
+			},
 		],
 	},
 	'http-get': {
 		Source: [
-			{ label: 'Ingest users from files via HTTP GET', url: 'https://www.meergo.com/docs/ingest-users/files?storage=http#panel-storage-http-get' },
+			{
+				label: 'Ingest users from files via HTTP GET',
+				url: 'https://www.meergo.com/docs/ingest-users/files?storage=http#panel-storage-http-get',
+			},
 		],
 	},
 	'http-post': {
 		Destination: [
-			{ label: 'Activate profiles to files via HTTP POST', url: 'https://www.meergo.com/docs/activate-profiles/files?storage=http#panel-storage-http-post' },
+			{
+				label: 'Activate profiles to files via HTTP POST',
+				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=http#panel-storage-http-post',
+			},
 		],
 	},
 	// SDKs
@@ -139,34 +170,22 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 		],
 	},
 	android: {
-		Source: [
-			{ label: 'Android SDK documentation', url: 'https://www.meergo.com/docs/integrations/android-sdk' },
-		],
+		Source: [{ label: 'Android SDK documentation', url: 'https://www.meergo.com/docs/integrations/android-sdk' }],
 	},
 	nodejs: {
-		Source: [
-			{ label: 'Node.js SDK documentation', url: 'https://www.meergo.com/docs/integrations/nodejs-sdk' },
-		],
+		Source: [{ label: 'Node.js SDK documentation', url: 'https://www.meergo.com/docs/integrations/nodejs-sdk' }],
 	},
 	python: {
-		Source: [
-			{ label: 'Python SDK documentation', url: 'https://www.meergo.com/docs/integrations/python-sdk' },
-		],
+		Source: [{ label: 'Python SDK documentation', url: 'https://www.meergo.com/docs/integrations/python-sdk' }],
 	},
 	go: {
-		Source: [
-			{ label: 'Go SDK documentation', url: 'https://www.meergo.com/docs/integrations/go-sdk' },
-		],
+		Source: [{ label: 'Go SDK documentation', url: 'https://www.meergo.com/docs/integrations/go-sdk' }],
 	},
 	java: {
-		Source: [
-			{ label: 'Java SDK documentation', url: 'https://www.meergo.com/docs/integrations/java-sdk' },
-		],
+		Source: [{ label: 'Java SDK documentation', url: 'https://www.meergo.com/docs/integrations/java-sdk' }],
 	},
 	dotnet: {
-		Source: [
-			{ label: '.NET SDK documentation', url: 'https://www.meergo.com/docs/integrations/dotnet-sdk' },
-		],
+		Source: [{ label: '.NET SDK documentation', url: 'https://www.meergo.com/docs/integrations/dotnet-sdk' }],
 	},
 };
 
@@ -175,16 +194,23 @@ interface DocumentationLinksProps {
 	role: string;
 	storageCode?: string;
 	connectorLabel?: string;
+	align?: 'start' | 'end';
 }
 
-const DocumentationLinks = ({ connectorCode, role, storageCode, connectorLabel }: DocumentationLinksProps) => {
+const DocumentationLinks = ({
+	connectorCode,
+	role,
+	storageCode,
+	connectorLabel,
+	align = 'end',
+}: DocumentationLinksProps) => {
 	let links: { label: string; url: string }[];
 
 	if (storageCode != null && connectorLabel != null) {
 		const isSource = role === 'Source';
 		const label = isSource ? `Import users from ${connectorLabel}` : `Export users to ${connectorLabel}`;
 		const basePath = isSource ? 'ingest-users' : 'activate-users';
-		const url = `https://www.meergo.com/docs/${basePath}/files?storage=${storageCode}&format=${connectorCode}`;
+		const url = `https://www.meergo.com/docs/${basePath}/files?storage=${storageCode}&format=${connectorCode}#4-enter-file-settings`;
 		links = [{ label, url }];
 	} else {
 		links = DOCUMENTATION_LINKS[connectorCode]?.[role];
@@ -193,7 +219,7 @@ const DocumentationLinks = ({ connectorCode, role, storageCode, connectorLabel }
 	if (!links || links.length === 0) return null;
 
 	return (
-		<div className='documentation-links'>
+		<div className={`documentation-links documentation-links--${align}`}>
 			{links.map((link) => (
 				<a key={link.url} href={link.url} target='_blank' rel='noopener'>
 					{link.label}

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -6,32 +6,58 @@ import './DocumentationLinks.css';
 const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: string }[]>> = {
 	// Databases
 	postgresql: {
-		Source: [{ label: 'Ingest users from PostgreSQL', url: 'https://www.meergo.com/docs/ingest-users/databases' }],
+		Source: [
+			{
+				label: 'Ingest users from PostgreSQL',
+				url: 'https://www.meergo.com/docs/ingest-users/databases?settings=postgresql#1-connect-a-database',
+			},
+		],
 		Destination: [
 			{
 				label: 'Activate profiles to PostgreSQL',
-				url: 'https://www.meergo.com/docs/activate-profiles/databases',
+				url: 'https://www.meergo.com/docs/activate-profiles/databases?settings=postgresql#1-connect-a-database-table',
 			},
 		],
 	},
 	mysql: {
-		Source: [{ label: 'Ingest users from MySQL', url: 'https://www.meergo.com/docs/ingest-users/databases' }],
+		Source: [
+			{
+				label: 'Ingest users from MySQL',
+				url: 'https://www.meergo.com/docs/ingest-users/databases?settings=mysql#1-connect-a-database',
+			},
+		],
 		Destination: [
-			{ label: 'Activate profiles to MySQL', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
+			{
+				label: 'Activate profiles to MySQL',
+				url: 'https://www.meergo.com/docs/activate-profiles/databases?settings=mysql#1-connect-a-database-table',
+			},
 		],
 	},
 	snowflake: {
-		Source: [{ label: 'Ingest users from Snowflake', url: 'https://www.meergo.com/docs/ingest-users/databases' }],
+		Source: [
+			{
+				label: 'Ingest users from Snowflake',
+				url: 'https://www.meergo.com/docs/ingest-users/databases?settings=snowflake#1-connect-a-database',
+			},
+		],
 		Destination: [
-			{ label: 'Activate profiles to Snowflake', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
+			{
+				label: 'Activate profiles to Snowflake',
+				url: 'https://www.meergo.com/docs/activate-profiles/databases?settings=snowflake#1-connect-a-database-table',
+			},
 		],
 	},
 	clickhouse: {
-		Source: [{ label: 'Ingest users from ClickHouse', url: 'https://www.meergo.com/docs/ingest-users/databases' }],
+		Source: [
+			{
+				label: 'Ingest users from ClickHouse',
+				url: 'https://www.meergo.com/docs/ingest-users/databases?settings=clickhouse#1-connect-a-database',
+			},
+		],
 		Destination: [
 			{
 				label: 'Activate profiles to ClickHouse',
-				url: 'https://www.meergo.com/docs/activate-profiles/databases',
+				url: 'https://www.meergo.com/docs/activate-profiles/databases?settings=clickhouse#1-connect-a-database-table',
 			},
 		],
 	},
@@ -110,13 +136,13 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 		Source: [
 			{
 				label: 'Ingest users from files on S3',
-				url: 'https://www.meergo.com/docs/ingest-users/files?storage=s3',
+				url: 'https://www.meergo.com/docs/ingest-users/files?storage=s3#1-connect-a-storage',
 			},
 		],
 		Destination: [
 			{
 				label: 'Activate profiles to files on S3',
-				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=s3',
+				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=s3#1-connect-a-storage',
 			},
 		],
 	},
@@ -124,13 +150,13 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 		Source: [
 			{
 				label: 'Ingest users from files on SFTP',
-				url: 'https://www.meergo.com/docs/ingest-users/files?storage=sftp',
+				url: 'https://www.meergo.com/docs/ingest-users/files?storage=sftp#1-connect-a-storage',
 			},
 		],
 		Destination: [
 			{
 				label: 'Activate profiles to files on SFTP',
-				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=sftp',
+				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=sftp#1-connect-a-storage',
 			},
 		],
 	},
@@ -138,13 +164,13 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 		Source: [
 			{
 				label: 'Ingest users from files on File System',
-				url: 'https://www.meergo.com/docs/ingest-users/files?storage=filesystem',
+				url: 'https://www.meergo.com/docs/ingest-users/files?storage=filesystem#1-connect-a-storage',
 			},
 		],
 		Destination: [
 			{
 				label: 'Activate profiles to files on File System',
-				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=filesystem',
+				url: 'https://www.meergo.com/docs/activate-profiles/files?storage=filesystem#1-connect-a-storage',
 			},
 		],
 	},

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -3,29 +3,170 @@ import './DocumentationLinks.css';
 
 // Mapping: connectorCode -> role -> links
 const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: string }[]>> = {
-	klaviyo: {
+	// Databases
+	postgresql: {
+		Source: [
+			{ label: 'Ingest users from PostgreSQL', url: 'https://www.meergo.com/docs/ingest-users/databases' },
+		],
 		Destination: [
-			{
-				label: 'Activate profiles on Klaviyo',
-				url: 'https://www.meergo.com/docs/activate-profiles/klaviyo',
-			},
-			{
-				label: 'Activate events on Klaviyo',
-				url: 'https://www.meergo.com/docs/activate-events/klaviyo',
-			},
+			{ label: 'Activate profiles to PostgreSQL', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
+		],
+	},
+	mysql: {
+		Source: [
+			{ label: 'Ingest users from MySQL', url: 'https://www.meergo.com/docs/ingest-users/databases' },
+		],
+		Destination: [
+			{ label: 'Activate profiles to MySQL', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
+		],
+	},
+	snowflake: {
+		Source: [
+			{ label: 'Ingest users from Snowflake', url: 'https://www.meergo.com/docs/ingest-users/databases' },
+		],
+		Destination: [
+			{ label: 'Activate profiles to Snowflake', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
+		],
+	},
+	clickhouse: {
+		Source: [
+			{ label: 'Ingest users from ClickHouse', url: 'https://www.meergo.com/docs/ingest-users/databases' },
+		],
+		Destination: [
+			{ label: 'Activate profiles to ClickHouse', url: 'https://www.meergo.com/docs/activate-profiles/databases' },
+		],
+	},
+	// SaaS apps (Source + Destination)
+	stripe: {
+		Source: [
+			{ label: 'Ingest users from Stripe', url: 'https://www.meergo.com/docs/ingest-users/saas-apps/stripe' },
+		],
+		Destination: [
+			{ label: 'Activate profiles on Stripe', url: 'https://www.meergo.com/docs/activate-profiles/stripe' },
+		],
+	},
+	hubspot: {
+		Source: [
+			{ label: 'Ingest users from HubSpot', url: 'https://www.meergo.com/docs/ingest-users/saas-apps/hubspot' },
+		],
+		Destination: [
+			{ label: 'Activate profiles on HubSpot', url: 'https://www.meergo.com/docs/activate-profiles/hubspot' },
+		],
+	},
+	klaviyo: {
+		Source: [
+			{ label: 'Ingest users from Klaviyo', url: 'https://www.meergo.com/docs/ingest-users/saas-apps/klaviyo' },
+		],
+		Destination: [
+			{ label: 'Activate profiles on Klaviyo', url: 'https://www.meergo.com/docs/activate-profiles/klaviyo' },
+			{ label: 'Activate events on Klaviyo', url: 'https://www.meergo.com/docs/activate-events/klaviyo' },
+		],
+	},
+	mailchimp: {
+		Source: [
+			{ label: 'Ingest users from Mailchimp', url: 'https://www.meergo.com/docs/ingest-users/saas-apps/mailchimp' },
+		],
+		Destination: [
+			{ label: 'Activate profiles on Mailchimp', url: 'https://www.meergo.com/docs/activate-profiles/mailchimp' },
+		],
+	},
+	// SaaS apps (Destination only, events)
+	mixpanel: {
+		Destination: [
+			{ label: 'Activate events on Mixpanel', url: 'https://www.meergo.com/docs/activate-events/mixpanel' },
+		],
+	},
+	'google-analytics': {
+		Destination: [
+			{ label: 'Activate events on Google Analytics', url: 'https://www.meergo.com/docs/activate-events/google-analytics' },
+		],
+	},
+	posthog: {
+		Destination: [
+			{ label: 'Activate events on PostHog', url: 'https://www.meergo.com/docs/activate-events/posthog' },
+		],
+	},
+	// SaaS apps (Source only)
+	segment: {
+		Source: [
+			{ label: 'Ingest users from Segment', url: 'https://www.meergo.com/docs/ingest-users/saas-apps/segment' },
+		],
+	},
+	rudderstack: {
+		Source: [
+			{ label: 'Ingest users from RudderStack', url: 'https://www.meergo.com/docs/ingest-users/saas-apps/rudderstack' },
+		],
+	},
+	// File storages
+	s3: {
+		Source: [
+			{ label: 'Ingest users from files on S3', url: 'https://www.meergo.com/docs/ingest-users/files?storage=s3' },
+		],
+		Destination: [
+			{ label: 'Activate profiles to files on S3', url: 'https://www.meergo.com/docs/activate-profiles/files?storage=s3' },
+		],
+	},
+	sftp: {
+		Source: [
+			{ label: 'Ingest users from files on SFTP', url: 'https://www.meergo.com/docs/ingest-users/files?storage=sftp' },
+		],
+		Destination: [
+			{ label: 'Activate profiles to files on SFTP', url: 'https://www.meergo.com/docs/activate-profiles/files?storage=sftp' },
+		],
+	},
+	filesystem: {
+		Source: [
+			{ label: 'Ingest users from files on File System', url: 'https://www.meergo.com/docs/ingest-users/files?storage=filesystem' },
+		],
+		Destination: [
+			{ label: 'Activate profiles to files on File System', url: 'https://www.meergo.com/docs/activate-profiles/files?storage=filesystem' },
 		],
 	},
 	'http-get': {
 		Source: [
-			{
-				label: 'Learn how to ingest users from HTTP GET',
-				url: 'https://www.meergo.com/docs/ingest-users/files?storage=http#panel-storage-http-get',
-			},
+			{ label: 'Ingest users from files via HTTP GET', url: 'https://www.meergo.com/docs/ingest-users/files?storage=http#panel-storage-http-get' },
 		],
 	},
-	postgresql: {
-		Source: [{ label: 'How to configure PostgreSQL as a source', url: 'https://docs.example.com/postgres-source' }],
-		Destination: [{ label: 'PostgreSQL destination setup', url: 'https://docs.example.com/postgres-dest' }],
+	'http-post': {
+		Destination: [
+			{ label: 'Activate profiles to files via HTTP POST', url: 'https://www.meergo.com/docs/activate-profiles/files?storage=http#panel-storage-http-post' },
+		],
+	},
+	// SDKs
+	javascript: {
+		Source: [
+			{ label: 'JavaScript SDK documentation', url: 'https://www.meergo.com/docs/integrations/javascript-sdk' },
+		],
+	},
+	android: {
+		Source: [
+			{ label: 'Android SDK documentation', url: 'https://www.meergo.com/docs/integrations/android-sdk' },
+		],
+	},
+	nodejs: {
+		Source: [
+			{ label: 'Node.js SDK documentation', url: 'https://www.meergo.com/docs/integrations/nodejs-sdk' },
+		],
+	},
+	python: {
+		Source: [
+			{ label: 'Python SDK documentation', url: 'https://www.meergo.com/docs/integrations/python-sdk' },
+		],
+	},
+	go: {
+		Source: [
+			{ label: 'Go SDK documentation', url: 'https://www.meergo.com/docs/integrations/go-sdk' },
+		],
+	},
+	java: {
+		Source: [
+			{ label: 'Java SDK documentation', url: 'https://www.meergo.com/docs/integrations/java-sdk' },
+		],
+	},
+	dotnet: {
+		Source: [
+			{ label: '.NET SDK documentation', url: 'https://www.meergo.com/docs/integrations/dotnet-sdk' },
+		],
 	},
 };
 

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -301,8 +301,9 @@ const DocumentationLinks = ({
 		const label = isSource
 			? `How to import users from ${connectorLabel}`
 			: `How to export users to ${connectorLabel}`;
-		const basePath = isSource ? 'ingest-users' : 'activate-users';
-		const url = `https://www.meergo.com/docs/${basePath}/files?storage=${storageCode}&format=${connectorCode}#4-enter-file-settings`;
+		const basePath = isSource ? 'ingest-users' : 'activate-profiles';
+		const fragment = isSource ? '4-enter-file-settings' : '5-enter-file-settings';
+		const url = `https://www.meergo.com/docs/${basePath}/files?storage=${storageCode}&format=${connectorCode}#${fragment}`;
 		links = [{ label, url }];
 	} else {
 		links = DOCUMENTATION_LINKS[connectorCode]?.[role];

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -23,14 +23,6 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 			},
 		],
 	},
-	parquet: {
-		Source: [
-			{
-				label: 'Import users from Parquet',
-				url: 'https://example.com',
-			},
-		],
-	},
 	postgresql: {
 		Source: [{ label: 'How to configure PostgreSQL as a source', url: 'https://docs.example.com/postgres-source' }],
 		Destination: [{ label: 'PostgreSQL destination setup', url: 'https://docs.example.com/postgres-dest' }],
@@ -40,10 +32,23 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 interface DocumentationLinksProps {
 	connectorCode: string;
 	role: string;
+	storageCode?: string;
+	connectorLabel?: string;
 }
 
-const DocumentationLinks = ({ connectorCode, role }: DocumentationLinksProps) => {
-	const links = DOCUMENTATION_LINKS[connectorCode]?.[role];
+const DocumentationLinks = ({ connectorCode, role, storageCode, connectorLabel }: DocumentationLinksProps) => {
+	let links: { label: string; url: string }[];
+
+	if (storageCode != null && connectorLabel != null) {
+		const isSource = role === 'Source';
+		const label = isSource ? `Import users from ${connectorLabel}` : `Export users to ${connectorLabel}`;
+		const basePath = isSource ? 'ingest-users' : 'activate-users';
+		const url = `https://www.meergo.com/docs/${basePath}/files?storage=${storageCode}&format=${connectorCode}`;
+		links = [{ label, url }];
+	} else {
+		links = DOCUMENTATION_LINKS[connectorCode]?.[role];
+	}
+
 	if (!links || links.length === 0) return null;
 
 	return (

--- a/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
+++ b/admin/src/components/base/DocumentationLinks/DocumentationLinks.tsx
@@ -167,26 +167,45 @@ const DOCUMENTATION_LINKS: Record<string, Record<string, { label: string; url: s
 	// SDKs
 	javascript: {
 		Source: [
-			{ label: 'JavaScript SDK documentation', url: 'https://www.meergo.com/docs/integrations/javascript-sdk' },
+			{ label: 'Collect events with JavaScript SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=javascript#1-connect-an-application' },
+			{ label: 'Ingest users with JavaScript SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=javascript#1-connect-an-application' },
 		],
 	},
 	android: {
-		Source: [{ label: 'Android SDK documentation', url: 'https://www.meergo.com/docs/integrations/android-sdk' }],
+		Source: [
+			{ label: 'Collect events with Android SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=android#1-connect-an-application' },
+			{ label: 'Ingest users with Android SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=android#1-connect-an-application' },
+		],
 	},
 	nodejs: {
-		Source: [{ label: 'Node.js SDK documentation', url: 'https://www.meergo.com/docs/integrations/nodejs-sdk' }],
+		Source: [
+			{ label: 'Collect events with Node.js SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=nodejs#1-connect-an-application' },
+			{ label: 'Ingest users with Node.js SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=nodejs#1-connect-an-application' },
+		],
 	},
 	python: {
-		Source: [{ label: 'Python SDK documentation', url: 'https://www.meergo.com/docs/integrations/python-sdk' }],
+		Source: [
+			{ label: 'Collect events with Python SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=python#1-connect-an-application' },
+			{ label: 'Ingest users with Python SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=python#1-connect-an-application' },
+		],
 	},
 	go: {
-		Source: [{ label: 'Go SDK documentation', url: 'https://www.meergo.com/docs/integrations/go-sdk' }],
+		Source: [
+			{ label: 'Collect events with Go SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=go#1-connect-an-application' },
+			{ label: 'Ingest users with Go SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=go#1-connect-an-application' },
+		],
 	},
 	java: {
-		Source: [{ label: 'Java SDK documentation', url: 'https://www.meergo.com/docs/integrations/java-sdk' }],
+		Source: [
+			{ label: 'Collect events with Java SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=java#1-connect-an-application' },
+			{ label: 'Ingest users with Java SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=java#1-connect-an-application' },
+		],
 	},
 	dotnet: {
-		Source: [{ label: '.NET SDK documentation', url: 'https://www.meergo.com/docs/integrations/dotnet-sdk' }],
+		Source: [
+			{ label: 'Collect events with .NET SDK', url: 'https://www.meergo.com/docs/collect-events/apps-you-developed?sdk=net#1-connect-an-application' },
+			{ label: 'Ingest users with .NET SDK', url: 'https://www.meergo.com/docs/ingest-users/apps-you-developed?sdk=net#1-connect-an-application' },
+		],
 	},
 };
 

--- a/admin/src/components/routes/ConnectorSettings/ConnectorSettings.css
+++ b/admin/src/components/routes/ConnectorSettings/ConnectorSettings.css
@@ -61,5 +61,13 @@
 	border: none;
 	border-top: 1px solid var(--sl-color-neutral-200);
 	margin-top: 2.6rem;
-	margin-bottom: 0.5rem;
+	margin-bottom: 0;
+}
+
+.connector-settings__documentation {
+	flex-basis: 100%;
+}
+
+.connector-settings__documentation .documentation-links {
+	margin-top: 0.75rem;
 }

--- a/admin/src/components/routes/ConnectorSettings/ConnectorSettings.css
+++ b/admin/src/components/routes/ConnectorSettings/ConnectorSettings.css
@@ -55,3 +55,11 @@
 	min-width: 180px;
 	display: inline-block;
 }
+
+.connector-settings__divider {
+	width: 100%;
+	border: none;
+	border-top: 1px solid var(--sl-color-neutral-200);
+	margin-top: 1.5rem;
+	margin-bottom: 0.5rem;
+}

--- a/admin/src/components/routes/ConnectorSettings/ConnectorSettings.css
+++ b/admin/src/components/routes/ConnectorSettings/ConnectorSettings.css
@@ -60,6 +60,6 @@
 	width: 100%;
 	border: none;
 	border-top: 1px solid var(--sl-color-neutral-200);
-	margin-top: 1.5rem;
+	margin-top: 2.6rem;
 	margin-bottom: 0.5rem;
 }

--- a/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
+++ b/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
@@ -18,6 +18,7 @@ import { ConnectorUIResponse, ConnectorSettings } from '../../../lib/api/types/r
 import ConnectorFieldInterface, { ConnectorButton } from '../../../lib/api/types/ui';
 import { validateConnectorSettings } from '../../../lib/core/connectorSettings';
 import * as icons from '../../../constants/icons';
+import DocumentationLinks from '../../base/DocumentationLinks/DocumentationLinks';
 
 const hasStrategy = (connectionRole: ConnectionRole, c: TransformedConnector): boolean => {
 	return connectionRole === 'Source' && c.strategies;
@@ -256,6 +257,9 @@ const ConnectorSettings = () => {
 			);
 		}
 	}
+	buttonsToRender.push(
+		<DocumentationLinks key='documentation-links' connectorCode={connectorCode} role={connectionRole} />,
+	);
 	buttonsToRender.push(
 		<div className='connector-settings__save-wrapper'>
 			<SlButton

--- a/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
+++ b/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
@@ -272,7 +272,7 @@ const ConnectorSettings = () => {
 		<hr key='documentation-divider' className='connector-settings__divider' />,
 	);
 	buttonsToRender.push(
-		<DocumentationLinks key='documentation-links' connectorCode={connectorCode} role={connectionRole} />,
+		<DocumentationLinks key='documentation-links' connectorCode={connectorCode} role={connectionRole} showIcon />,
 	);
 
 	if (isLoading) {

--- a/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
+++ b/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
@@ -258,9 +258,6 @@ const ConnectorSettings = () => {
 		}
 	}
 	buttonsToRender.push(
-		<DocumentationLinks key='documentation-links' connectorCode={connectorCode} role={connectionRole} />,
-	);
-	buttonsToRender.push(
 		<div className='connector-settings__save-wrapper'>
 			<SlButton
 				className='connector-settings__save-button'
@@ -270,6 +267,12 @@ const ConnectorSettings = () => {
 				Add
 			</SlButton>
 		</div>,
+	);
+	buttonsToRender.push(
+		<hr key='documentation-divider' className='connector-settings__divider' />,
+	);
+	buttonsToRender.push(
+		<DocumentationLinks key='documentation-links' connectorCode={connectorCode} role={connectionRole} />,
 	);
 
 	if (isLoading) {

--- a/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
+++ b/admin/src/components/routes/ConnectorSettings/ConnectorSettings.tsx
@@ -269,10 +269,10 @@ const ConnectorSettings = () => {
 		</div>,
 	);
 	buttonsToRender.push(
-		<hr key='documentation-divider' className='connector-settings__divider' />,
-	);
-	buttonsToRender.push(
-		<DocumentationLinks key='documentation-links' connectorCode={connectorCode} role={connectionRole} showIcon />,
+		<div key='documentation-wrapper' className='connector-settings__documentation'>
+			<hr className='connector-settings__divider' />
+			<DocumentationLinks connectorCode={connectorCode} role={connectionRole} showIcon />
+		</div>,
 	);
 
 	if (isLoading) {

--- a/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
@@ -38,6 +38,7 @@ import {
 import { Combobox } from '../../base/Combobox/Combobox';
 import { PipelineIssues } from './PipelineIssues';
 import { CONNECTORS_ASSETS_PATH } from '../../../constants/paths';
+import DocumentationLinks from '../../base/DocumentationLinks/DocumentationLinks';
 
 const PipelineFile = () => {
 	const [fileFields, setFileFields] = useState<ConnectorFieldInterface[]>([]);
@@ -861,6 +862,7 @@ const FileSettings = ({ hasSheets, fileExtension, fileFields, pathInputRef }: Fi
 					/>
 				</div>
 			)}
+			<DocumentationLinks connectorCode={connection.connector.code} role={connection.role} />
 			<SlDrawer
 				className='pipeline__file-preview-drawer'
 				open={filePreviewColumns != null && filePreviewRows != null}

--- a/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
@@ -196,7 +196,7 @@ const PipelineFile = () => {
 			description={
 				<>
 					<span>{`Configure the format, location, and options of the file to ${isImport ? 'import' : 'export'}.`}</span>
-					{pipeline.format !== '' && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} storageCode={connection.connector.code} connectorLabel={formatLabel} align="start" />}
+					{pipeline.format !== '' && !isFormatLoading && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} storageCode={connection.connector.code} connectorLabel={formatLabel} align="start" fade />}
 				</>
 			}
 			padded={true}

--- a/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
@@ -154,9 +154,9 @@ const PipelineFile = () => {
 		fetchFields();
 	}, [formatRef.current]);
 
-	const { hasSheets, formatCode, fileExtension } = useMemo(() => {
+	const { hasSheets, formatCode, formatLabel, fileExtension } = useMemo(() => {
 		const format = connectors.find((c) => c.code === pipeline.format);
-		return { hasSheets: format?.hasSheets, formatCode: format?.code, fileExtension: format?.fileExtension };
+		return { hasSheets: format?.hasSheets, formatCode: format?.code, formatLabel: format?.label, fileExtension: format?.fileExtension };
 	}, [pipeline]);
 
 	const onFormatChange = (e) => {
@@ -196,7 +196,7 @@ const PipelineFile = () => {
 			description={
 				<>
 					<span>{`Configure the format, location, and options of the file to ${isImport ? 'import' : 'export'}.`}</span>
-					{pipeline.format !== '' && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} />}
+					{pipeline.format !== '' && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} storageCode={connection.connector.code} connectorLabel={formatLabel} />}
 				</>
 			}
 			padded={true}

--- a/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
@@ -156,7 +156,12 @@ const PipelineFile = () => {
 
 	const { hasSheets, formatCode, formatLabel, fileExtension } = useMemo(() => {
 		const format = connectors.find((c) => c.code === pipeline.format);
-		return { hasSheets: format?.hasSheets, formatCode: format?.code, formatLabel: format?.label, fileExtension: format?.fileExtension };
+		return {
+			hasSheets: format?.hasSheets,
+			formatCode: format?.code,
+			formatLabel: format?.label,
+			fileExtension: format?.fileExtension,
+		};
 	}, [pipeline]);
 
 	const onFormatChange = (e) => {
@@ -196,7 +201,15 @@ const PipelineFile = () => {
 			description={
 				<>
 					<span>{`Configure the format, location, and options of the file to ${isImport ? 'import' : 'export'}.`}</span>
-					{pipeline.format !== '' && !isFormatLoading && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} storageCode={connection.connector.code} connectorLabel={formatLabel} fade />}
+					{pipeline.format !== '' && !isFormatLoading && (
+						<DocumentationLinks
+							connectorCode={pipeline.format}
+							role={connection.role}
+							storageCode={connection.connector.code}
+							connectorLabel={formatLabel}
+							fade
+						/>
+					)}
 				</>
 			}
 			padded={true}

--- a/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
@@ -196,7 +196,7 @@ const PipelineFile = () => {
 			description={
 				<>
 					<span>{`Configure the format, location, and options of the file to ${isImport ? 'import' : 'export'}.`}</span>
-					{pipeline.format !== '' && !isFormatLoading && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} storageCode={connection.connector.code} connectorLabel={formatLabel} align="start" fade />}
+					{pipeline.format !== '' && !isFormatLoading && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} storageCode={connection.connector.code} connectorLabel={formatLabel} fade />}
 				</>
 			}
 			padded={true}

--- a/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
@@ -196,7 +196,7 @@ const PipelineFile = () => {
 			description={
 				<>
 					<span>{`Configure the format, location, and options of the file to ${isImport ? 'import' : 'export'}.`}</span>
-					{pipeline.format !== '' && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} storageCode={connection.connector.code} connectorLabel={formatLabel} />}
+					{pipeline.format !== '' && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} storageCode={connection.connector.code} connectorLabel={formatLabel} align="start" />}
 				</>
 			}
 			padded={true}

--- a/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFile.tsx
@@ -193,7 +193,12 @@ const PipelineFile = () => {
 		<Section
 			title={`${isImport ? 'Import' : 'Export'} file`}
 			className='pipeline__file'
-			description={`Configure the format, location, and options of the file to ${isImport ? 'import' : 'export'}.`}
+			description={
+				<>
+					<span>{`Configure the format, location, and options of the file to ${isImport ? 'import' : 'export'}.`}</span>
+					{pipeline.format !== '' && <DocumentationLinks connectorCode={pipeline.format} role={connection.role} />}
+				</>
+			}
 			padded={true}
 			annotated={true}
 		>
@@ -862,7 +867,6 @@ const FileSettings = ({ hasSheets, fileExtension, fileFields, pathInputRef }: Fi
 					/>
 				</div>
 			)}
-			<DocumentationLinks connectorCode={connection.connector.code} role={connection.role} />
 			<SlDrawer
 				className='pipeline__file-preview-drawer'
 				open={filePreviewColumns != null && filePreviewRows != null}


### PR DESCRIPTION
## Commit message

```
admin: add doc links when adding connection or creating file pipeline

Currently, when creating a new connection or adding a file pipeline to a
file storage connection, no contextual help is displayed nor any links
to the documentation.

This can clearly create confusion, especially when there are settings to
be entered.

This commit therefore adds contextual documentation links.

NOTE: The links currently point directly to the site pages, not a URL
containing /ref/. This will be changed later, when changes are made to
the documentation.
```