### PR TITLE
core/internal/collector: route events per connection stream

### DIFF
--- a/core/internal/collector/collector.go
+++ b/core/internal/collector/collector.go
@@ -70,8 +70,8 @@ type Collector struct {
 	destinations     *destinations // destination connections used to send events
 	identityWriters  sync.Map      // a map from pipeline identifier to a *identityWriter value
 	workers          struct {
-		cancelConnection map[int]context.CancelFunc // maps connection IDs to their worker cancel functions
 		cancelPipeline   map[int]context.CancelFunc // maps pipeline IDs to their worker cancel functions
+		cancelConnection map[int]context.CancelFunc // maps connection IDs to their worker cancel functions
 		sync.WaitGroup                              // wait group used to wait for all workers to exit
 	}
 	closed atomic.Bool
@@ -118,15 +118,16 @@ func New(db *db.DB, sc streams.Connection, st *state.State, ds *datastore.Datast
 		}
 		switch connection.Role {
 		case state.Source:
-			// There is one worker per source SDK and webhook pipeline.
+			// There is one worker per active source SDK and webhook pipeline.
 			for _, p := range connection.Pipelines() {
 				if p.Enabled {
 					c.startPipelineWorker(p)
 				}
 			}
 		case state.Destination:
-			// There is one worker per destination app connection that is linked to at least
-			// one source connection with at least one active pipeline sending events.
+			// There is one worker per destination app connection
+			// that has at least one active pipeline sending events
+			// and is linked to at least one source connection.
 			if len(connection.LinkedConnections) == 0 {
 				continue
 			}
@@ -314,7 +315,15 @@ func (c *Collector) onDeleteConnection(n state.DeleteConnection) {
 	}
 	if connection.Role == state.Source {
 		for _, p := range connection.Pipelines() {
-			c.stopPipelineWorker(p)
+			if p.Enabled {
+				c.stopPipelineWorker(p)
+			}
+		}
+		for _, id := range connection.LinkedConnections {
+			destination, _ := c.state.Connection(id)
+			if len(destination.LinkedConnections) == 0 {
+				c.stopConnectionWorker(connection)
+			}
 		}
 		return
 	}
@@ -403,10 +412,6 @@ func (c *Collector) onSetPipelineStatus(n state.SetPipelineStatus) {
 	if len(connection.LinkedConnections) == 0 || p.Target != state.TargetEvent {
 		return
 	}
-	if p.Enabled {
-		c.startConnectionWorker(connection)
-		return
-	}
 	for _, p := range connection.Pipelines() {
 		if p.Enabled && p.Target == state.TargetEvent {
 			c.startConnectionWorker(connection)
@@ -452,10 +457,7 @@ func (c *Collector) onUpdatePipeline(n state.UpdatePipeline) {
 	if len(connection.LinkedConnections) == 0 || p.Target != state.TargetEvent {
 		return
 	}
-	if p.Enabled {
-		c.startConnectionWorker(connection)
-		return
-	}
+	// The pipeline may have been enabled and may no longer be.
 	for _, p := range connection.Pipelines() {
 		if p.Enabled && p.Target == state.TargetEvent {
 			c.startConnectionWorker(connection)
@@ -491,16 +493,16 @@ func (c *Collector) processIdentityEvents(ctx context.Context, w *identityWriter
 	}
 }
 
-// processForwardedEvents reads events from the pipeline and forwards them to
-// the configured destination pipelines.
+// processForwardedEvents reads events from the connection and forwards them to
+// its destination pipelines.
 //
 // It is called in its own goroutine and runs until the context is canceled.
-func (c *Collector) processForwardedEvents(ctx context.Context, destinations *destinations, connection *state.Connection) {
+func (c *Collector) processForwardedEvents(ctx context.Context, destinations *destinations, connection int) {
 	stream, err := c.sc.Stream(ctx)
 	if err != nil {
 		return // ctx has been canceled or c.sc has been closed.
 	}
-	consumer := stream.Consume("connection-"+strconv.Itoa(connection.ID), 1000)
+	consumer := stream.Consume("connection-"+strconv.Itoa(connection), 1000)
 	events := consumer.Events()
 	done := ctx.Done()
 	for {
@@ -509,7 +511,7 @@ func (c *Collector) processForwardedEvents(ctx context.Context, destinations *de
 			if !ok {
 				panic("consumer channel was closed before the worker terminated")
 			}
-			destinations.QueueEvent(connection.ID, event)
+			destinations.QueueEvent(connection, event)
 		case <-done:
 			consumer.Close()
 			return
@@ -837,7 +839,7 @@ func (c *Collector) startConnectionWorker(connection *state.Connection) {
 	ctx, cancel := context.WithCancel(context.Background())
 	c.workers.cancelConnection[connection.ID] = cancel
 	c.workers.Go(func() {
-		c.processForwardedEvents(ctx, c.destinations, connection)
+		c.processForwardedEvents(ctx, c.destinations, connection.ID)
 	})
 }
 
@@ -872,8 +874,8 @@ func (c *Collector) startPipelineWorker(pipeline *state.Pipeline) {
 }
 
 // stopConnectionWorker stops the worker associated with the given connection.
-// If no worker exists, it does nothing. Cancellation runs asynchronously in a
-// separate goroutine. It must be called with the state frozen.
+// If no worker exists, it does nothing.
+// It must be called with the state frozen.
 func (c *Collector) stopConnectionWorker(connection *state.Connection) {
 	if cancel, ok := c.workers.cancelConnection[connection.ID]; ok {
 		cancel()
@@ -882,8 +884,8 @@ func (c *Collector) stopConnectionWorker(connection *state.Connection) {
 }
 
 // stopPipelineWorker stops the worker associated with the given pipeline.
-// If no worker exists, it does nothing. Cancellation runs asynchronously in a
-// separate goroutine. It must be called with the state frozen.
+// If no worker exists, it does nothing.
+// It must be called with the state frozen.
 func (c *Collector) stopPipelineWorker(pipeline *state.Pipeline) {
 	cancel, ok := c.workers.cancelPipeline[pipeline.ID]
 	if !ok {

--- a/core/internal/collector/collector.go
+++ b/core/internal/collector/collector.go
@@ -70,8 +70,9 @@ type Collector struct {
 	destinations     *destinations // destination connections used to send events
 	identityWriters  sync.Map      // a map from pipeline identifier to a *identityWriter value
 	workers          struct {
-		cancels        map[int]context.CancelFunc // maps pipeline IDs to their worker cancel functions
-		sync.WaitGroup                            // wait group used to wait for all workers to exit
+		cancelConnection map[int]context.CancelFunc // maps connection IDs to their worker cancel functions
+		cancelPipeline   map[int]context.CancelFunc // maps pipeline IDs to their worker cancel functions
+		sync.WaitGroup                              // wait group used to wait for all workers to exit
 	}
 	closed atomic.Bool
 }
@@ -94,7 +95,8 @@ func New(db *db.DB, sc streams.Connection, st *state.State, ds *datastore.Datast
 		functionProvider: provider,
 		destinations:     newDestinations(st, connections, provider, metrics),
 	}
-	c.workers.cancels = map[int]context.CancelFunc{}
+	c.workers.cancelPipeline = map[int]context.CancelFunc{}
+	c.workers.cancelConnection = map[int]context.CancelFunc{}
 
 	st.Freeze()
 	st.AddListener(c.onCreateConnection)
@@ -110,8 +112,31 @@ func New(db *db.DB, sc streams.Connection, st *state.State, ds *datastore.Datast
 	for _, ws := range st.Workspaces() {
 		c.addWorkspace(ws.ID)
 	}
-	for _, pipeline := range st.Pipelines() {
-		c.startPipelineWorker(pipeline)
+	for _, connection := range st.Connections() {
+		if connection.LinkedConnections == nil {
+			continue
+		}
+		switch connection.Role {
+		case state.Source:
+			// There is one worker per source SDK and webhook pipeline.
+			for _, p := range connection.Pipelines() {
+				if p.Enabled {
+					c.startPipelineWorker(p)
+				}
+			}
+		case state.Destination:
+			// There is one worker per destination app connection that is linked to at least
+			// one source connection with at least one active pipeline sending events.
+			if len(connection.LinkedConnections) == 0 {
+				continue
+			}
+			for _, p := range connection.Pipelines() {
+				if p.Enabled && p.Target == state.TargetEvent {
+					c.startConnectionWorker(connection)
+					break
+				}
+			}
+		}
 	}
 	st.Unfreeze()
 
@@ -133,7 +158,10 @@ func (c *Collector) Close(ctx context.Context) {
 	if c.closed.Swap(true) {
 		panic("core/events/collector already closed")
 	}
-	for _, cancel := range c.workers.cancels {
+	for _, cancel := range c.workers.cancelPipeline {
+		cancel()
+	}
+	for _, cancel := range c.workers.cancelConnection {
 		cancel()
 	}
 	c.workers.Wait()
@@ -239,21 +267,38 @@ func (c *Collector) connectionByKey(key string) (*state.Connection, bool) {
 // onCreateConnection is called when a connection is created.
 func (c *Collector) onCreateConnection(n state.CreateConnection) {
 	connection, _ := c.state.Connection(n.ID)
-	if !(connection.Role == state.Source && len(connection.LinkedConnections) > 0) {
+	if connection.Role != state.Source {
 		return
 	}
 	for _, id := range connection.LinkedConnections {
-		connection, _ := c.state.Connection(id)
-		for _, pipeline := range connection.Pipelines() {
-			c.startPipelineWorker(pipeline)
+		destination, _ := c.state.Connection(id)
+		for _, p := range destination.Pipelines() {
+			if p.Enabled && p.Target == state.TargetEvent {
+				c.startConnectionWorker(destination)
+				break
+			}
 		}
 	}
 }
 
 // onCreatePipeline is called when a pipeline is created.
 func (c *Collector) onCreatePipeline(n state.CreatePipeline) {
-	pipeline, _ := c.state.Pipeline(n.ID)
-	c.startPipelineWorker(pipeline)
+	p, _ := c.state.Pipeline(n.ID)
+	if !p.Enabled {
+		return
+	}
+	connection := p.Connection()
+	if connection.LinkedConnections == nil {
+		return
+	}
+	if connection.Role == state.Source {
+		c.startPipelineWorker(p)
+		return
+	}
+	if len(connection.LinkedConnections) == 0 || p.Target != state.TargetEvent {
+		return
+	}
+	c.startConnectionWorker(connection)
 }
 
 // onCreateWorkspace is called when a workspace is created.
@@ -267,15 +312,38 @@ func (c *Collector) onDeleteConnection(n state.DeleteConnection) {
 	if connection.LinkedConnections == nil {
 		return
 	}
-	for _, pipeline := range connection.Pipelines() {
-		c.stopPipelineWorker(pipeline)
+	if connection.Role == state.Source {
+		for _, p := range connection.Pipelines() {
+			c.stopPipelineWorker(p)
+		}
+		return
 	}
+	c.stopConnectionWorker(connection)
 }
 
 // onDeletePipeline is called when a pipeline is deleted.
 func (c *Collector) onDeletePipeline(n state.DeletePipeline) {
-	c.stopPipelineWorker(n.Pipeline())
-	// TODO(marco): should the ongoing transformations be interrupted?
+	p := n.Pipeline()
+	if !p.Enabled {
+		return
+	}
+	connection := p.Connection()
+	if connection.LinkedConnections == nil {
+		return
+	}
+	if connection.Role == state.Source {
+		c.stopPipelineWorker(p)
+		return
+	}
+	if len(connection.LinkedConnections) == 0 {
+		return
+	}
+	for _, p := range connection.Pipelines() {
+		if p.Enabled && p.Target == state.TargetEvent {
+			return
+		}
+	}
+	c.stopConnectionWorker(connection)
 }
 
 // onDeleteWorkspace is called when a workspace is deleted.
@@ -286,8 +354,14 @@ func (c *Collector) onDeleteWorkspace(n state.DeleteWorkspace) {
 		if connection.LinkedConnections == nil {
 			continue
 		}
-		for _, pipeline := range connection.Pipelines() {
-			c.stopPipelineWorker(pipeline)
+		if connection.Role == state.Source {
+			for _, p := range connection.Pipelines() {
+				if p.Enabled {
+					c.stopPipelineWorker(p)
+				}
+			}
+		} else if len(connection.LinkedConnections) > 0 {
+			c.stopConnectionWorker(connection)
 		}
 	}
 	ew, _ := c.eventWriters.LoadAndDelete(ws.ID)
@@ -300,46 +374,95 @@ func (c *Collector) onDeleteWorkspace(n state.DeleteWorkspace) {
 // onLinkConnection is called when two unlinked connections are linked.
 func (c *Collector) onLinkConnection(n state.LinkConnection) {
 	connection, _ := c.state.Connection(n.Connections[1])
-	for _, pipeline := range connection.Pipelines() {
-		c.startPipelineWorker(pipeline)
+	if len(connection.LinkedConnections) > 1 {
+		return
+	}
+	for _, p := range connection.Pipelines() {
+		if p.Enabled && p.Target == state.TargetEvent {
+			c.startConnectionWorker(connection)
+			break
+		}
 	}
 }
 
 // onSetPipelineStatus is called when the status of a pipeline is set.
 func (c *Collector) onSetPipelineStatus(n state.SetPipelineStatus) {
 	p, _ := c.state.Pipeline(n.ID)
-	if p.Enabled {
-		c.startPipelineWorker(p)
-	} else {
-		c.stopPipelineWorker(p)
+	connection := p.Connection()
+	if connection.LinkedConnections == nil {
+		return
 	}
+	if connection.Role == state.Source {
+		if p.Enabled {
+			c.startPipelineWorker(p)
+		} else {
+			c.stopPipelineWorker(p)
+		}
+		return
+	}
+	if len(connection.LinkedConnections) == 0 || p.Target != state.TargetEvent {
+		return
+	}
+	if p.Enabled {
+		c.startConnectionWorker(connection)
+		return
+	}
+	for _, p := range connection.Pipelines() {
+		if p.Enabled && p.Target == state.TargetEvent {
+			c.startConnectionWorker(connection)
+			return
+		}
+	}
+	c.stopConnectionWorker(connection)
 }
 
 // onUnlinkConnection is called when two linked connections are unlinked.
 func (c *Collector) onUnlinkConnection(n state.UnlinkConnection) {
 	connection, _ := c.state.Connection(n.Connections[1])
-	for _, pipeline := range connection.Pipelines() {
-		c.stopPipelineWorker(pipeline)
+	if len(connection.LinkedConnections) == 0 {
+		c.stopConnectionWorker(connection)
 	}
 }
 
 // onUpdatePipeline is called when a pipeline is updated.
 func (c *Collector) onUpdatePipeline(n state.UpdatePipeline) {
 	p, _ := c.state.Pipeline(n.ID)
-	if !p.Enabled {
-		c.stopPipelineWorker(p)
-		// TODO(marco): how does changing the warehouse mode affect the source pipeline?
+	if p.Enabled {
+		// The transformation might have changed.
+		if w, ok := c.identityWriters.Load(p.ID); ok {
+			var transformer *transformers.Transformer
+			if p.Transformation.Mapping != nil || p.Transformation.Function != nil {
+				transformer, _ = transformers.New(p, c.functionProvider, nil)
+			}
+			w.(*identityWriter).SetTransformer(transformer)
+		}
+	}
+	connection := p.Connection()
+	if connection.LinkedConnections == nil {
 		return
 	}
-	// The transformation might have changed.
-	if w, ok := c.identityWriters.Load(p.ID); ok {
-		var transformer *transformers.Transformer
-		if p.Transformation.Mapping != nil || p.Transformation.Function != nil {
-			transformer, _ = transformers.New(p, c.functionProvider, nil)
+	if connection.Role == state.Source {
+		if p.Enabled {
+			c.startPipelineWorker(p)
+		} else {
+			c.stopPipelineWorker(p)
 		}
-		w.(*identityWriter).SetTransformer(transformer)
+		return
 	}
-	c.startPipelineWorker(p)
+	if len(connection.LinkedConnections) == 0 || p.Target != state.TargetEvent {
+		return
+	}
+	if p.Enabled {
+		c.startConnectionWorker(connection)
+		return
+	}
+	for _, p := range connection.Pipelines() {
+		if p.Enabled && p.Target == state.TargetEvent {
+			c.startConnectionWorker(connection)
+			return
+		}
+	}
+	c.stopConnectionWorker(connection)
 }
 
 // processIdentityEvents reads events from the pipeline, extracts identities,
@@ -351,7 +474,7 @@ func (c *Collector) processIdentityEvents(ctx context.Context, w *identityWriter
 	if err != nil {
 		return // ctx has been canceled or c.sc has been closed.
 	}
-	consumer := stream.Consume(strconv.Itoa(pipeline), 1000)
+	consumer := stream.Consume("pipeline-"+strconv.Itoa(pipeline), 1000)
 	events := consumer.Events()
 	done := ctx.Done()
 	for {
@@ -372,12 +495,12 @@ func (c *Collector) processIdentityEvents(ctx context.Context, w *identityWriter
 // the configured destination pipelines.
 //
 // It is called in its own goroutine and runs until the context is canceled.
-func (c *Collector) processForwardedEvents(ctx context.Context, destinations *destinations, pipeline *state.Pipeline) {
+func (c *Collector) processForwardedEvents(ctx context.Context, destinations *destinations, connection *state.Connection) {
 	stream, err := c.sc.Stream(ctx)
 	if err != nil {
 		return // ctx has been canceled or c.sc has been closed.
 	}
-	consumer := stream.Consume(strconv.Itoa(pipeline.ID), 1000)
+	consumer := stream.Consume("connection-"+strconv.Itoa(connection.ID), 1000)
 	events := consumer.Events()
 	done := ctx.Done()
 	for {
@@ -386,7 +509,7 @@ func (c *Collector) processForwardedEvents(ctx context.Context, destinations *de
 			if !ok {
 				panic("consumer channel was closed before the worker terminated")
 			}
-			destinations.QueueEvent(pipeline, event)
+			destinations.QueueEvent(connection.ID, event)
 		case <-done:
 			consumer.Close()
 			return
@@ -403,7 +526,7 @@ func (c *Collector) processWarehouseEvents(ctx context.Context, w *datastore.Eve
 	if err != nil {
 		return // ctx has been canceled or c.sc has been closed.
 	}
-	consumer := stream.Consume(strconv.Itoa(pipeline), 1000)
+	consumer := stream.Consume("pipeline-"+strconv.Itoa(pipeline), 1000)
 	events := consumer.Events()
 	done := ctx.Done()
 	for {
@@ -560,7 +683,9 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 		return errNoStreamConnection
 	}
 	batch := stream.Batch()
+
 	var topics []string
+	var destinations []int
 
 	var observedEvents []events.Event
 
@@ -582,6 +707,7 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		topics = topics[0:0]
+		destinations = destinations[0:0]
 
 		// Store the events into the data warehouse.
 		for _, p := range pipelines {
@@ -595,7 +721,7 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 			}
 			c.metrics.FilterPassed(p.ID, 1)
 			if _, ok := c.eventWriters.Load(ws.ID); ok {
-				topics = append(topics, strconv.Itoa(p.ID))
+				topics = append(topics, "pipeline-"+strconv.Itoa(p.ID))
 			}
 		}
 
@@ -611,7 +737,7 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 			}
 			c.metrics.FilterPassed(p.ID, 1)
 			if _, ok := c.identityWriters.Load(p.ID); ok {
-				topics = append(topics, strconv.Itoa(p.ID))
+				topics = append(topics, "pipeline-"+strconv.Itoa(p.ID))
 			}
 		}
 
@@ -631,7 +757,10 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 					continue
 				}
 				c.metrics.FilterPassed(p.ID, 1)
-				topics = append(topics, strconv.Itoa(p.ID))
+				destinations = append(destinations, p.ID)
+			}
+			if len(destinations) > 0 {
+				topics = append(topics, "connection-"+strconv.Itoa(id))
 			}
 		}
 
@@ -640,7 +769,7 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		// Publish the event.
-		err = batch.Publish(topics, event)
+		err = batch.Publish(topics, event, destinations)
 		if err != nil {
 			return err
 		}
@@ -697,25 +826,31 @@ func (c *Collector) serveSettings(w http.ResponseWriter, r *http.Request) error 
 	return nil
 }
 
-// startPipelineWorker evaluates whether an event worker should be started
-// for the given pipeline and starts it if needed. It must be called with
-// the state frozen.
-func (c *Collector) startPipelineWorker(pipeline *state.Pipeline) {
-	if !pipeline.Enabled {
-		return
-	}
-	if _, ok := c.workers.cancels[pipeline.ID]; ok {
-		return
-	}
-	connection := pipeline.Connection()
-	if connection.LinkedConnections == nil {
-		return
-	}
-	if connection.Role == state.Destination && len(connection.LinkedConnections) == 0 {
+// startConnectionWorker starts a worker for the given connection if one does
+// not already exist.
+//
+// It must be called with the state frozen.
+func (c *Collector) startConnectionWorker(connection *state.Connection) {
+	if _, ok := c.workers.cancelConnection[connection.ID]; ok {
 		return
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	c.workers.cancels[pipeline.ID] = cancel
+	c.workers.cancelConnection[connection.ID] = cancel
+	c.workers.Go(func() {
+		c.processForwardedEvents(ctx, c.destinations, connection)
+	})
+}
+
+// startPipelineWorker starts a worker for the given pipeline if one does not
+// already exist.
+//
+// It must be called with the state frozen.
+func (c *Collector) startPipelineWorker(pipeline *state.Pipeline) {
+	if _, ok := c.workers.cancelPipeline[pipeline.ID]; ok {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c.workers.cancelPipeline[pipeline.ID] = cancel
 	switch pipeline.Target {
 	case state.TargetUser:
 		// Import the identity into the data warehouse.
@@ -726,54 +861,40 @@ func (c *Collector) startPipelineWorker(pipeline *state.Pipeline) {
 		})
 	case state.TargetEvent:
 		// Store the event into the data warehouse.
-		if pipeline.EventType == "" {
-			ws := connection.Workspace()
-			ew, _ := c.eventWriters.Load(ws.ID)
-			c.workers.Go(func() {
-				c.processWarehouseEvents(ctx, ew.(*datastore.EventWriter), pipeline.ID)
-			})
-			return
-		}
-		// Send the event to apps.
+		ws := pipeline.Connection().Workspace()
+		ew, _ := c.eventWriters.Load(ws.ID)
 		c.workers.Go(func() {
-			c.processForwardedEvents(ctx, c.destinations, pipeline)
+			c.processWarehouseEvents(ctx, ew.(*datastore.EventWriter), pipeline.ID)
 		})
 	default:
 		panic("unreachable")
 	}
-
 }
 
-// stopPipelineWorker evaluates whether the event worker for the given pipeline
-// should be stopped and cancels it if needed.
-//
-// It must be called with the state frozen. Cancellation is performed
-// asynchronously in its own goroutine.
+// stopConnectionWorker stops the worker associated with the given connection.
+// If no worker exists, it does nothing. Cancellation runs asynchronously in a
+// separate goroutine. It must be called with the state frozen.
+func (c *Collector) stopConnectionWorker(connection *state.Connection) {
+	if cancel, ok := c.workers.cancelConnection[connection.ID]; ok {
+		cancel()
+		delete(c.workers.cancelConnection, connection.ID)
+	}
+}
+
+// stopPipelineWorker stops the worker associated with the given pipeline.
+// If no worker exists, it does nothing. Cancellation runs asynchronously in a
+// separate goroutine. It must be called with the state frozen.
 func (c *Collector) stopPipelineWorker(pipeline *state.Pipeline) {
-	cancel, ok := c.workers.cancels[pipeline.ID]
+	cancel, ok := c.workers.cancelPipeline[pipeline.ID]
 	if !ok {
 		return
 	}
-	stop := func() {
-		cancel()
-		delete(c.workers.cancels, pipeline.ID)
-		if pipeline.Target == state.TargetUser {
-			iw, _ := c.identityWriters.LoadAndDelete(pipeline.ID)
-			go func() {
-				_ = iw.(*identityWriter).Close(context.Background())
-			}()
-		}
-	}
-	if !pipeline.Enabled {
-		stop()
-		return
-	}
-	connection := pipeline.Connection()
-	if connection.Role == state.Destination && len(connection.LinkedConnections) == 0 {
-		stop()
-		return
-	}
-	if _, ok := c.state.Pipeline(pipeline.ID); !ok {
-		stop()
+	cancel()
+	delete(c.workers.cancelPipeline, pipeline.ID)
+	if pipeline.Target == state.TargetUser {
+		iw, _ := c.identityWriters.LoadAndDelete(pipeline.ID)
+		go func() {
+			_ = iw.(*identityWriter).Close(context.Background())
+		}()
 	}
 }

--- a/core/internal/collector/destinations.go
+++ b/core/internal/collector/destinations.go
@@ -92,18 +92,15 @@ func newDestinations(st *state.State, connections *connections.Connections, prov
 	return &d
 }
 
-// QueueEvent queues the given event to be sent on the specified destination
-// connection.
+// QueueEvent enqueues the given event to the pipelines of the provided
+// connection that are specified in the event.
 func (d *destinations) QueueEvent(connection int, event streams.Event) {
 	d.mu.Lock()
 	pipelines := d.pipelines[connection]
 	d.mu.Unlock()
-	for _, d := range event.Destinations {
-		for _, p := range pipelines {
-			if p.id == d {
-				p.QueueEvent(event)
-				break
-			}
+	for _, id := range event.Destinations {
+		if p, _ := pipelines.find(id); p != nil {
+			p.QueueEvent(event)
 		}
 	}
 }

--- a/core/internal/collector/destinations.go
+++ b/core/internal/collector/destinations.go
@@ -93,14 +93,18 @@ func newDestinations(st *state.State, connections *connections.Connections, prov
 }
 
 // QueueEvent queues the given event to be sent on the specified destination
-// pipeline.
-func (d *destinations) QueueEvent(pipeline *state.Pipeline, event streams.Event) {
-	connection := pipeline.Connection()
+// connection.
+func (d *destinations) QueueEvent(connection int, event streams.Event) {
 	d.mu.Lock()
-	pipelines := d.pipelines[connection.ID]
+	pipelines := d.pipelines[connection]
 	d.mu.Unlock()
-	if dp, _ := pipelines.find(pipeline.ID); dp != nil {
-		dp.QueueEvent(event)
+	for _, d := range event.Destinations {
+		for _, p := range pipelines {
+			if p.id == d {
+				p.QueueEvent(event)
+				break
+			}
+		}
 	}
 }
 

--- a/core/internal/streams/nats/nats.go
+++ b/core/internal/streams/nats/nats.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -484,6 +485,18 @@ func (s *stream) Consume(topic string, size int) streams.Consumer {
 						err = fmt.Errorf("invalid event data: %s", err)
 						return
 					}
+					if header := msg.Headers(); header != nil {
+						if destinations, ok := header["destinations"]; ok {
+							event.Destinations = make([]int, len(destinations))
+							for i, d := range destinations {
+								event.Destinations[i], _ = strconv.Atoi(d)
+								if event.Destinations[i] < 1 {
+									err = fmt.Errorf("invalid event destination: %q", d)
+									return
+								}
+							}
+						}
+					}
 					event.Ack = func() {
 						if err := msg.Ack(); err != nil {
 							slog.Warn(fmt.Sprintf("collector: cannot ack event: %s", err))
@@ -562,14 +575,23 @@ func (batch *batch) Done(ctx context.Context) error {
 }
 
 // Publish adds an event to the current batch for the given topic.
-func (batch *batch) Publish(topics []string, event map[string]any) error {
+func (batch *batch) Publish(topics []string, event map[string]any, destinations []int) error {
 	shard := shardOf(event["anonymousId"].(string))
 	data, err := types.Marshal(event, schemas.Event)
 	if err != nil {
 		return err
 	}
 	for _, topic := range topics {
+		var header nats.Header
+		if strings.HasPrefix(topic, "connection-") {
+			s := make([]string, len(destinations))
+			for i, d := range destinations {
+				s[i] = strconv.Itoa(d)
+			}
+			header = nats.Header{"destinations": s}
+		}
 		future, err := batch.conn.js.jetStream.PublishMsgAsync(&nats.Msg{
+			Header:  header,
 			Subject: "events.v1." + topic + "." + strconv.Itoa(shard),
 			Data:    data,
 		})

--- a/core/internal/streams/nats/nats.go
+++ b/core/internal/streams/nats/nats.go
@@ -489,11 +489,12 @@ func (s *stream) Consume(topic string, size int) streams.Consumer {
 						if destinations, ok := header["destinations"]; ok {
 							event.Destinations = make([]int, len(destinations))
 							for i, d := range destinations {
-								event.Destinations[i], _ = strconv.Atoi(d)
-								if event.Destinations[i] < 1 {
+								id, _ := strconv.Atoi(d)
+								if id <= 0 {
 									err = fmt.Errorf("invalid event destination: %q", d)
 									return
 								}
+								event.Destinations[i] = id
 							}
 						}
 					}
@@ -575,6 +576,8 @@ func (batch *batch) Done(ctx context.Context) error {
 }
 
 // Publish adds an event to the current batch for the given topic.
+// If the topic begins with "connection-", destinations contains the destination
+// pipelines the event is sent to.
 func (batch *batch) Publish(topics []string, event map[string]any, destinations []int) error {
 	shard := shardOf(event["anonymousId"].(string))
 	data, err := types.Marshal(event, schemas.Event)
@@ -584,11 +587,11 @@ func (batch *batch) Publish(topics []string, event map[string]any, destinations 
 	for _, topic := range topics {
 		var header nats.Header
 		if strings.HasPrefix(topic, "connection-") {
-			s := make([]string, len(destinations))
+			h := make([]string, len(destinations))
 			for i, d := range destinations {
-				s[i] = strconv.Itoa(d)
+				h[i] = strconv.Itoa(d)
 			}
-			header = nats.Header{"destinations": s}
+			header = nats.Header{"destinations": h}
 		}
 		future, err := batch.conn.js.jetStream.PublishMsgAsync(&nats.Msg{
 			Header:  header,

--- a/core/internal/streams/stream.go
+++ b/core/internal/streams/stream.go
@@ -37,7 +37,7 @@ type Consumer interface {
 type BatchPublisher interface {
 
 	// Publish adds an event to the current batch for the given topics.
-	Publish(topics []string, event map[string]any) error
+	Publish(topics []string, event map[string]any, destinations []int) error
 
 	// Done publishes all buffered events.
 	//
@@ -66,6 +66,7 @@ type Ack func()
 
 // Event represents an event read from the stream.
 type Event struct {
-	Attributes map[string]any
-	Ack        Ack
+	Attributes   map[string]any
+	Destinations []int
+	Ack          Ack
 }

--- a/core/internal/streams/stream.go
+++ b/core/internal/streams/stream.go
@@ -36,7 +36,9 @@ type Consumer interface {
 // BatchPublisher publishes events in batches.
 type BatchPublisher interface {
 
-	// Publish adds an event to the current batch for the given topics.
+	// Publish adds an event to the current batch for the given topic.
+	// If the topic begins with "connection-", destinations contains the destination
+	// pipelines the event is sent to.
 	Publish(topics []string, event map[string]any, destinations []int) error
 
 	// Done publishes all buffered events.

--- a/core/internal/streams/streamstest/streamstest.go
+++ b/core/internal/streams/streamstest/streamstest.go
@@ -81,14 +81,14 @@ func (s *Stream) Consume(topic string, size int) streams.Consumer {
 
 // batchPublisher is a mock for streams.BatchPublisher.
 type batchPublisher struct {
-	PublishFunc func(topics []string, attributes map[string]any) error
+	PublishFunc func(topics []string, attributes map[string]any, destinations []int) error
 	DoneFunc    func(context.Context) error
 }
 
 // Publish implements streams.BatchPublisher.
-func (b *batchPublisher) Publish(topics []string, attributes map[string]any) error {
+func (b *batchPublisher) Publish(topics []string, attributes map[string]any, destinations []int) error {
 	if b.PublishFunc != nil {
-		return b.PublishFunc(topics, attributes)
+		return b.PublishFunc(topics, attributes, destinations)
 	}
 	return nil
 }


### PR DESCRIPTION
```
core/internal/collector: route events per connection stream

Previously, incoming events that had to be forwarded to a destination
were pushed into a separate stream for each destination pipeline. This
however meant that when multiple pipelines were configured for the same
connection, events belonging to the same user could be delivered to the
apps out of their original reception order.

With this change, events are first grouped into a single stream per
destination connection and only later consumed by the respective
pipelines. This ensures that all events for a given user follow a single
ordered path before being processed, preserving their original sequence
even when multiple pipelines share the same connection.
```