### PR TITLE
admin: standardize checkbox labels with other settings components

### DIFF
--- a/admin/src/components/base/ConnectorFields/ConnectorCheckbox/ConnectorCheckbox.css
+++ b/admin/src/components/base/ConnectorFields/ConnectorCheckbox/ConnectorCheckbox.css
@@ -1,3 +1,8 @@
 .connector-checkbox {
 	margin: 18px auto !important;
 }
+
+.connector-checkbox sl-checkbox::part(label) {
+	font-size: var(--sl-input-label-font-size-medium);
+	color: var(--text-light);
+}


### PR DESCRIPTION
Resolves #1738.

## Commit message

```
admin: standardize checkbox labels with other settings components

In the settings screen of a connection or pipeline file, the font used
for the checkbox labels is heavier than that of the rest of the
interface components.

This commit standardizes it.

Resolves #1738.
```

<img width="1219" height="621" alt="immagine" src="https://github.com/user-attachments/assets/8660e64f-c56f-445c-9317-db34729a4df0" />

<img width="1165" height="894" alt="immagine" src="https://github.com/user-attachments/assets/ea0936ab-dd22-4db4-8175-7ebd813717c6" />
