### PR TITLE
admin: add "type to confirm" before deleting and refactor dialogs

### DIFF
--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
@@ -6,7 +6,7 @@
 }
 
 .confirm-by-typing__instruction {
-	margin: 0 0 10px 10%;
+	margin: 0 auto 10px;
 	font-size: 15px;
 	width: 80%;
 }
@@ -25,6 +25,6 @@
 	font-family: var(--monospace-fonts);
 	background-color: var(--sl-color-neutral-100);
 	display: inline-block;
-	padding: 0px 5px;
+	padding: 0 5px;
 	border-radius: 3px;
 }

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
@@ -6,9 +6,11 @@
 }
 
 .confirm-by-typing__instruction {
-	margin: 0 0 20px 0;
+	margin: 0 0 10px 0;
 	font-size: 15px;
-	text-align: center;
+	/* text-align: center; */
+	margin-left: 10%;
+	width: 80%;
 }
 
 .confirm-by-typing__input {

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
@@ -1,7 +1,7 @@
 .confirm-by-typing {
 	text-align: left;
 	margin-top: 20px;
-	padding-top: 10px;
+	padding-top: 20px;
 	border-top: 1px solid var(--sl-color-neutral-200);
 }
 

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
@@ -6,7 +6,7 @@
 }
 
 .confirm-by-typing__instruction {
-	margin: 0 0 10px 0;
+	margin: 0 0 20px 0;
 	font-size: 15px;
 	text-align: center;
 }

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
@@ -6,10 +6,8 @@
 }
 
 .confirm-by-typing__instruction {
-	margin: 0 0 10px 0;
+	margin: 0 0 10px 10%;
 	font-size: 15px;
-	/* text-align: center; */
-	margin-left: 10%;
 	width: 80%;
 }
 

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
@@ -1,7 +1,7 @@
 .confirm-by-typing {
 	text-align: left;
 	margin-top: 20px;
-	padding-top: 20px;
+	padding-top: 10px;
 	border-top: 1px solid var(--sl-color-neutral-200);
 }
 

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
@@ -1,11 +1,24 @@
 .confirm-by-typing {
 	text-align: left;
 	margin-top: 20px;
+	padding-top: 20px;
+	border-top: 1px solid var(--sl-color-neutral-200);
 }
 
 .confirm-by-typing__instruction {
-	margin: 0 0 8px 0;
-	font-size: 14px;
+	margin: 0 0 10px 0;
+	font-size: 15px;
+	text-align: center;
+}
+
+.confirm-by-typing__input {
+	width: 80%;
+	display: block;
+	margin: 0 auto;
+}
+
+.confirm-by-typing__input::part(input) {
+	font-family: var(--monospace-fonts);
 }
 
 .confirm-by-typing__confirm-text {

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.css
@@ -1,0 +1,17 @@
+.confirm-by-typing {
+	text-align: left;
+	margin-top: 20px;
+}
+
+.confirm-by-typing__instruction {
+	margin: 0 0 8px 0;
+	font-size: 14px;
+}
+
+.confirm-by-typing__confirm-text {
+	font-family: var(--monospace-fonts);
+	background-color: var(--sl-color-neutral-100);
+	display: inline-block;
+	padding: 0px 5px;
+	border-radius: 3px;
+}

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.tsx
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import SlInput from '@shoelace-style/shoelace/dist/react/input/index.js';
+import './ConfirmByTyping.css';
+
+interface ConfirmByTypingProps {
+	confirmText: string;
+	value: string;
+	onInput: (value: string) => void;
+}
+
+const ConfirmByTyping = ({ confirmText, value, onInput }: ConfirmByTypingProps) => {
+	return (
+		<div className='confirm-by-typing'>
+			<p className='confirm-by-typing__instruction'>
+				Type <span className='confirm-by-typing__confirm-text'>{confirmText}</span> to confirm:
+			</p>
+			<SlInput
+				className='confirm-by-typing__input'
+				value={value}
+				onSlInput={(e) => onInput((e.target as HTMLInputElement).value)}
+			/>
+		</div>
+	);
+};
+
+export default ConfirmByTyping;

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.tsx
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.tsx
@@ -8,6 +8,8 @@ interface ConfirmByTypingProps {
 	onInput: (value: string) => void;
 }
 
+// TODO: focus direttamente nella casella
+
 const ConfirmByTyping = ({ confirmText, value, onInput }: ConfirmByTypingProps) => {
 	return (
 		<div className='confirm-by-typing'>
@@ -16,7 +18,7 @@ const ConfirmByTyping = ({ confirmText, value, onInput }: ConfirmByTypingProps) 
 			</p>
 			<SlInput
 				className='confirm-by-typing__input'
-				placeholder={confirmText}
+				// placeholder={confirmText}
 				value={value}
 				onSlInput={(e) => onInput((e.target as HTMLInputElement).value)}
 			/>

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.tsx
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import SlInput from '@shoelace-style/shoelace/dist/react/input/index.js';
 import './ConfirmByTyping.css';
 
@@ -8,17 +8,31 @@ interface ConfirmByTypingProps {
 	onInput: (value: string) => void;
 }
 
-// TODO: focus direttamente nella casella
-
 const ConfirmByTyping = ({ confirmText, value, onInput }: ConfirmByTypingProps) => {
+	const inputRef = useRef<any>();
+
+	useEffect(() => {
+		const input = inputRef.current;
+		if (!input) return;
+
+		const dialog = input.closest('sl-dialog');
+		if (dialog) {
+			const onAfterShow = () => input.focus();
+			dialog.addEventListener('sl-after-show', onAfterShow);
+			return () => dialog.removeEventListener('sl-after-show', onAfterShow);
+		} else {
+			setTimeout(() => input.focus(), 50);
+		}
+	}, []);
+
 	return (
 		<div className='confirm-by-typing'>
 			<p className='confirm-by-typing__instruction'>
 				Type <span className='confirm-by-typing__confirm-text'>{confirmText}</span> to confirm:
 			</p>
 			<SlInput
+				ref={inputRef}
 				className='confirm-by-typing__input'
-				// placeholder={confirmText}
 				value={value}
 				onSlInput={(e) => onInput((e.target as HTMLInputElement).value)}
 			/>

--- a/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.tsx
+++ b/admin/src/components/base/ConfirmByTyping/ConfirmByTyping.tsx
@@ -16,6 +16,7 @@ const ConfirmByTyping = ({ confirmText, value, onInput }: ConfirmByTypingProps) 
 			</p>
 			<SlInput
 				className='confirm-by-typing__input'
+				placeholder={confirmText}
 				value={value}
 				onSlInput={(e) => onInput((e.target as HTMLInputElement).value)}
 			/>

--- a/admin/src/components/routes/ConnectionPipelines/ConnectionPipelines.css
+++ b/admin/src/components/routes/ConnectionPipelines/ConnectionPipelines.css
@@ -240,6 +240,10 @@
 	text-decoration: underline;
 }
 
+.connection-pipelines__grid-alert .alert-dialog__content {
+	text-align: left;
+}
+
 @media screen and (max-width: 1440px) {
 	.connection-pipelines__buttons > .connection-pipelines__manage-button {
 		display: none;

--- a/admin/src/components/routes/ConnectionPipelines/PipelinesGrid.tsx
+++ b/admin/src/components/routes/ConnectionPipelines/PipelinesGrid.tsx
@@ -15,6 +15,7 @@ import { Pipeline } from '../../../lib/api/types/pipeline';
 import { GridColumn, GridRow } from '../../base/Grid/Grid.types';
 import FeedbackButton from '../../base/FeedbackButton/FeedbackButton';
 import AlertDialog from '../../base/AlertDialog/AlertDialog';
+import ConfirmByTyping from '../../base/ConfirmByTyping/ConfirmByTyping';
 import { Variant } from '../App/App.types';
 import { serializeFilter } from '../../../utils/filters';
 import LittleLogo from '../../base/LittleLogo/LittleLogo';
@@ -38,6 +39,7 @@ interface PipelinesGridProps {
 const PipelinesGrid = ({ newPipelineID, pipelines, onSelectPipeline }: PipelinesGridProps) => {
 	const [pipelineToDelete, setPipelineToDelete] = useState<Pipeline | null>();
 	const [isAlertDialogOpen, setIsDialogAlertOpen] = useState<boolean>(false);
+	const [deleteConfirmationInput, setDeleteConfirmationInput] = useState<string>('');
 	const [windowWidth, setWindowWidth] = useState<number>(window.innerWidth);
 	const [gridColumnsWidths, setGridColumnsWidths] = useState<string>();
 
@@ -120,6 +122,7 @@ const PipelinesGrid = ({ newPipelineID, pipelines, onSelectPipeline }: Pipelines
 
 	const onDeletePipeline = (pipelineID: number) => {
 		setPipelineToDelete(pipelines.find((p) => p.id === pipelineID));
+		setDeleteConfirmationInput('');
 		setIsDialogAlertOpen(true);
 	};
 
@@ -140,6 +143,7 @@ const PipelinesGrid = ({ newPipelineID, pipelines, onSelectPipeline }: Pipelines
 
 	const closeAlertDialog = () => {
 		setIsDialogAlertOpen(false);
+		setDeleteConfirmationInput('');
 		setTimeout(() => {
 			// Reset the pipeline to delete after a delay to prevent flash of
 			// content in the dialog, where the pipeline name is used.
@@ -389,7 +393,7 @@ const PipelinesGrid = ({ newPipelineID, pipelines, onSelectPipeline }: Pipelines
 				actions={
 					<>
 						<SlButton onClick={closeAlertDialog}>Cancel</SlButton>
-						<SlButton variant='danger' onClick={onConfirmDeletePipeline}>
+						<SlButton variant='danger' onClick={onConfirmDeletePipeline} disabled={!pipelineToDelete || deleteConfirmationInput !== pipelineToDelete.name}>
 							Delete
 						</SlButton>
 					</>
@@ -407,6 +411,7 @@ const PipelinesGrid = ({ newPipelineID, pipelines, onSelectPipeline }: Pipelines
 				) : (
 					<p>If you continue, you will permanently lose the pipeline</p>
 				)}
+				<ConfirmByTyping confirmText={pipelineToDelete?.name ?? ''} value={deleteConfirmationInput} onInput={setDeleteConfirmationInput} />
 			</AlertDialog>
 		</>
 	);

--- a/admin/src/components/routes/ConnectionPipelines/PipelinesGrid.tsx
+++ b/admin/src/components/routes/ConnectionPipelines/PipelinesGrid.tsx
@@ -399,7 +399,6 @@ const PipelinesGrid = ({ newPipelineID, pipelines, onSelectPipeline }: Pipelines
 			>
 				{connection.isSource && pipelineToDelete?.target === 'User' ? (
 					<p>
-						{/* TODO Allineare a sx */}
 						If you continue{' '}
 						<span className='connection-pipelines__grid-alert-identities'>
 							you will permanently lose the identities

--- a/admin/src/components/routes/ConnectionPipelines/PipelinesGrid.tsx
+++ b/admin/src/components/routes/ConnectionPipelines/PipelinesGrid.tsx
@@ -382,25 +382,24 @@ const PipelinesGrid = ({ newPipelineID, pipelines, onSelectPipeline }: Pipelines
 				variant='danger'
 				isOpen={isAlertDialogOpen}
 				onClose={closeAlertDialog}
-				title={
-					<span>
-						Are you sure you want to delete the pipeline{' '}
-						<span className='connection-pipelines__grid-alert-pipeline-name'>{pipelineToDelete?.name}</span>{' '}
-						?
-					</span>
-				}
+				title={<span>Delete the pipeline?</span>}
 				className='connection-pipelines__grid-alert'
 				actions={
 					<>
 						<SlButton onClick={closeAlertDialog}>Cancel</SlButton>
-						<SlButton variant='danger' onClick={onConfirmDeletePipeline} disabled={!pipelineToDelete || deleteConfirmationInput !== pipelineToDelete.name}>
-							Delete
+						<SlButton
+							variant='danger'
+							onClick={onConfirmDeletePipeline}
+							disabled={!pipelineToDelete || deleteConfirmationInput !== pipelineToDelete.name}
+						>
+							Delete pipeline
 						</SlButton>
 					</>
 				}
 			>
 				{connection.isSource && pipelineToDelete?.target === 'User' ? (
 					<p>
+						{/* TODO Allineare a sx */}
 						If you continue{' '}
 						<span className='connection-pipelines__grid-alert-identities'>
 							you will permanently lose the identities
@@ -411,7 +410,11 @@ const PipelinesGrid = ({ newPipelineID, pipelines, onSelectPipeline }: Pipelines
 				) : (
 					<p>If you continue, you will permanently lose the pipeline</p>
 				)}
-				<ConfirmByTyping confirmText={pipelineToDelete?.name ?? ''} value={deleteConfirmationInput} onInput={setDeleteConfirmationInput} />
+				<ConfirmByTyping
+					confirmText={pipelineToDelete?.name ?? ''}
+					value={deleteConfirmationInput}
+					onInput={setDeleteConfirmationInput}
+				/>
 			</AlertDialog>
 		</>
 	);

--- a/admin/src/components/routes/ConnectionPipelines/PipelinesGrid.tsx
+++ b/admin/src/components/routes/ConnectionPipelines/PipelinesGrid.tsx
@@ -407,7 +407,7 @@ const PipelinesGrid = ({ newPipelineID, pipelines, onSelectPipeline }: Pipelines
 						resolution execution.
 					</p>
 				) : (
-					<p>If you continue, you will permanently lose the pipeline</p>
+					<p>If you continue, you will permanently lose the pipeline.</p>
 				)}
 				<ConfirmByTyping
 					confirmText={pipelineToDelete?.name ?? ''}

--- a/admin/src/components/routes/ConnectionSettings/ConnectionGeneralSettings.tsx
+++ b/admin/src/components/routes/ConnectionSettings/ConnectionGeneralSettings.tsx
@@ -4,6 +4,7 @@ import TransformedConnection from '../../../lib/core/connection';
 import { NotFoundError } from '../../../lib/api/errors';
 import DangerZone from '../../base/DangerZone/DangerZone';
 import AlertDialog from '../../base/AlertDialog/AlertDialog';
+import ConfirmByTyping from '../../base/ConfirmByTyping/ConfirmByTyping';
 import Flex from '../../base/Flex/Flex';
 import SlButton from '@shoelace-style/shoelace/dist/react/button/index.js';
 import SlInput from '@shoelace-style/shoelace/dist/react/input/index.js';
@@ -25,6 +26,7 @@ const ConnectionGeneralSettings = ({ connection, onDelete }: GeneralProps) => {
 		sendingMode: connection.sendingMode,
 	});
 	const [askDeletionConfirmation, setAskDeletionConfirmation] = useState<boolean>(false);
+	const [deleteConfirmationInput, setDeleteConfirmationInput] = useState<string>('');
 	const [isDeleting, setIsDeleting] = useState<boolean>(false);
 	const [isSaving, setIsSaving] = useState<boolean>(false);
 
@@ -168,7 +170,7 @@ const ConnectionGeneralSettings = ({ connection, onDelete }: GeneralProps) => {
 					<SlButton
 						className='connection-settings__danger-zone-delete-button'
 						variant='danger'
-						onClick={() => setAskDeletionConfirmation(true)}
+						onClick={() => { setDeleteConfirmationInput(''); setAskDeletionConfirmation(true); }}
 					>
 						Delete
 					</SlButton>
@@ -178,18 +180,19 @@ const ConnectionGeneralSettings = ({ connection, onDelete }: GeneralProps) => {
 			<AlertDialog
 				variant='danger'
 				isOpen={askDeletionConfirmation}
-				onClose={() => setAskDeletionConfirmation(false)}
+				onClose={() => { setAskDeletionConfirmation(false); setDeleteConfirmationInput(''); }}
 				title='Are you sure?'
 				actions={
 					<>
-						<SlButton onClick={() => setAskDeletionConfirmation(false)}>Cancel</SlButton>
-						<SlButton variant='danger' onClick={onDeletionConfirmation} loading={isDeleting}>
+						<SlButton onClick={() => { setAskDeletionConfirmation(false); setDeleteConfirmationInput(''); }}>Cancel</SlButton>
+						<SlButton variant='danger' onClick={onDeletionConfirmation} loading={isDeleting} disabled={deleteConfirmationInput !== connection.name}>
 							Delete
 						</SlButton>
 					</>
 				}
 			>
 				<p>If you continue, you will permanently lose all the connection data</p>
+				<ConfirmByTyping confirmText={connection.name} value={deleteConfirmationInput} onInput={setDeleteConfirmationInput} />
 			</AlertDialog>
 		</div>
 	);

--- a/admin/src/components/routes/ConnectionSettings/ConnectionGeneralSettings.tsx
+++ b/admin/src/components/routes/ConnectionSettings/ConnectionGeneralSettings.tsx
@@ -182,6 +182,7 @@ const ConnectionGeneralSettings = ({ connection, onDelete }: GeneralProps) => {
 
 			<AlertDialog
 				variant='danger'
+				className='connection-settings__delete-alert'
 				isOpen={askDeletionConfirmation}
 				onClose={() => {
 					setAskDeletionConfirmation(false);
@@ -209,7 +210,13 @@ const ConnectionGeneralSettings = ({ connection, onDelete }: GeneralProps) => {
 					</>
 				}
 			>
-				<p>If you continue, you will permanently lose all the connection data</p>
+				<p>
+					If you continue, you will permanently lose the connection and{' '}
+					<span className='connection-settings__delete-alert-pipelines'>
+						all its associated pipelines and their data
+					</span>
+					. The profiles will be updated accordingly at the next identity resolution execution.
+				</p>
 				<ConfirmByTyping
 					confirmText={connection.name}
 					value={deleteConfirmationInput}

--- a/admin/src/components/routes/ConnectionSettings/ConnectionGeneralSettings.tsx
+++ b/admin/src/components/routes/ConnectionSettings/ConnectionGeneralSettings.tsx
@@ -170,7 +170,10 @@ const ConnectionGeneralSettings = ({ connection, onDelete }: GeneralProps) => {
 					<SlButton
 						className='connection-settings__danger-zone-delete-button'
 						variant='danger'
-						onClick={() => { setDeleteConfirmationInput(''); setAskDeletionConfirmation(true); }}
+						onClick={() => {
+							setDeleteConfirmationInput('');
+							setAskDeletionConfirmation(true);
+						}}
 					>
 						Delete
 					</SlButton>
@@ -180,19 +183,38 @@ const ConnectionGeneralSettings = ({ connection, onDelete }: GeneralProps) => {
 			<AlertDialog
 				variant='danger'
 				isOpen={askDeletionConfirmation}
-				onClose={() => { setAskDeletionConfirmation(false); setDeleteConfirmationInput(''); }}
+				onClose={() => {
+					setAskDeletionConfirmation(false);
+					setDeleteConfirmationInput('');
+				}}
 				title='Are you sure?'
 				actions={
 					<>
-						<SlButton onClick={() => { setAskDeletionConfirmation(false); setDeleteConfirmationInput(''); }}>Cancel</SlButton>
-						<SlButton variant='danger' onClick={onDeletionConfirmation} loading={isDeleting} disabled={deleteConfirmationInput !== connection.name}>
-							Delete
+						<SlButton
+							onClick={() => {
+								setAskDeletionConfirmation(false);
+								setDeleteConfirmationInput('');
+							}}
+						>
+							Cancel
+						</SlButton>
+						<SlButton
+							variant='danger'
+							onClick={onDeletionConfirmation}
+							loading={isDeleting}
+							disabled={deleteConfirmationInput !== connection.name}
+						>
+							Delete connection
 						</SlButton>
 					</>
 				}
 			>
 				<p>If you continue, you will permanently lose all the connection data</p>
-				<ConfirmByTyping confirmText={connection.name} value={deleteConfirmationInput} onInput={setDeleteConfirmationInput} />
+				<ConfirmByTyping
+					confirmText={connection.name}
+					value={deleteConfirmationInput}
+					onInput={setDeleteConfirmationInput}
+				/>
 			</AlertDialog>
 		</div>
 	);

--- a/admin/src/components/routes/ConnectionSettings/ConnectionGeneralSettings.tsx
+++ b/admin/src/components/routes/ConnectionSettings/ConnectionGeneralSettings.tsx
@@ -188,7 +188,7 @@ const ConnectionGeneralSettings = ({ connection, onDelete }: GeneralProps) => {
 					setAskDeletionConfirmation(false);
 					setDeleteConfirmationInput('');
 				}}
-				title='Are you sure?'
+				title='Delete the connection?'
 				actions={
 					<>
 						<SlButton
@@ -210,13 +210,23 @@ const ConnectionGeneralSettings = ({ connection, onDelete }: GeneralProps) => {
 					</>
 				}
 			>
-				<p>
-					If you continue, you will permanently lose the connection and{' '}
-					<span className='connection-settings__delete-alert-pipelines'>
-						all its associated pipelines and their data
-					</span>
-					. The profiles will be updated accordingly at the next identity resolution execution.
-				</p>
+				{connection.isSource ? (
+					<p>
+						If you continue, you will permanently lose the connection and{' '}
+						<span className='connection-settings__delete-alert-pipelines'>
+							all its associated pipelines and their data
+						</span>
+						. The profiles will be updated accordingly at the next identity resolution execution.
+					</p>
+				) : (
+					<p>
+						If you continue, you will permanently lose the connection and{' '}
+						<span className='connection-settings__delete-alert-pipelines'>
+							all its associated pipelines
+						</span>
+						.
+					</p>
+				)}
 				<ConfirmByTyping
 					confirmText={connection.name}
 					value={deleteConfirmationInput}

--- a/admin/src/components/routes/ConnectionSettings/ConnectionSettings.css
+++ b/admin/src/components/routes/ConnectionSettings/ConnectionSettings.css
@@ -150,3 +150,11 @@
 .connection-settings__danger-zone-description {
 	font-size: 14px;
 }
+
+.connection-settings__delete-alert .alert-dialog__content {
+	text-align: left;
+}
+
+.connection-settings__delete-alert-pipelines {
+	text-decoration: underline;
+}

--- a/admin/src/components/routes/GeneralSettings/GeneralSettings.tsx
+++ b/admin/src/components/routes/GeneralSettings/GeneralSettings.tsx
@@ -277,8 +277,8 @@ const GeneralSettings = () => {
 					<li>The workspace will be permanently removed.</li>
 					<li>Data stored in the connected data warehouse will NOT be deleted.</li>
 					<li>
-						The data warehouse NON SI POTRÀ CONNETTERE to another Meergo workspace unless its contents are
-						manually cleared.
+						The data warehouse will not be able to connect to another Meergo workspace unless its contents
+						are manually cleared.
 					</li>
 				</ul>
 				<ConfirmByTyping

--- a/admin/src/components/routes/GeneralSettings/GeneralSettings.tsx
+++ b/admin/src/components/routes/GeneralSettings/GeneralSettings.tsx
@@ -6,6 +6,7 @@ import FeedbackButton from '../../base/FeedbackButton/FeedbackButton';
 import { CONFIRM_ANIMATION_DURATION } from '../PipelineWrapper/Pipeline.constants';
 import appContext from '../../../context/AppContext';
 import AlertDialog from '../../base/AlertDialog/AlertDialog';
+import ConfirmByTyping from '../../base/ConfirmByTyping/ConfirmByTyping';
 import SlInput from '@shoelace-style/shoelace/dist/react/input/index.js';
 import SlButton from '@shoelace-style/shoelace/dist/react/button/index.js';
 import SlDivider from '@shoelace-style/shoelace/dist/react/divider/index.js';
@@ -24,6 +25,7 @@ const GeneralSettings = () => {
 	const [lastName, setLastName] = useState<string>();
 	const [extra, setExtra] = useState<string>();
 	const [isDeleteConfirmationDialogOpen, setIsDeleteConfirmationDialogOpen] = useState<boolean>(false);
+	const [deleteConfirmationInput, setDeleteConfirmationInput] = useState<string>('');
 
 	const deleteButtonRef = useRef<any>();
 
@@ -127,7 +129,12 @@ const GeneralSettings = () => {
 		setIsLoadingWorkspaces(true);
 	};
 
-	const onDelete = () => setIsDeleteConfirmationDialogOpen(true);
+	const isDeleteConfirmed = deleteConfirmationInput === name;
+
+	const onDelete = () => {
+		setDeleteConfirmationInput('');
+		setIsDeleteConfirmationDialogOpen(true);
+	};
 
 	const onDeleteConfirmation = async () => {
 		deleteButtonRef.current!.load();
@@ -150,6 +157,7 @@ const GeneralSettings = () => {
 
 	const onCancelDeletion = () => {
 		setIsDeleteConfirmationDialogOpen(false);
+		setDeleteConfirmationInput('');
 	};
 
 	return (
@@ -263,6 +271,7 @@ const GeneralSettings = () => {
 							variant='danger'
 							onClick={onDeleteConfirmation}
 							animationDuration={CONFIRM_ANIMATION_DURATION}
+							disabled={!isDeleteConfirmed}
 						>
 							Permanently delete workspace
 						</FeedbackButton>
@@ -277,6 +286,7 @@ const GeneralSettings = () => {
 						cleared.
 					</li>
 				</ul>
+				<ConfirmByTyping confirmText={name} value={deleteConfirmationInput} onInput={setDeleteConfirmationInput} />
 			</AlertDialog>
 		</div>
 	);

--- a/admin/src/components/routes/GeneralSettings/GeneralSettings.tsx
+++ b/admin/src/components/routes/GeneralSettings/GeneralSettings.tsx
@@ -256,12 +256,7 @@ const GeneralSettings = () => {
 				variant='danger'
 				isOpen={isDeleteConfirmationDialogOpen}
 				onClose={onCancelDeletion}
-				title={
-					<span>
-						Permanently delete workspace{' '}
-						<span className='general-settings__grid-alert-workspace-name'>{name}</span> ?
-					</span>
-				}
+				title={<span>Delete the workspace?</span>}
 				actions={
 					<>
 						<SlButton onClick={onCancelDeletion}>Cancel</SlButton>
@@ -273,20 +268,24 @@ const GeneralSettings = () => {
 							animationDuration={CONFIRM_ANIMATION_DURATION}
 							disabled={!isDeleteConfirmed}
 						>
-							Permanently delete workspace
+							Delete workspace
 						</FeedbackButton>
 					</>
 				}
 			>
 				<ul className='general-settings__grid-alert-workspace-ul'>
 					<li>The workspace will be permanently removed.</li>
-					<li>Customer data stored in the connected data warehouse will NOT be deleted.</li>
+					<li>Data stored in the connected data warehouse will NOT be deleted.</li>
 					<li>
-						The warehouse cannot be connected to another Meergo workspace unless its contents are manually
-						cleared.
+						The data warehouse NON SI POTRÀ CONNETTERE to another Meergo workspace unless its contents are
+						manually cleared.
 					</li>
 				</ul>
-				<ConfirmByTyping confirmText={name} value={deleteConfirmationInput} onInput={setDeleteConfirmationInput} />
+				<ConfirmByTyping
+					confirmText={name}
+					value={deleteConfirmationInput}
+					onInput={setDeleteConfirmationInput}
+				/>
 			</AlertDialog>
 		</div>
 	);


### PR DESCRIPTION
Commit message:

```
admin: add "type to confirm" before deleting and refactor dialogs

This commit:

1. Adds the "ConfirmByTyping" component, which implements a check before
   deleting important elements by requiring the user to type their name.

2. Ensures that confirmation by typing their name is required when
   deleting a pipeline, connection, and workspace.

3. In light of the above changes, refactors the dialogs to adapt them to
   the new behavior and avoid clutter and redundancy (especially in
   titles and texts). Also, adds information to dialogs where it was
   missing (e.g., connection, where the text was really poor).

4. Improves and generally standardizes the five confirmation dialogs
   (source and destination pipeline, source and destination connection,
   workspace).
```