### PR TITLE
all: rename Go declarations from "meergo" to "krenalis"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,9 +73,9 @@ func Main(assets fs.FS) {
 	// configuration passed from the environment.
 	for _, v := range os.Environ() {
 		if key, _, ok := strings.Cut(v, "="); ok {
-			isMeergoVar := strings.HasPrefix(key, "KRENALIS_")
-			isMeergoConnectorVar := strings.HasPrefix(key, "KRENALIS_CONNECTOR_")
-			if isMeergoVar && !isMeergoConnectorVar {
+			isKrenalisVar := strings.HasPrefix(key, "KRENALIS_")
+			isKrenalisConnectorVar := strings.HasPrefix(key, "KRENALIS_CONNECTOR_")
+			if isKrenalisVar && !isKrenalisConnectorVar {
 				// os.Unsetenv can only fail on Windows if the key is not UTF-8
 				// encoded. But since Meergo only supports UTF-8 keys, and this
 				// is a rare edge case, failing to unset such a variable

--- a/connectors/clickhouse/clickhouse_test.go
+++ b/connectors/clickhouse/clickhouse_test.go
@@ -33,8 +33,8 @@ func Test_Merge_Query(t *testing.T) {
 	cols := []struct {
 		DriverType  string
 		DriverValue any
-		MeergoType  types.Type
-		MeergoValue any
+		KrenalisType  types.Type
+		KrenalisValue any
 	}{
 		{"Bool", true, types.Boolean(), true},
 		{"Int8", int8(-23), types.Int(8), -23},
@@ -74,7 +74,7 @@ func Test_Merge_Query(t *testing.T) {
 	for i, c := range cols {
 		table.Columns[i] = connectors.Column{
 			Name:     fmt.Sprintf("c%d", i),
-			Type:     c.MeergoType,
+			Type:     c.KrenalisType,
 			Nullable: strings.HasPrefix(c.DriverType, "Nullable("),
 		}
 	}
@@ -160,7 +160,7 @@ func Test_Merge_Query(t *testing.T) {
 	}()
 	row := make([]any, len(cols))
 	for i, c := range cols {
-		row[i] = c.MeergoValue
+		row[i] = c.KrenalisValue
 	}
 	err = connector.Merge(context.Background(), table, [][]any{row})
 	if err != nil {
@@ -214,7 +214,7 @@ func Test_Merge_Query(t *testing.T) {
 			case fmt.Stringer:
 				// Normalize the decimal type in the same way as the normalization does.
 				// This avoids the explicit dependency on "github.com/shopspring/decimal" for the meergo module.
-				if typ := cols[i].MeergoType; typ.Kind() == types.DecimalKind {
+				if typ := cols[i].KrenalisType; typ.Kind() == types.DecimalKind {
 					v, err = decimal.Parse(vt.String(), typ.Precision(), typ.Scale())
 					if err != nil {
 						t.Fatalf("column %q: an error occurred parsing %v (%T) as decimal: %s", table.Columns[i].Name, v, v, err)

--- a/connectors/clickhouse/clickhouse_test.go
+++ b/connectors/clickhouse/clickhouse_test.go
@@ -31,8 +31,8 @@ import (
 func Test_Merge_Query(t *testing.T) {
 
 	cols := []struct {
-		DriverType  string
-		DriverValue any
+		DriverType    string
+		DriverValue   any
 		KrenalisType  types.Type
 		KrenalisValue any
 	}{

--- a/connectors/googleanalytics/event_types.go
+++ b/connectors/googleanalytics/event_types.go
@@ -29,7 +29,7 @@ type eventType struct {
 }
 
 var eventTypeByID map[string]*eventType
-var meergoEventTypes []*connectors.EventType
+var krenalisEventTypes []*connectors.EventType
 
 // https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events.
 var measurementProtocolEvents []*eventType
@@ -420,7 +420,7 @@ func init() {
 	eventTypeByID = make(map[string]*eventType, len(measurementProtocolEvents))
 	for _, def := range measurementProtocolEvents {
 		eventTypeByID[def.ID] = def
-		meergoEventTypes = append(meergoEventTypes, &connectors.EventType{
+		krenalisEventTypes = append(krenalisEventTypes, &connectors.EventType{
 			ID:          def.ID,
 			Name:        def.Name,
 			Description: fmt.Sprintf("Send '%s' events to Google Analytics", def.Name),

--- a/connectors/googleanalytics/googleanalytics.go
+++ b/connectors/googleanalytics/googleanalytics.go
@@ -74,7 +74,7 @@ type innerSettings struct {
 
 // EventTypes returns the event types.
 func (ga *Analytics) EventTypes(ctx context.Context) ([]*connectors.EventType, error) {
-	return meergoEventTypes, nil
+	return krenalisEventTypes, nil
 }
 
 // EventTypeSchema returns the schema of the specified event type.

--- a/connectors/mixpanel/badrequest_test.go
+++ b/connectors/mixpanel/badrequest_test.go
@@ -75,15 +75,15 @@ func TestBadRequest(t *testing.T) {
 	if err == nil {
 		t.Fatal("test should fail, but it returned no errors")
 	}
-	gotMeergoError, ok := err.(connectors.EventsError)
+	gotKrenalisError, ok := err.(connectors.EventsError)
 	if !ok {
 		t.Fatalf("expected a connectors.EventsError error, got %T instead", err)
 	}
-	if len(gotMeergoError) != 2 {
-		t.Fatalf("expected a connectors.EventsError with 2 event(s) inside, have %d instead", len(gotMeergoError))
+	if len(gotKrenalisError) != 2 {
+		t.Fatalf("expected a connectors.EventsError with 2 event(s) inside, have %d instead", len(gotKrenalisError))
 	}
-	gotErr1 := gotMeergoError[0].Error()
-	gotErr2 := gotMeergoError[1].Error()
+	gotErr1 := gotKrenalisError[0].Error()
+	gotErr2 := gotKrenalisError[1].Error()
 	if gotErr1 != gotErr2 {
 		t.Fatal("the two errors should be the same")
 	}

--- a/connectors/mysql/mysql_test.go
+++ b/connectors/mysql/mysql_test.go
@@ -31,8 +31,8 @@ func Test_Merge_Query(t *testing.T) {
 	cols := []struct {
 		DriverType  string
 		DriverValue any
-		MeergoType  types.Type
-		MeergoValue any
+		KrenalisType  types.Type
+		KrenalisValue any
 	}{
 		{"TINYINT", int64(-112), types.Int(8), -112},
 		{"SMALLINT", int64(1427), types.Int(16), 1427},
@@ -76,7 +76,7 @@ func Test_Merge_Query(t *testing.T) {
 	for i, c := range cols {
 		table.Columns[i] = connectors.Column{
 			Name:     fmt.Sprintf("c%d", i),
-			Type:     c.MeergoType,
+			Type:     c.KrenalisType,
 			Nullable: i > 0,
 		}
 	}
@@ -182,7 +182,7 @@ func Test_Merge_Query(t *testing.T) {
 	}()
 	row := make([]any, len(cols))
 	for i, c := range cols {
-		row[i] = c.MeergoValue
+		row[i] = c.KrenalisValue
 	}
 	err = connector.Merge(context.Background(), table, [][]any{row})
 	if err != nil {

--- a/connectors/mysql/mysql_test.go
+++ b/connectors/mysql/mysql_test.go
@@ -29,8 +29,8 @@ import (
 func Test_Merge_Query(t *testing.T) {
 
 	cols := []struct {
-		DriverType  string
-		DriverValue any
+		DriverType    string
+		DriverValue   any
 		KrenalisType  types.Type
 		KrenalisValue any
 	}{

--- a/connectors/postgresql/postgresql_test.go
+++ b/connectors/postgresql/postgresql_test.go
@@ -39,8 +39,8 @@ func Test_Merge_Query(t *testing.T) {
 	cols := []struct {
 		DriverType  string
 		DriverValue any
-		MeergoType  types.Type
-		MeergoValue any
+		KrenalisType  types.Type
+		KrenalisValue any
 	}{
 		{"SERIAL", int64(1), types.Int(32), 1},
 		{"smallint", int64(1), types.Int(16), 1},
@@ -74,7 +74,7 @@ func Test_Merge_Query(t *testing.T) {
 	for i, c := range cols {
 		table.Columns[i] = connectors.Column{
 			Name:     fmt.Sprintf("c%d", i),
-			Type:     c.MeergoType,
+			Type:     c.KrenalisType,
 			Nullable: true,
 		}
 	}
@@ -156,7 +156,7 @@ func Test_Merge_Query(t *testing.T) {
 	}()
 	row := make([]any, len(cols))
 	for i, c := range cols {
-		row[i] = c.MeergoValue
+		row[i] = c.KrenalisValue
 	}
 	err = connector.Merge(context.Background(), table, [][]any{row})
 	if err != nil {

--- a/connectors/postgresql/postgresql_test.go
+++ b/connectors/postgresql/postgresql_test.go
@@ -37,8 +37,8 @@ const (
 func Test_Merge_Query(t *testing.T) {
 
 	cols := []struct {
-		DriverType  string
-		DriverValue any
+		DriverType    string
+		DriverValue   any
 		KrenalisType  types.Type
 		KrenalisValue any
 	}{

--- a/connectors/snowflake/snowflake_test.go
+++ b/connectors/snowflake/snowflake_test.go
@@ -113,8 +113,8 @@ func Test_Merge_Query(t *testing.T) {
 	cols := []struct {
 		DriverType  string
 		DriverValue any
-		MeergoType  types.Type
-		MeergoValue any
+		KrenalisType  types.Type
+		KrenalisValue any
 	}{
 		{"BOOLEAN", true, types.Boolean(), true},
 		{"FLOAT", 703.219, types.Float(64), 703.219},
@@ -135,7 +135,7 @@ func Test_Merge_Query(t *testing.T) {
 	for i, c := range cols {
 		table.Columns[i] = connectors.Column{
 			Name:     fmt.Sprintf("c%d", i),
-			Type:     c.MeergoType,
+			Type:     c.KrenalisType,
 			Nullable: true,
 		}
 	}
@@ -171,7 +171,7 @@ func Test_Merge_Query(t *testing.T) {
 	}()
 	row := make([]any, len(cols))
 	for i, c := range cols {
-		row[i] = c.MeergoValue
+		row[i] = c.KrenalisValue
 	}
 	err = connector.Merge(context.Background(), table, [][]any{row})
 	if err != nil {

--- a/connectors/snowflake/snowflake_test.go
+++ b/connectors/snowflake/snowflake_test.go
@@ -111,8 +111,8 @@ func Test_Columns(t *testing.T) {
 func Test_Merge_Query(t *testing.T) {
 
 	cols := []struct {
-		DriverType  string
-		DriverValue any
+		DriverType    string
+		DriverValue   any
 		KrenalisType  types.Type
 		KrenalisValue any
 	}{

--- a/test/admin_initial_user_schema_test.go
+++ b/test/admin_initial_user_schema_test.go
@@ -22,7 +22,7 @@ func TestAdminInitialProfileSchema(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.PopulateProfileSchema(false)
 	c.Start()
 	defer c.Stop()

--- a/test/admin_test.go
+++ b/test/admin_test.go
@@ -46,7 +46,7 @@ func TestAdmin(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(fsTempDir.Root())
 	c.Start()
 	defer c.Stop()

--- a/test/anonymous_not_anonymous_test.go
+++ b/test/anonymous_not_anonymous_test.go
@@ -20,7 +20,7 @@ func TestAnonymousNotAnonymous(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/change_user_schema_test.go
+++ b/test/change_user_schema_test.go
@@ -22,7 +22,7 @@ func TestChangeProfileSchema(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/connections_test.go
+++ b/test/connections_test.go
@@ -18,7 +18,7 @@ func TestConnections(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/dispatch_events_to_dummy_test.go
+++ b/test/dispatch_events_to_dummy_test.go
@@ -39,7 +39,7 @@ func TestDispatchEventsToDummy(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/dummy_import_not_required_test.go
+++ b/test/dummy_import_not_required_test.go
@@ -18,7 +18,7 @@ func TestDummyImportNotRequired(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/events_context_test.go
+++ b/test/events_context_test.go
@@ -24,7 +24,7 @@ func TestEventsContext(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/events_test.go
+++ b/test/events_test.go
@@ -25,7 +25,7 @@ func TestEvents(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/export_to_postgresql_test.go
+++ b/test/export_to_postgresql_test.go
@@ -18,7 +18,7 @@ func TestExportToPostgreSQL(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/export_users_to_file_test.go
+++ b/test/export_users_to_file_test.go
@@ -31,7 +31,7 @@ func TestExportUsersToFile(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storage.Root())
 	c.Start()
 	defer c.Stop()

--- a/test/export_zero_users_test.go
+++ b/test/export_zero_users_test.go
@@ -27,7 +27,7 @@ func TestExportZeroProfiles(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storage.Root())
 	c.Start()
 	defer c.Stop()

--- a/test/identity_resolution_2_test.go
+++ b/test/identity_resolution_2_test.go
@@ -27,7 +27,7 @@ func TestIdentityResolution2(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.PopulateProfileSchema(false)
 	c.SetFileSystemRoot(storage.Root())
 	c.Start()

--- a/test/identity_resolution_test.go
+++ b/test/identity_resolution_test.go
@@ -31,7 +31,7 @@ func TestIdentityResolution(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storage.Root())
 	c.Start()
 	defer c.Stop()

--- a/test/import_export_users_to_dummy_test.go
+++ b/test/import_export_users_to_dummy_test.go
@@ -17,7 +17,7 @@ func TestImportExportUsersToDummy(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/import_from_database_test.go
+++ b/test/import_from_database_test.go
@@ -17,7 +17,7 @@ func TestImportFromDatabase(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/import_from_many_connections_test.go
+++ b/test/import_from_many_connections_test.go
@@ -41,7 +41,7 @@ func Test_ImportFromManyConnections(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storageDir)
 	c.Start()
 	defer c.Stop()

--- a/test/import_from_two_dummies_test.go
+++ b/test/import_from_two_dummies_test.go
@@ -17,7 +17,7 @@ func TestImportFromTwoDummies(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/import_from_two_pipelines_test.go
+++ b/test/import_from_two_pipelines_test.go
@@ -33,7 +33,7 @@ func TestImportUsersFromFileWithTwoPipelines(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storageDir)
 	c.Start()
 	defer c.Stop()

--- a/test/import_objects_into_warehouse_test.go
+++ b/test/import_objects_into_warehouse_test.go
@@ -18,7 +18,7 @@ func TestImportObjectsIntoWarehouse(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/import_users_from_file_test.go
+++ b/test/import_users_from_file_test.go
@@ -32,7 +32,7 @@ func TestImportUsersFromFile(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storageDir)
 	c.Start()
 	defer c.Stop()

--- a/test/js_sdk_event_url_test.go
+++ b/test/js_sdk_event_url_test.go
@@ -16,7 +16,7 @@ func TestJavaScriptSDKEventURL(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/krenalistester/build_run_meergo.go
+++ b/test/krenalistester/build_run_meergo.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 )
 
-// buildMeergo builds Meergo.
-func buildMeergo(t *testing.T, repo, meergoDir string) {
+// buildKrenalis builds Krenalis.
+func buildKrenalis(t *testing.T, repo, krenalisDir string) {
 
 	// Create a temporary directory.
 	tmpdir, err := os.MkdirTemp("", "krenalis-build-for-tests-*")
@@ -60,9 +60,9 @@ func buildMeergo(t *testing.T, repo, meergoDir string) {
 	// Generate the assets.
 	execCmd(t, tmpdir, "go", "generate")
 
-	// Build Meergo, putting the output into the meergoDir, where it will be
+	// Build Krenalis, putting the output into the krenalisDir, where it will be
 	// executed by the tests.
-	execCmd(t, tmpdir, "go", "build", "-o", filepath.Join(meergoDir, meergoExecFilename()))
+	execCmd(t, tmpdir, "go", "build", "-o", filepath.Join(krenalisDir, krenalisExecFilename()))
 
 }
 
@@ -107,21 +107,21 @@ func generateAssets(ctx context.Context, repo string) error {
 	return nil
 }
 
-func launchMeergo(ctx context.Context, env []string) error {
+func launchKrenalis(ctx context.Context, env []string) error {
 	repo, err := filepath.Abs("../")
 	if err != nil {
 		return err
 	}
-	meergoDir := filepath.Join(repo, "test", "krenalis-executable-for-tests")
-	cmd := exec.CommandContext(ctx, "./"+meergoExecFilename(), "-init-db-if-empty")
+	krenalisDir := filepath.Join(repo, "test", "krenalis-executable-for-tests")
+	cmd := exec.CommandContext(ctx, "./"+krenalisExecFilename(), "-init-db-if-empty")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
-	cmd.Dir = meergoDir
+	cmd.Dir = krenalisDir
 	cmd.Env = env
 	return cmd.Run()
 }
 
-func meergoExecFilename() string {
+func krenalisExecFilename() string {
 	if runtime.GOOS == "windows" {
 		return "krenalis.exe"
 	}

--- a/test/krenalistester/call.go
+++ b/test/krenalistester/call.go
@@ -35,7 +35,7 @@ func (e *StatusCodeError) Error() string {
 // Returns an error if the calls returns an error, which may be a
 // StatusCodeError error in case of a HTTP request which returned a status code
 // which is not 200, or if the HTTP response cannot be decoded into response.
-func (c *Meergo) Call(method, path string, body, response any) error {
+func (c *Krenalis) Call(method, path string, body, response any) error {
 	return c.call(method, path, body, response)
 }
 
@@ -45,7 +45,7 @@ func (c *Meergo) Call(method, path string, body, response any) error {
 // Calls (*testing.T).Fatal if the call returns an error, if the HTTP response
 // cannot be decoded into response, or if the HTTP response's status code is not
 // 200.
-func (c *Meergo) MustCall(method, path string, body, response any) {
+func (c *Krenalis) MustCall(method, path string, body, response any) {
 	err := c.call(method, path, body, response)
 	if err != nil {
 		c.t.Logf("%s %s: %s\n[has body: %t, has response: %t]\nStack trace:\n%s", method, path, strings.TrimSpace(err.Error()), body != nil, response != nil, string(debug.Stack()))
@@ -53,7 +53,7 @@ func (c *Meergo) MustCall(method, path string, body, response any) {
 	}
 }
 
-func (c *Meergo) call(method, path string, body any, response any) error {
+func (c *Krenalis) call(method, path string, body any, response any) error {
 
 	path = strings.TrimLeft(path, "/")
 	url := "http://" + c.Addr() + "/" + path

--- a/test/krenalistester/krenalistester.go
+++ b/test/krenalistester/krenalistester.go
@@ -52,8 +52,8 @@ const launchKrenalisExternally = true
 type Krenalis struct {
 	cancel func()
 	t      *testing.T
-	// krenalisRunning is used as a synchronization mechanism to wait for Krenalis
-	// to end its execution.
+	// krenalisRunning is used as a synchronization mechanism to wait for
+	// Krenalis to end its execution.
 	// When Krenalis is started -- both as an external process or as a goroutine
 	// --, an empty channel should be assigned to it; when Krenalis exits, the
 	// channel must be closed; this allows the testing framework to wait for

--- a/test/krenalistester/krenalistester.go
+++ b/test/krenalistester/krenalistester.go
@@ -38,27 +38,27 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-// launchMeergoExternally determines if Meergo should be launched externally
+// launchKrenalisExternally determines if Krenalis should be launched externally
 // when testing.
 //
-//   - Set this to true when testing Meergo using 'go run ./commit' or
+//   - Set this to true when testing Krenalis using 'go run ./commit' or
 //     'go test'.
 //
-//   - Set this to false when debugging a single Meergo test.
-const launchMeergoExternally = true
+//   - Set this to false when debugging a single Krenalis test.
+const launchKrenalisExternally = true
 
-// Meergo represents an instance of Meergo which responds to HTTP requests and
+// Krenalis represents an instance of Krenalis which responds to HTTP requests and
 // exposes methods to make calls to the APIs.
-type Meergo struct {
+type Krenalis struct {
 	cancel func()
 	t      *testing.T
-	// meergoRunning is used as a synchronization mechanism to wait for Meergo
+	// krenalisRunning is used as a synchronization mechanism to wait for Krenalis
 	// to end its execution.
-	// When Meergo is started -- both as an external process or as a goroutine
-	// --, an empty channel should be assigned to it; when Meergo exits, the
+	// When Krenalis is started -- both as an external process or as a goroutine
+	// --, an empty channel should be assigned to it; when Krenalis exits, the
 	// channel must be closed; this allows the testing framework to wait for
-	// Meergo to correctly exit before finishing the tests.
-	meergoRunning          chan struct{}
+	// Krenalis to correctly exit before finishing the tests.
+	krenalisRunning          chan struct{}
 	transformationsTempDir string
 	httpClient             *http.Client
 	ws                     int
@@ -76,34 +76,34 @@ type Meergo struct {
 }
 
 var assetsAlreadyGenerated bool
-var meergoAlreadyBuilt bool
-var meergoAlreadyLaunched bool
+var krenalisAlreadyBuilt bool
+var krenalisAlreadyLaunched bool
 
-// Addr returns the host (along with the port) on which the Meergo instance
+// Addr returns the host (along with the port) on which the Krenalis instance
 // runs.
-func (c *Meergo) Addr() string {
+func (c *Krenalis) Addr() string {
 	return testsSettings.HTTP.Host + ":" + strconv.Itoa(testsSettings.HTTP.Port)
 }
 
-// NewMeergoInstance initializes a new instance of Meergo for testing.
+// NewKrenalisInstance initializes a new instance of Krenalis for testing.
 //
 // After initializing an instance, its options can be set (via
 // [PopulateProfileSchema] and [SetFileSystemRoot]) and finally the instance can be
 // started with the [Start] method.
-func NewMeergoInstance(t *testing.T) *Meergo {
+func NewKrenalisInstance(t *testing.T) *Krenalis {
 
-	if !launchMeergoExternally {
-		if meergoAlreadyLaunched {
-			msg := "aborting tests: you are executing more than one test, consequently the 'launchMeergoExternally'" +
+	if !launchKrenalisExternally {
+		if krenalisAlreadyLaunched {
+			msg := "aborting tests: you are executing more than one test, consequently the 'launchKrenalisExternally'" +
 				" constant cannot be false. It can be false only when executing a single test"
 			t.Fatal(msg)
 		}
-		meergoAlreadyLaunched = true
+		krenalisAlreadyLaunched = true
 	}
 
 	ctx := context.Background()
 
-	c := Meergo{
+	c := Krenalis{
 		t:                     t,
 		populateProfileSchema: true,
 	}
@@ -125,7 +125,7 @@ func NewMeergoInstance(t *testing.T) *Meergo {
 	// If Meergo is run inside the testing process, it is necessary to generate
 	// the assets. If it is run externally, the assets are generated separately,
 	// when Meergo is compiled, so there is no need to compile them.
-	const needToGenerateAssets = !launchMeergoExternally
+	const needToGenerateAssets = !launchKrenalisExternally
 	if needToGenerateAssets {
 		c.assetsGenerated = make(chan struct{}, 1)
 		go func() {
@@ -160,22 +160,22 @@ func NewMeergoInstance(t *testing.T) *Meergo {
 //
 // By default, if this method is not called before calling [Start], the option
 // is considered true.
-func (c *Meergo) PopulateProfileSchema(populate bool) {
+func (c *Krenalis) PopulateProfileSchema(populate bool) {
 	c.populateProfileSchema = populate
 }
 
 // SetFileSystemRoot sets the root of the File System connections; the value set
-// here will be passed to Meergo via the KRENALIS_CONNECTOR_FILESYSTEM_ROOT
+// here will be passed to Krenalis via the KRENALIS_CONNECTOR_FILESYSTEM_ROOT
 // environment variable.
-func (c *Meergo) SetFileSystemRoot(root string) {
+func (c *Krenalis) SetFileSystemRoot(root string) {
 	c.fileSystemRoot = root
 }
 
-// Start starts the Meergo instance.
+// Start starts the Krenalis instance.
 //
 // After calling this method, the [Stop] method must be called to stop the
 // instance and shutdown the server.
-func (c *Meergo) Start() {
+func (c *Krenalis) Start() {
 
 	ctx := context.Background()
 
@@ -313,22 +313,22 @@ func (c *Meergo) Start() {
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	c.cancel = cancel
 
-	if launchMeergoExternally {
-		// Create, if necessary, the directory that will hold the Meergo
+	if launchKrenalisExternally {
+		// Create, if necessary, the directory that will hold the Krenalis
 		// executable (as well as the other files needed for the execution).
-		meergoDir := filepath.Join(c.repo, "test", "krenalis-executable-for-tests")
-		err = os.Mkdir(meergoDir, 0755)
+		krenalisDir := filepath.Join(c.repo, "test", "krenalis-executable-for-tests")
+		err = os.Mkdir(krenalisDir, 0755)
 		if err != nil && !errors.Is(err, os.ErrExist) {
 			c.t.Fatal(err)
 		}
 		// In addition to the environment variables already present for the
-		// process, add those needed to run Meergo.
+		// process, add those needed to run Krenalis.
 		//
 		// It is important to preserve the environment variables already present
-		// because (1) it is the same thing we do when we test Meergo not as an
+		// because (1) it is the same thing we do when we test Krenalis not as an
 		// external process but "embedded" inside the current process, so this
 		// makes the two test modes more consistent and (2) problems can occur
-		// in running Meergo if certain system environment variables are not
+		// in running Krenalis if certain system environment variables are not
 		// provided (this for example gives errors on Windows).
 		env := append(os.Environ(), []string{
 			"KRENALIS_EXTERNAL_ASSETS_URLS=https://assets.krenalis.com/",
@@ -351,16 +351,16 @@ func (c *Meergo) Start() {
 			"KRENALIS_NATS_USER=" + testsSettings.NATS.User,
 			"KRENALIS_NATS_PASSWORD=" + testsSettings.NATS.Password,
 		}...)
-		if !meergoAlreadyBuilt {
-			buildMeergo(c.t, c.repo, meergoDir)
-			meergoAlreadyBuilt = true
+		if !krenalisAlreadyBuilt {
+			buildKrenalis(c.t, c.repo, krenalisDir)
+			krenalisAlreadyBuilt = true
 		}
 		go func() {
-			c.meergoRunning = make(chan struct{})
+			c.krenalisRunning = make(chan struct{})
 			defer func() {
-				close(c.meergoRunning)
+				close(c.krenalisRunning)
 			}()
-			err := launchMeergo(ctxWithCancel, env)
+			err := launchKrenalis(ctxWithCancel, env)
 			if err != nil && ctxWithCancel.Err() == nil {
 				log.Printf("[error] %s", err)
 			}
@@ -397,9 +397,9 @@ func (c *Meergo) Start() {
 			c.t.Fatal(err)
 		}
 		go func() {
-			c.meergoRunning = make(chan struct{})
+			c.krenalisRunning = make(chan struct{})
 			defer func() {
-				close(c.meergoRunning)
+				close(c.krenalisRunning)
 			}()
 			assets := os.DirFS(filepath.Join(c.repo, "admin", "assets"))
 			{
@@ -429,7 +429,7 @@ func (c *Meergo) Start() {
 	attempts := 0
 	for {
 		select {
-		case <-c.meergoRunning:
+		case <-c.krenalisRunning:
 			c.t.Fatalf("Krenalis has exited")
 		default:
 		}
@@ -479,7 +479,7 @@ func (c *Meergo) Start() {
 
 // CountEventsInWarehouse returns the counts of events stored in the "events"
 // table of the testing data warehouse.
-func (c *Meergo) CountEventsInWarehouse(ctx context.Context) int {
+func (c *Krenalis) CountEventsInWarehouse(ctx context.Context) int {
 	pool, err := ConnectionPool(ctx, testsSettings.Warehouse)
 	if err != nil {
 		c.t.Fatalf("cannot open warehouse for executing query tests: %s", err)
@@ -493,13 +493,13 @@ func (c *Meergo) CountEventsInWarehouse(ctx context.Context) int {
 	return count
 }
 
-// Stop stops the execution of Meergo.
-func (c *Meergo) Stop() {
+// Stop stops the execution of Krenalis.
+func (c *Krenalis) Stop() {
 	if c.cancel != nil {
 		c.cancel()
 	}
-	if c.meergoRunning != nil {
-		<-c.meergoRunning
+	if c.krenalisRunning != nil {
+		<-c.krenalisRunning
 	}
 	if c.transformationsTempDir == "" {
 		panic("BUG: transformationsTempDir not set")
@@ -545,7 +545,7 @@ func init() {
 	}
 }
 
-func (c *Meergo) createWorkspace(name string, profileSchema types.Type, uiPreferences UIPreferences) (int, error) {
+func (c *Krenalis) createWorkspace(name string, profileSchema types.Type, uiPreferences UIPreferences) (int, error) {
 	req := map[string]any{
 		"name":          name,
 		"profileSchema": profileSchema,
@@ -565,7 +565,7 @@ func (c *Meergo) createWorkspace(name string, profileSchema types.Type, uiPrefer
 	return response.ID, nil
 }
 
-func (c *Meergo) login() error {
+func (c *Krenalis) login() error {
 	body := map[string]any{
 		"email":    "acme@krenalis.com",
 		"password": "meergo-password",
@@ -574,7 +574,7 @@ func (c *Meergo) login() error {
 }
 
 // ExecQueryTestDatabase executes a query on the test database.
-func (c *Meergo) ExecQueryTestDatabase(ctx context.Context, query string, args ...any) {
+func (c *Krenalis) ExecQueryTestDatabase(ctx context.Context, query string, args ...any) {
 	pool, err := ConnectionPool(ctx, testsSettings.Database)
 	if err != nil {
 		c.t.Fatalf("cannot establish connection to database: %s", err)
@@ -588,7 +588,7 @@ func (c *Meergo) ExecQueryTestDatabase(ctx context.Context, query string, args .
 
 // QueryRowTestDatabase queries a row on the test database, scanning it into
 // dest, which must be a pointer.
-func (c *Meergo) QueryRowTestDatabase(ctx context.Context, dest any, query string, args ...any) {
+func (c *Krenalis) QueryRowTestDatabase(ctx context.Context, dest any, query string, args ...any) {
 	if reflect.TypeOf(dest).Kind() != reflect.Pointer {
 		panic("dest must be a pointer")
 	}
@@ -603,9 +603,9 @@ func (c *Meergo) QueryRowTestDatabase(ctx context.Context, dest any, query strin
 	}
 }
 
-// WorkspaceID returns the ID of the workspace on which the instance of Meergo
+// WorkspaceID returns the ID of the workspace on which the instance of Krenalis
 // operates.
-func (c *Meergo) WorkspaceID() int {
+func (c *Krenalis) WorkspaceID() int {
 	return c.ws
 }
 

--- a/test/krenalistester/krenalistester.go
+++ b/test/krenalistester/krenalistester.go
@@ -58,7 +58,7 @@ type Krenalis struct {
 	// --, an empty channel should be assigned to it; when Krenalis exits, the
 	// channel must be closed; this allows the testing framework to wait for
 	// Krenalis to correctly exit before finishing the tests.
-	krenalisRunning          chan struct{}
+	krenalisRunning        chan struct{}
 	transformationsTempDir string
 	httpClient             *http.Client
 	ws                     int

--- a/test/krenalistester/support.go
+++ b/test/krenalistester/support.go
@@ -28,7 +28,7 @@ var defaultStrategy Strategy = "Conversion"
 
 // This file contains support methods which reduce verbosity of tests.
 
-func (c *Meergo) AlterProfileSchema(schema types.Type, primarySources map[string]int, rePaths map[string]any) {
+func (c *Krenalis) AlterProfileSchema(schema types.Type, primarySources map[string]int, rePaths map[string]any) {
 	req := map[string]any{
 		"schema":         schema,
 		"primarySources": primarySources,
@@ -55,7 +55,7 @@ func (c *Meergo) AlterProfileSchema(schema types.Type, primarySources map[string
 
 // AlterProfileSchemaErr is like AlterProfileSchema but returns an error instead of
 // panicking.
-func (c *Meergo) AlterProfileSchemaErr(schema types.Type, primarySources map[string]int, rePaths map[string]any) error {
+func (c *Krenalis) AlterProfileSchemaErr(schema types.Type, primarySources map[string]int, rePaths map[string]any) error {
 	req := map[string]any{
 		"schema":         schema,
 		"primarySources": primarySources,
@@ -64,7 +64,7 @@ func (c *Meergo) AlterProfileSchemaErr(schema types.Type, primarySources map[str
 	return c.Call("PUT", "/v1/profiles/schema", req, nil)
 }
 
-func (c *Meergo) AbsolutePath(storage int, path string) string {
+func (c *Krenalis) AbsolutePath(storage int, path string) string {
 	var response struct {
 		Path string `json:"path"`
 	}
@@ -76,7 +76,7 @@ func (c *Meergo) AbsolutePath(storage int, path string) string {
 	return response.Path
 }
 
-func (c *Meergo) PipelineSchemas(conn int, target core.Target, eventType string) map[string]any {
+func (c *Krenalis) PipelineSchemas(conn int, target core.Target, eventType string) map[string]any {
 	path := fmt.Sprintf("/v1/connections/%d/pipelines/schemas/%s", conn, target)
 	if eventType != "" {
 		path += "?type=" + url.QueryEscape(eventType)
@@ -86,7 +86,7 @@ func (c *Meergo) PipelineSchemas(conn int, target core.Target, eventType string)
 	return schemas
 }
 
-func (c *Meergo) ConnectionIdentities(conn, first, limit int) ([]Identity, int) {
+func (c *Krenalis) ConnectionIdentities(conn, first, limit int) ([]Identity, int) {
 	var response struct {
 		Identities []Identity `json:"identities"`
 		Total      int        `json:"total"`
@@ -96,14 +96,14 @@ func (c *Meergo) ConnectionIdentities(conn, first, limit int) ([]Identity, int) 
 	return response.Identities, response.Total
 }
 
-func (c *Meergo) ConnectionUI(connection int) map[string]any {
+func (c *Krenalis) ConnectionUI(connection int) map[string]any {
 	path := fmt.Sprintf("/v1/connections/%d/ui", connection)
 	var ui map[string]any
 	c.MustCall("GET", path, nil, &ui)
 	return ui
 }
 
-func (c *Meergo) CreatePipeline(conn int, target string, pipeline PipelineToSet) int {
+func (c *Krenalis) CreatePipeline(conn int, target string, pipeline PipelineToSet) int {
 	switch target {
 	case "Event", "User", "Group":
 	default:
@@ -129,7 +129,7 @@ func (c *Meergo) CreatePipeline(conn int, target string, pipeline PipelineToSet)
 
 // CreatePipelineErr is like CreatePipeline but returns an error instead of
 // panicking.
-func (c *Meergo) CreatePipelineErr(conn int, target string, pipeline PipelineToSet) (int, error) {
+func (c *Krenalis) CreatePipelineErr(conn int, target string, pipeline PipelineToSet) (int, error) {
 	switch target {
 	case "Event", "User", "Group":
 	default:
@@ -174,7 +174,7 @@ var DefaultFilterUserFromEvents = &Filter{
 	},
 }
 
-func (c *Meergo) CreateConnection(connection ConnectionToCreate) int {
+func (c *Krenalis) CreateConnection(connection ConnectionToCreate) int {
 	var response struct {
 		ID int `json:"id"`
 	}
@@ -182,7 +182,7 @@ func (c *Meergo) CreateConnection(connection ConnectionToCreate) int {
 	return response.ID
 }
 
-func (c *Meergo) CreateDestinationFilesystem() int {
+func (c *Krenalis) CreateDestinationFilesystem() int {
 	return c.CreateConnection(ConnectionToCreate{
 		Name:      "File System",
 		Role:      Destination,
@@ -193,7 +193,7 @@ func (c *Meergo) CreateDestinationFilesystem() int {
 	})
 }
 
-func (c *Meergo) CreateDestinationPostgreSQL() int {
+func (c *Krenalis) CreateDestinationPostgreSQL() int {
 	return c.CreateConnection(ConnectionToCreate{
 		Name:      "PostgreSQL (destination)",
 		Role:      Destination,
@@ -209,7 +209,7 @@ func (c *Meergo) CreateDestinationPostgreSQL() int {
 	})
 }
 
-func (c *Meergo) CreateDummy(name string, role Role) int {
+func (c *Krenalis) CreateDummy(name string, role Role) int {
 	conn := ConnectionToCreate{
 		Name:      name,
 		Role:      role,
@@ -223,7 +223,7 @@ func (c *Meergo) CreateDummy(name string, role Role) int {
 	return c.CreateConnection(conn)
 }
 
-func (c *Meergo) CreateDummyWithSettings(name string, role Role, settings DummySettings) int {
+func (c *Krenalis) CreateDummyWithSettings(name string, role Role, settings DummySettings) int {
 	conn := ConnectionToCreate{
 		Name:      name,
 		Role:      role,
@@ -237,7 +237,7 @@ func (c *Meergo) CreateDummyWithSettings(name string, role Role, settings DummyS
 	return c.CreateConnection(conn)
 }
 
-func (c *Meergo) CreateEventPipeline(conn int, eventType string, pipeline PipelineToSet) int {
+func (c *Krenalis) CreateEventPipeline(conn int, eventType string, pipeline PipelineToSet) int {
 	pipelineJSON, err := stdjson.Marshal(pipeline)
 	if err != nil {
 		panic(err)
@@ -257,7 +257,7 @@ func (c *Meergo) CreateEventPipeline(conn int, eventType string, pipeline Pipeli
 	return response.ID
 }
 
-func (c *Meergo) CreateWebhookSource(name string, linkedConnections []int) int {
+func (c *Krenalis) CreateWebhookSource(name string, linkedConnections []int) int {
 	return c.CreateConnection(ConnectionToCreate{
 		Name:              name,
 		Role:              Source,
@@ -266,7 +266,7 @@ func (c *Meergo) CreateWebhookSource(name string, linkedConnections []int) int {
 	})
 }
 
-func (c *Meergo) CreateJavaScriptSource(name string, linkedConnections []int) int {
+func (c *Krenalis) CreateJavaScriptSource(name string, linkedConnections []int) int {
 	return c.CreateConnection(ConnectionToCreate{
 		Name:              name,
 		Role:              Source,
@@ -276,7 +276,7 @@ func (c *Meergo) CreateJavaScriptSource(name string, linkedConnections []int) in
 	})
 }
 
-func (c *Meergo) CreateSourceFileSystem() int {
+func (c *Krenalis) CreateSourceFileSystem() int {
 	return c.CreateConnection(ConnectionToCreate{
 		Name:      "File System",
 		Role:      Source,
@@ -287,7 +287,7 @@ func (c *Meergo) CreateSourceFileSystem() int {
 	})
 }
 
-func (c *Meergo) CreateSourcePostgreSQL() int {
+func (c *Krenalis) CreateSourcePostgreSQL() int {
 	return c.CreateConnection(ConnectionToCreate{
 		Name:      "PostgreSQL (destination)",
 		Role:      Source,
@@ -303,12 +303,12 @@ func (c *Meergo) CreateSourcePostgreSQL() int {
 	})
 }
 
-func (c *Meergo) DeleteConnection(conn int) {
+func (c *Krenalis) DeleteConnection(conn int) {
 	path := fmt.Sprintf("/v1/connections/%d", conn)
 	c.MustCall("DELETE", path, nil, nil)
 }
 
-func (c *Meergo) RunPipeline(pipeline int) int {
+func (c *Krenalis) RunPipeline(pipeline int) int {
 	var response struct {
 		ID int
 	}
@@ -317,13 +317,13 @@ func (c *Meergo) RunPipeline(pipeline int) int {
 	return response.ID
 }
 
-func (c *Meergo) ExternalEventURL() string {
+func (c *Krenalis) ExternalEventURL() string {
 	var metadata map[string]any
 	c.MustCall("GET", "/v1/public/metadata", nil, &metadata)
 	return metadata["externalEventURL"].(string)
 }
 
-func (c *Meergo) Events(properties []string) []map[string]any {
+func (c *Krenalis) Events(properties []string) []map[string]any {
 	queryString := url.Values{
 		"properties": properties,
 		"first":      []string{"0"},
@@ -336,7 +336,7 @@ func (c *Meergo) Events(properties []string) []map[string]any {
 	return response.Events
 }
 
-func (c *Meergo) File(storage int, path, format, sheet string, compression Compression, settings json.Value, limit int) ([]map[string]any, types.Type) {
+func (c *Krenalis) File(storage int, path, format, sheet string, compression Compression, settings json.Value, limit int) ([]map[string]any, types.Type) {
 	queryString := url.Values{
 		"path":           []string{path},
 		"format":         []string{format},
@@ -354,13 +354,13 @@ func (c *Meergo) File(storage int, path, format, sheet string, compression Compr
 	return response.Records, response.Schema
 }
 
-func (c *Meergo) JavaScriptSDKURL() string {
+func (c *Krenalis) JavaScriptSDKURL() string {
 	var metadata map[string]any
 	c.MustCall("GET", "/v1/public/metadata", nil, &metadata)
 	return metadata["javascriptSDKURL"].(string)
 }
 
-func (c *Meergo) LatestAlterProfileSchema() (startTime, endTime *time.Time, alterError *string) {
+func (c *Krenalis) LatestAlterProfileSchema() (startTime, endTime *time.Time, alterError *string) {
 	var response struct {
 		StartTime *time.Time `json:"startTime"`
 		EndTime   *time.Time `json:"endTime"`
@@ -370,7 +370,7 @@ func (c *Meergo) LatestAlterProfileSchema() (startTime, endTime *time.Time, alte
 	return response.StartTime, response.EndTime, response.Error
 }
 
-func (c *Meergo) LatestIdentityResolution() (startTime, endTime *time.Time) {
+func (c *Krenalis) LatestIdentityResolution() (startTime, endTime *time.Time) {
 	var response struct {
 		StartTime *time.Time `json:"startTime"`
 		EndTime   *time.Time `json:"endTime"`
@@ -379,14 +379,14 @@ func (c *Meergo) LatestIdentityResolution() (startTime, endTime *time.Time) {
 	return response.StartTime, response.EndTime
 }
 
-func (c *Meergo) PipelineRun(id int) PipelineRun {
+func (c *Krenalis) PipelineRun(id int) PipelineRun {
 	var run PipelineRun
 	path := fmt.Sprintf("/v1/pipelines/runs/%d", id)
 	c.MustCall("GET", path, nil, &run)
 	return run
 }
 
-func (c *Meergo) PipelineRuns() []PipelineRun {
+func (c *Krenalis) PipelineRuns() []PipelineRun {
 	var response struct {
 		Runs []PipelineRun
 	}
@@ -394,7 +394,7 @@ func (c *Meergo) PipelineRuns() []PipelineRun {
 	return response.Runs
 }
 
-func (c *Meergo) PreviewAlterProfileSchema(schema types.Type, rePaths map[string]any) []string {
+func (c *Krenalis) PreviewAlterProfileSchema(schema types.Type, rePaths map[string]any) []string {
 	req := map[string]any{
 		"schema":  schema,
 		"rePaths": rePaths,
@@ -408,7 +408,7 @@ func (c *Meergo) PreviewAlterProfileSchema(schema types.Type, rePaths map[string
 
 // PreviewAlterProfileSchemaErr is like PreviewAlterProfileSchema but returns an
 // error instead of panicking.
-func (c *Meergo) PreviewAlterProfileSchemaErr(schema types.Type, rePaths map[string]any) ([]string, error) {
+func (c *Krenalis) PreviewAlterProfileSchemaErr(schema types.Type, rePaths map[string]any) ([]string, error) {
 	req := map[string]any{
 		"schema":  schema,
 		"rePaths": rePaths,
@@ -423,13 +423,13 @@ func (c *Meergo) PreviewAlterProfileSchemaErr(schema types.Type, rePaths map[str
 	return response.Queries, nil
 }
 
-func (c *Meergo) RepairWarehouse() {
+func (c *Krenalis) RepairWarehouse() {
 	c.MustCall("POST", "/v1/warehouse/repair", nil, nil)
 }
 
 // RunIdentityResolution starts the identity resolution and waits for it to
 // complete.
-func (c *Meergo) RunIdentityResolution() {
+func (c *Krenalis) RunIdentityResolution() {
 	ts := time.Now().UTC()
 	c.MustCall("POST", "/v1/identity-resolution/start", nil, nil)
 	// Waits for the Identity Resolution that was started following the call to
@@ -446,7 +446,7 @@ func (c *Meergo) RunIdentityResolution() {
 	}
 }
 
-func (c *Meergo) SendEvent(writeKey string, message analytics.Message) {
+func (c *Krenalis) SendEvent(writeKey string, message analytics.Message) {
 	endpoint := "http://" + c.Addr() + "/v1/events"
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -491,7 +491,7 @@ func (s sendEventCallback) Failure(msg analytics.Message, err error) {
 	s.ch <- err
 }
 
-func (c *Meergo) Sheets(storage int, path string, format string, compression Compression, settings json.Value) []string {
+func (c *Krenalis) Sheets(storage int, path string, format string, compression Compression, settings json.Value) []string {
 	queryString := url.Values{
 		"path":           []string{path},
 		"format":         []string{format},
@@ -506,7 +506,7 @@ func (c *Meergo) Sheets(storage int, path string, format string, compression Com
 	return response.Sheets
 }
 
-func (c *Meergo) TableSchema(conn int, table string) (types.Type, []string) {
+func (c *Krenalis) TableSchema(conn int, table string) (types.Type, []string) {
 	var response struct {
 		Schema types.Type `json:"schema"`
 		Issues []string   `json:"issues"`
@@ -519,14 +519,14 @@ func (c *Meergo) TableSchema(conn int, table string) (types.Type, []string) {
 	return response.Schema, response.Issues
 }
 
-func (c *Meergo) TestWarehouseUpdate(settings json.Value) {
+func (c *Krenalis) TestWarehouseUpdate(settings json.Value) {
 	body := map[string]any{
 		"settings": settings,
 	}
 	c.MustCall("PUT", "/v1/warehouse/test", body, nil)
 }
 
-func (c *Meergo) TestWorkspaceCreation(name string, profileSchema types.Type,
+func (c *Krenalis) TestWorkspaceCreation(name string, profileSchema types.Type,
 	uiPreferences UIPreferences, whPlatform string, whSettings json.Value, mode WarehouseMode) error {
 	body := map[string]any{
 		"name":          name,
@@ -541,12 +541,12 @@ func (c *Meergo) TestWorkspaceCreation(name string, profileSchema types.Type,
 	return c.Call("POST", "/v1/workspaces/test", body, nil)
 }
 
-func (c *Meergo) UpdatePipeline(pipelineID int, pipeline PipelineToSet) {
+func (c *Krenalis) UpdatePipeline(pipelineID int, pipeline PipelineToSet) {
 	path := fmt.Sprintf("/v1/pipelines/%d", pipelineID)
 	c.MustCall("PUT", path, pipeline, nil)
 }
 
-func (c *Meergo) UpdateIdentityResolution(runOnBatchImport bool, identifiers []string) {
+func (c *Krenalis) UpdateIdentityResolution(runOnBatchImport bool, identifiers []string) {
 	body := map[string]any{
 		"runOnBatchImport": runOnBatchImport,
 		"identifiers":      identifiers,
@@ -554,14 +554,14 @@ func (c *Meergo) UpdateIdentityResolution(runOnBatchImport bool, identifiers []s
 	c.MustCall("PUT", "/v1/identity-resolution/settings", body, nil)
 }
 
-func (c *Meergo) UpdateIdentityResolutionErr(identifiers []string) error {
+func (c *Krenalis) UpdateIdentityResolutionErr(identifiers []string) error {
 	body := map[string]any{
 		"identifiers": identifiers,
 	}
 	return c.Call("PUT", "/v1/identity-resolution/settings", body, nil)
 }
 
-func (c *Meergo) UpdateWarehouse(mode string, settings json.Value) {
+func (c *Krenalis) UpdateWarehouse(mode string, settings json.Value) {
 	body := map[string]any{
 		"mode":     mode,
 		"settings": settings,
@@ -569,7 +569,7 @@ func (c *Meergo) UpdateWarehouse(mode string, settings json.Value) {
 	c.MustCall("PUT", "/v1/warehouse", body, nil)
 }
 
-func (c *Meergo) ProfileEvents(mpid uuid.UUID, properties []string) []map[string]any {
+func (c *Krenalis) ProfileEvents(mpid uuid.UUID, properties []string) []map[string]any {
 	queryString := url.Values{
 		"properties": properties,
 		"first":      []string{"0"},
@@ -595,7 +595,7 @@ func (c *Meergo) ProfileEvents(mpid uuid.UUID, properties []string) []map[string
 	return response.Events
 }
 
-func (c *Meergo) Identities(mpid uuid.UUID, first, limit int) ([]Identity, int) {
+func (c *Krenalis) Identities(mpid uuid.UUID, first, limit int) ([]Identity, int) {
 	var response struct {
 		Identities []Identity `json:"identities"`
 		Total      int        `json:"total"`
@@ -605,13 +605,13 @@ func (c *Meergo) Identities(mpid uuid.UUID, first, limit int) ([]Identity, int) 
 	return response.Identities, response.Total
 }
 
-func (c *Meergo) ProfilePropertiesSuitableAsIdentifiers() types.Type {
+func (c *Krenalis) ProfilePropertiesSuitableAsIdentifiers() types.Type {
 	var schema types.Type
 	c.MustCall("GET", "/v1/profiles/schema/suitable-as-identifiers", nil, &schema)
 	return schema
 }
 
-func (c *Meergo) Profiles(properties []string, order string, orderDesc bool, first, limit int) (users []Profile, schema types.Type, total int) {
+func (c *Krenalis) Profiles(properties []string, order string, orderDesc bool, first, limit int) (users []Profile, schema types.Type, total int) {
 	queryString := url.Values{
 		"properties": properties,
 		"order":      []string{order},
@@ -628,7 +628,7 @@ func (c *Meergo) Profiles(properties []string, order string, orderDesc bool, fir
 	return response.Profiles, response.Schema, response.Total
 }
 
-func (c *Meergo) WaitEventsStoredIntoWarehouse(ctx context.Context, expected int) {
+func (c *Krenalis) WaitEventsStoredIntoWarehouse(ctx context.Context, expected int) {
 	bo := backoff.New(200)
 	bo.SetAttempts(20)
 	bo.SetCap(2 * time.Second)
@@ -651,7 +651,7 @@ func (c *Meergo) WaitEventsStoredIntoWarehouse(ctx context.Context, expected int
 //
 // If you intend to proceed even in the case of one or more "Failed" (but not an
 // error for the entire run), see the method WaitForRunsCompletionAllowFailed.
-func (c *Meergo) WaitRunsCompletion(conn int, runs ...int) {
+func (c *Krenalis) WaitRunsCompletion(conn int, runs ...int) {
 	c.waitForRunsCompletion(false, runs...)
 }
 
@@ -662,11 +662,11 @@ func (c *Meergo) WaitRunsCompletion(conn int, runs ...int) {
 //
 // If you want the method to result in an error even in the case of one or more
 // "Failed", see the method WaitForRunsCompletion.
-func (c *Meergo) WaitForRunsCompletionAllowFailed(conn int, runs ...int) {
+func (c *Krenalis) WaitForRunsCompletionAllowFailed(conn int, runs ...int) {
 	c.waitForRunsCompletion(true, runs...)
 }
 
-func (c *Meergo) EventWriteKeys(conn int) []string {
+func (c *Krenalis) EventWriteKeys(conn int) []string {
 	var res struct {
 		Keys []string `json:"keys"`
 	}
@@ -675,13 +675,13 @@ func (c *Meergo) EventWriteKeys(conn int) []string {
 	return res.Keys
 }
 
-func (c *Meergo) Workspace() Workspace {
+func (c *Krenalis) Workspace() Workspace {
 	var ws Workspace
 	c.MustCall("GET", "/v1/workspaces/current", nil, &ws)
 	return ws
 }
 
-func (c *Meergo) waitForRunsCompletion(allowFailed bool, ids ...int) {
+func (c *Krenalis) waitForRunsCompletion(allowFailed bool, ids ...int) {
 	time.Sleep(500 * time.Millisecond)
 	for {
 		if len(ids) == 1 {

--- a/test/parquet_import_test.go
+++ b/test/parquet_import_test.go
@@ -31,7 +31,7 @@ func TestParquetImport(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.PopulateProfileSchema(false)
 	c.SetFileSystemRoot(storageDir)
 	c.Start()

--- a/test/parquet_test_apache_files_test.go
+++ b/test/parquet_test_apache_files_test.go
@@ -32,7 +32,7 @@ func TestParquetTestApacheFiles(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.PopulateProfileSchema(false)
 	c.SetFileSystemRoot(storageDir)
 	c.Start()

--- a/test/pipelines_creation_test.go
+++ b/test/pipelines_creation_test.go
@@ -39,7 +39,7 @@ func TestPipelinesCreation(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storageDir)
 	c.Start()
 	defer c.Stop()

--- a/test/reimport_test.go
+++ b/test/reimport_test.go
@@ -18,7 +18,7 @@ func TestReimport(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/remove_users_when_deleting_connections_test.go
+++ b/test/remove_users_when_deleting_connections_test.go
@@ -18,7 +18,7 @@ func Test_RemoveUsersWhenDeletingConnections(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/repair_test.go
+++ b/test/repair_test.go
@@ -16,7 +16,7 @@ func TestRepair(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/source_app_users_filtering_test.go
+++ b/test/source_app_users_filtering_test.go
@@ -17,7 +17,7 @@ func TestSourceAppUsersFiltering(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/source_file_storage_users_filtering_test.go
+++ b/test/source_file_storage_users_filtering_test.go
@@ -24,7 +24,7 @@ func TestSourceFileStorageUsersFiltering(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storageDir)
 	c.Start()
 	defer c.Stop()

--- a/test/storage_test.go
+++ b/test/storage_test.go
@@ -36,7 +36,7 @@ func TestStorage(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storageDir)
 	c.Start()
 	defer c.Stop()

--- a/test/test_same_identity_from_two_pipelines_test.go
+++ b/test/test_same_identity_from_two_pipelines_test.go
@@ -17,7 +17,7 @@ func TestSameIdentityFromTwoPipelines(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/transformation2_test.go
+++ b/test/transformation2_test.go
@@ -20,7 +20,7 @@ func TestTransformation2(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/transformation_test.go
+++ b/test/transformation_test.go
@@ -18,7 +18,7 @@ func TestImportWithTransformation(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/user_identities_from_events_test.go
+++ b/test/user_identities_from_events_test.go
@@ -21,7 +21,7 @@ func TestIdentitiesFromEvents(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/user_identities_test.go
+++ b/test/user_identities_test.go
@@ -25,7 +25,7 @@ func Test_Identities(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.SetFileSystemRoot(storageDir)
 	c.Start()
 	defer c.Stop()

--- a/test/user_properties_suitable_as_identifiers_test.go
+++ b/test/user_properties_suitable_as_identifiers_test.go
@@ -16,7 +16,7 @@ func TestProfilePropertiesSuitableAsIdentifiers(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/warehouse_test.go
+++ b/test/warehouse_test.go
@@ -17,7 +17,7 @@ func TestWarehouse(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/test/workspace_identifiers_test.go
+++ b/test/workspace_identifiers_test.go
@@ -16,7 +16,7 @@ func Test_WorkspaceIdentifiers(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	c := krenalistester.NewMeergoInstance(t)
+	c := krenalistester.NewKrenalisInstance(t)
 	c.Start()
 	defer c.Stop()
 

--- a/warehouses/postgresql/warehouse_test.go
+++ b/warehouses/postgresql/warehouse_test.go
@@ -33,8 +33,8 @@ const (
 func Test_Merge(t *testing.T) {
 
 	cols := []struct {
-		MeergoType  types.Type
-		MeergoValue any
+		KrenalisType  types.Type
+		KrenalisValue any
 	}{
 		{types.String(), "foo"},
 		{types.Boolean(), true},
@@ -92,7 +92,7 @@ func Test_Merge(t *testing.T) {
 	for i, c := range cols {
 		table.Columns[i] = warehouses.Column{
 			Name:     fmt.Sprintf("c%d", i),
-			Type:     c.MeergoType,
+			Type:     c.KrenalisType,
 			Nullable: true,
 		}
 	}
@@ -160,7 +160,7 @@ func Test_Merge(t *testing.T) {
 		}
 		create.WriteString(quoteIdent(c.Name))
 		create.WriteByte(' ')
-		create.WriteString(typeToPostgresType(cols[i].MeergoType))
+		create.WriteString(typeToPostgresType(cols[i].KrenalisType))
 		if i == 0 {
 			create.WriteString(" PRIMARY KEY")
 		}
@@ -180,12 +180,12 @@ func Test_Merge(t *testing.T) {
 	// Merge the values.
 	row1 := make([]any, len(table.Columns))
 	for i := range table.Columns {
-		row1[i] = cols[i].MeergoValue
+		row1[i] = cols[i].KrenalisValue
 	}
 	row2 := make([]any, len(table.Columns))
 	for i := range table.Columns {
 		if i == 0 {
-			row2[i] = cols[0].MeergoValue.(string) + "2"
+			row2[i] = cols[0].KrenalisValue.(string) + "2"
 			continue
 		}
 		row2[i] = nil
@@ -219,56 +219,56 @@ func Test_Merge(t *testing.T) {
 	}
 	for i, got := range row {
 		c := cols[i]
-		switch c.MeergoType.Kind() {
+		switch c.KrenalisType.Kind() {
 		case types.JSONKind:
 			v, ok := got.(json.Value)
 			if !ok {
-				t.Fatalf("type %s: expected a json.Value value, got %#v (type %T)", c.MeergoType, got, got)
+				t.Fatalf("type %s: expected a json.Value value, got %#v (type %T)", c.KrenalisType, got, got)
 			}
 			v, err = json.Compact(v)
 			if err != nil {
-				t.Fatalf("type %s: cannot compact JSON value %#v", c.MeergoType, got)
+				t.Fatalf("type %s: cannot compact JSON value %#v", c.KrenalisType, got)
 			}
 			got = v
 		case types.ArrayKind:
-			if c.MeergoType.Elem().Kind() == types.JSONKind {
+			if c.KrenalisType.Elem().Kind() == types.JSONKind {
 				elements, ok := got.([]any)
 				if !ok {
-					t.Fatalf("type %s: expected a []any value, got %#v (type %T)", c.MeergoType, got, got)
+					t.Fatalf("type %s: expected a []any value, got %#v (type %T)", c.KrenalisType, got, got)
 				}
 				for i, element := range elements {
 					v, ok := element.(json.Value)
 					if !ok {
-						t.Fatalf("type %s: expected a json.Value element, got %#v (type %T)", c.MeergoType, element, element)
+						t.Fatalf("type %s: expected a json.Value element, got %#v (type %T)", c.KrenalisType, element, element)
 					}
 					v, err = json.Compact(v)
 					if err != nil {
-						t.Fatalf("type %s: cannot compact JSON value %#v", c.MeergoType, got)
+						t.Fatalf("type %s: cannot compact JSON value %#v", c.KrenalisType, got)
 					}
 					elements[i] = v
 				}
 			}
 		case types.MapKind:
-			if c.MeergoType.Elem().Kind() == types.JSONKind {
+			if c.KrenalisType.Elem().Kind() == types.JSONKind {
 				elements, ok := got.(map[string]any)
 				if !ok {
-					t.Fatalf("type %s: expected a map[string]any value, got %#v (type %T)", c.MeergoType, got, got)
+					t.Fatalf("type %s: expected a map[string]any value, got %#v (type %T)", c.KrenalisType, got, got)
 				}
 				for key, value := range elements {
 					v, ok := value.(json.Value)
 					if !ok {
-						t.Fatalf("type %s: expected a json.Value element, got %#v (type %T)", c.MeergoType, value, value)
+						t.Fatalf("type %s: expected a json.Value element, got %#v (type %T)", c.KrenalisType, value, value)
 					}
 					v, err = json.Compact(v)
 					if err != nil {
-						t.Fatalf("type %s: cannot compact JSON value %#v", c.MeergoType, got)
+						t.Fatalf("type %s: cannot compact JSON value %#v", c.KrenalisType, got)
 					}
 					elements[key] = v
 				}
 			}
 		}
-		if !cmp.Equal(c.MeergoValue, got) {
-			t.Fatalf("type %s: expected %#v (type %T), got %#v (type %T)", c.MeergoType, c.MeergoValue, c.MeergoValue, got, got)
+		if !cmp.Equal(c.KrenalisValue, got) {
+			t.Fatalf("type %s: expected %#v (type %T), got %#v (type %T)", c.KrenalisType, c.KrenalisValue, c.KrenalisValue, got, got)
 		}
 	}
 	if !rows.Next() {
@@ -284,7 +284,7 @@ func Test_Merge(t *testing.T) {
 		}
 		c := cols[i]
 		if got != nil {
-			t.Fatalf("type %s: expected nil, got %#v (type %T)", c.MeergoType, got, got)
+			t.Fatalf("type %s: expected nil, got %#v (type %T)", c.KrenalisType, got, got)
 		}
 	}
 	if rows.Next() {

--- a/warehouses/snowflake/warehouse_test.go
+++ b/warehouses/snowflake/warehouse_test.go
@@ -25,8 +25,8 @@ const settingsEnvKey = "KRENALIS_TEST_PATH_SNOWFLAKE"
 func Test_Merge(t *testing.T) {
 
 	cols := []struct {
-		MeergoType  types.Type
-		MeergoValue any
+		KrenalisType  types.Type
+		KrenalisValue any
 	}{
 		{types.String(), "foo"},
 		{types.Boolean(), true},
@@ -84,7 +84,7 @@ func Test_Merge(t *testing.T) {
 	for i, c := range cols {
 		table.Columns[i] = warehouses.Column{
 			Name:     fmt.Sprintf("c%d", i),
-			Type:     c.MeergoType,
+			Type:     c.KrenalisType,
 			Nullable: true,
 		}
 	}
@@ -117,7 +117,7 @@ func Test_Merge(t *testing.T) {
 		}
 		create.WriteString(quoteIdent(c.Name))
 		create.WriteByte(' ')
-		create.WriteString(typeToSnowflakeType(cols[i].MeergoType))
+		create.WriteString(typeToSnowflakeType(cols[i].KrenalisType))
 	}
 	create.WriteString("\n)")
 	_, err = db.ExecContext(context.Background(), create.String())
@@ -134,7 +134,7 @@ func Test_Merge(t *testing.T) {
 	// Merge the values.
 	row1 := make([]any, len(table.Columns))
 	for i := range table.Columns {
-		row1[i] = cols[i].MeergoValue
+		row1[i] = cols[i].KrenalisValue
 	}
 	row2 := make([]any, len(table.Columns))
 	for i := range table.Columns {
@@ -169,56 +169,56 @@ func Test_Merge(t *testing.T) {
 	}
 	for i, got := range row {
 		c := cols[i]
-		switch c.MeergoType.Kind() {
+		switch c.KrenalisType.Kind() {
 		case types.JSONKind:
 			v, ok := got.(json.Value)
 			if !ok {
-				t.Fatalf("type %s: expected a json.Value value, got %#v (type %T)", c.MeergoType, got, got)
+				t.Fatalf("type %s: expected a json.Value value, got %#v (type %T)", c.KrenalisType, got, got)
 			}
 			v, err = json.Compact(v)
 			if err != nil {
-				t.Fatalf("type %s: cannot compact JSON value %#v", c.MeergoType, got)
+				t.Fatalf("type %s: cannot compact JSON value %#v", c.KrenalisType, got)
 			}
 			got = v
 		case types.ArrayKind:
-			if c.MeergoType.Elem().Kind() == types.JSONKind {
+			if c.KrenalisType.Elem().Kind() == types.JSONKind {
 				elements, ok := got.([]any)
 				if !ok {
-					t.Fatalf("type %s: expected a []any value, got %#v (type %T)", c.MeergoType, got, got)
+					t.Fatalf("type %s: expected a []any value, got %#v (type %T)", c.KrenalisType, got, got)
 				}
 				for i, element := range elements {
 					v, ok := element.(json.Value)
 					if !ok {
-						t.Fatalf("type %s: expected a json.Value element, got %#v (type %T)", c.MeergoType, element, element)
+						t.Fatalf("type %s: expected a json.Value element, got %#v (type %T)", c.KrenalisType, element, element)
 					}
 					v, err = json.Compact(v)
 					if err != nil {
-						t.Fatalf("type %s: cannot compact JSON value %#v", c.MeergoType, got)
+						t.Fatalf("type %s: cannot compact JSON value %#v", c.KrenalisType, got)
 					}
 					elements[i] = v
 				}
 			}
 		case types.MapKind:
-			if c.MeergoType.Elem().Kind() == types.JSONKind {
+			if c.KrenalisType.Elem().Kind() == types.JSONKind {
 				elements, ok := got.(map[string]any)
 				if !ok {
-					t.Fatalf("type %s: expected a map[string]any value, got %#v (type %T)", c.MeergoType, got, got)
+					t.Fatalf("type %s: expected a map[string]any value, got %#v (type %T)", c.KrenalisType, got, got)
 				}
 				for key, value := range elements {
 					v, ok := value.(json.Value)
 					if !ok {
-						t.Fatalf("type %s: expected a json.Value element, got %#v (type %T)", c.MeergoType, value, value)
+						t.Fatalf("type %s: expected a json.Value element, got %#v (type %T)", c.KrenalisType, value, value)
 					}
 					v, err = json.Compact(v)
 					if err != nil {
-						t.Fatalf("type %s: cannot compact JSON value %#v", c.MeergoType, got)
+						t.Fatalf("type %s: cannot compact JSON value %#v", c.KrenalisType, got)
 					}
 					elements[key] = v
 				}
 			}
 		}
-		if !cmp.Equal(c.MeergoValue, got) {
-			t.Fatalf("type %s: expected %#v (type %T), got %#v (type %T)", c.MeergoType, c.MeergoValue, c.MeergoValue, got, got)
+		if !cmp.Equal(c.KrenalisValue, got) {
+			t.Fatalf("type %s: expected %#v (type %T), got %#v (type %T)", c.KrenalisType, c.KrenalisValue, c.KrenalisValue, got, got)
 		}
 	}
 	if !rows.Next() {
@@ -234,7 +234,7 @@ func Test_Merge(t *testing.T) {
 		}
 		c := cols[i]
 		if got != nil {
-			t.Fatalf("type %s: expected nil, got %#v (type %T)", c.MeergoType, got, got)
+			t.Fatalf("type %s: expected nil, got %#v (type %T)", c.KrenalisType, got, got)
 		}
 	}
 	if rows.Next() {


### PR DESCRIPTION
## Commit message

```
all: rename Go declarations from "meergo" to "krenalis"

This change should affect all Go declarations (constants, variables,
functions, etc.) that reference "meergo", changing their names to
"krenalis".

Of course, some of them may have been overlooked, but that's not a
problem since subsequent commits will search for all occurrences of
"meergo" in the repository. This commit is just a further step.
```