### PR TITLE
connectors/hubspot: use Legacy Apps tokens instead of OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,10 +85,6 @@ KRENALIS_TRANSFORMERS_LOCAL_FUNCTIONS_DIR=""
 KRENALIS_TRANSFORMERS_LOCAL_SUDO_USER=""
 KRENALIS_TRANSFORMERS_LOCAL_DOAS_USER=""
 
-# OAuth configuration for Hubspot.
-KRENALIS_OAUTH_HUBSPOT_CLIENT_ID=""      # OAuth client ID for HubSpot.
-KRENALIS_OAUTH_HUBSPOT_CLIENT_SECRET=""  # OAuth client secret for HubSpot.
-
 # OAuth configuration for Mailchimp.
 KRENALIS_OAUTH_MAILCHIMP_CLIENT_ID=""      # OAuth client ID for Mailchimp.
 KRENALIS_OAUTH_MAILCHIMP_CLIENT_SECRET=""  # OAuth client secret for Mailchimp.

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -379,20 +379,6 @@ func parseEnvSettings() (*Settings, error) {
 		return nil, fmt.Errorf("KRENALIS_PROMETHEUS_METRICS_ENABLED must be a boolean: %s", err)
 	}
 
-	if id := envVars.Get("KRENALIS_OAUTH_HUBSPOT_CLIENT_ID"); id != "" {
-		secret := envVars.Get("KRENALIS_OAUTH_HUBSPOT_CLIENT_SECRET")
-		if secret == "" {
-			return nil, fmt.Errorf("KRENALIS_OAUTH_HUBSPOT_CLIENT_SECRET is required when KRENALIS_OAUTH_HUBSPOT_CLIENT_ID is set")
-		}
-		settings.OAuthCredentials = map[string]*core.OAuthCredentials{
-			"hubspot": {
-				ClientID:     id,
-				ClientSecret: secret,
-			}}
-	} else if secret := envVars.Get("KRENALIS_OAUTH_HUBSPOT_CLIENT_SECRET"); secret != "" {
-		return nil, fmt.Errorf("KRENALIS_OAUTH_HUBSPOT_CLIENT_ID is required when KRENALIS_OAUTH_HUBSPOT_CLIENT_SECRET is set")
-	}
-
 	if id := envVars.Get("KRENALIS_OAUTH_MAILCHIMP_CLIENT_ID"); id != "" {
 		secret := envVars.Get("KRENALIS_OAUTH_MAILCHIMP_CLIENT_SECRET")
 		if secret == "" {

--- a/cmd/settings_test.go
+++ b/cmd/settings_test.go
@@ -1362,29 +1362,16 @@ func TestParseSettings(t *testing.T) {
 		}
 	})
 
-	t.Run("OAuth HubSpot and Mailchimp combinations", func(t *testing.T) {
-		// HubSpot ID without secret -> error.
-		setBaseline(t)
-		t.Setenv("KRENALIS_OAUTH_HUBSPOT_CLIENT_ID", "id")
-		_, err := parseEnvSettings()
-		if err == nil {
-			t.Fatalf("expected error for HubSpot ID without secret, got nil")
-		}
-		want := "KRENALIS_OAUTH_HUBSPOT_CLIENT_SECRET is required when KRENALIS_OAUTH_HUBSPOT_CLIENT_ID is set"
-		if err.Error() != want {
-			t.Fatalf("expected %q, got %q", want, err)
-		}
+	t.Run("OAuth Mailchimp combinations", func(t *testing.T) {
 
-		// HubSpot valid, Mailchimp missing secret -> error.
+		//  Mailchimp missing secret -> error.
 		setBaseline(t)
-		t.Setenv("KRENALIS_OAUTH_HUBSPOT_CLIENT_ID", "id")
-		t.Setenv("KRENALIS_OAUTH_HUBSPOT_CLIENT_SECRET", "sec")
 		t.Setenv("KRENALIS_OAUTH_MAILCHIMP_CLIENT_ID", "mcid")
-		_, err = parseEnvSettings()
+		_, err := parseEnvSettings()
 		if err == nil {
 			t.Fatalf("expected error for Mailchimp ID without secret, got nil")
 		}
-		want = "KRENALIS_OAUTH_MAILCHIMP_CLIENT_SECRET is required when KRENALIS_OAUTH_MAILCHIMP_CLIENT_ID is set"
+		want := "KRENALIS_OAUTH_MAILCHIMP_CLIENT_SECRET is required when KRENALIS_OAUTH_MAILCHIMP_CLIENT_ID is set"
 		if err.Error() != want {
 			t.Fatalf("expected %q, got %q", want, err)
 		}
@@ -1404,8 +1391,6 @@ func TestParseSettings(t *testing.T) {
 
 		// Both valid.
 		setBaseline(t)
-		t.Setenv("KRENALIS_OAUTH_HUBSPOT_CLIENT_ID", "id")
-		t.Setenv("KRENALIS_OAUTH_HUBSPOT_CLIENT_SECRET", "sec")
 		t.Setenv("KRENALIS_OAUTH_MAILCHIMP_CLIENT_ID", "mcid")
 		t.Setenv("KRENALIS_OAUTH_MAILCHIMP_CLIENT_SECRET", "msec")
 		s, err := parseEnvSettings()

--- a/cmd/settings_test.go
+++ b/cmd/settings_test.go
@@ -1362,7 +1362,7 @@ func TestParseSettings(t *testing.T) {
 		}
 	})
 
-	t.Run("OAuth Mailchimp combinations", func(t *testing.T) {
+	t.Run("OAuth Mailchimp", func(t *testing.T) {
 
 		//  Mailchimp missing secret -> error.
 		setBaseline(t)
@@ -1397,8 +1397,8 @@ func TestParseSettings(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if s.OAuthCredentials == nil || s.OAuthCredentials["hubspot"] == nil || s.OAuthCredentials["mailchimp"] == nil {
-			t.Fatalf("expected both OAuth connectors present, got %#v", s.OAuthCredentials)
+		if s.OAuthCredentials == nil || s.OAuthCredentials["mailchimp"] == nil {
+			t.Fatalf("expected both mailchimp connector present, got %#v", s.OAuthCredentials)
 		}
 	})
 }

--- a/connectors/hubspot/documentation/destination/overview.md
+++ b/connectors/hubspot/documentation/destination/overview.md
@@ -17,7 +17,7 @@ Using this connector you can create and update unified Krenalis users from your 
 3. Click **Create legacy app app**.
 4. When HubSpots asks you *What kind of legacy app do you want to create?*, click **Private**
 5. In the **Basic Info** tab, give the app a name (e.g. "Krenalis").
-6. Go to the **Scopes** tab and add: `crm.objects.contacts.read`, `crm.schemas.contacts.read`.
+6. Go to the **Scopes** tab and add: `crm.objects.contacts.read`, `crm.objects.contacts.write` and `crm.schemas.contacts.read`.
 7. Click **Create app** in the top right and confirm.
 8. In the **Auth** tab of the app details page, in the section **Access token**, click **Show token**, then **Copy**.
 

--- a/connectors/hubspot/documentation/destination/overview.md
+++ b/connectors/hubspot/documentation/destination/overview.md
@@ -8,8 +8,18 @@ Using this connector you can create and update unified Krenalis users from your 
 ## What does it require?
 
 * An account with [HubSpot](https://www.hubspot.com/).
-* A [HubSpot developer account](https://developers.hubspot.com/).
-* The ability to set environment variables when starting Krenalis.
+* A HubSpot private app access token with the `crm.objects.contacts.read`, `crm.objects.contacts.write`, and `crm.schemas.contacts.read` scopes.
+
+## How to generate the access token
+
+1. In HubSpot, click the settings icon (⚙) in the top navigation bar.
+2. Go to **Integrations → Legacy Apps** in the left sidebar.
+3. Click **Create legacy app app**.
+4. When HubSpots asks you *What kind of legacy app do you want to create?*, click **Private**
+5. In the **Basic Info** tab, give the app a name (e.g. "Krenalis").
+6. Go to the **Scopes** tab and add: `crm.objects.contacts.read`, `crm.schemas.contacts.read`.
+7. Click **Create app** in the top right and confirm.
+8. In the **Auth** tab of the app details page, in the section **Access token**, click **Show token**, then **Copy**.
 
 > HubSpot is a trademark of HubSpot, Inc.
 > This connector is not affiliated with or endorsed by HubSpot, Inc.

--- a/connectors/hubspot/documentation/destination/overview.md
+++ b/connectors/hubspot/documentation/destination/overview.md
@@ -10,16 +10,5 @@ Using this connector you can create and update unified Krenalis users from your 
 * An account with [HubSpot](https://www.hubspot.com/).
 * A HubSpot private app access token with the `crm.objects.contacts.read`, `crm.objects.contacts.write`, and `crm.schemas.contacts.read` scopes.
 
-## How to generate the access token
-
-1. In HubSpot, click the settings icon (⚙) in the top navigation bar.
-2. Go to **Integrations → Legacy Apps** in the left sidebar.
-3. Click **Create legacy app app**.
-4. When HubSpots asks you *What kind of legacy app do you want to create?*, click **Private**
-5. In the **Basic Info** tab, give the app a name (e.g. "Krenalis").
-6. Go to the **Scopes** tab and add: `crm.objects.contacts.read`, `crm.objects.contacts.write` and `crm.schemas.contacts.read`.
-7. Click **Create app** in the top right and confirm.
-8. In the **Auth** tab of the app details page, in the section **Access token**, click **Show token**, then **Copy**.
-
 > HubSpot is a trademark of HubSpot, Inc.
 > This connector is not affiliated with or endorsed by HubSpot, Inc.

--- a/connectors/hubspot/documentation/source/overview.md
+++ b/connectors/hubspot/documentation/source/overview.md
@@ -10,16 +10,5 @@ Using this connector you can read contacts from HubSpot, import them into your d
 * An account with [HubSpot](https://www.hubspot.com/).
 * A HubSpot private app access token with the `crm.objects.contacts.read` and `crm.schemas.contacts.read` scopes.
 
-## How to generate the access token
-
-1. In HubSpot, click the settings icon (⚙) in the top navigation bar.
-2. Go to **Integrations → Legacy Apps** in the left sidebar.
-3. Click **Create legacy app app**.
-4. When HubSpots asks you *What kind of legacy app do you want to create?*, click **Private**
-5. In the **Basic Info** tab, give the app a name (e.g. "Krenalis").
-6. Go to the **Scopes** tab and add: `crm.objects.contacts.read`, `crm.schemas.contacts.read`.
-7. Click **Create app** in the top right and confirm.
-8. In the **Auth** tab of the app details page, in the section **Access token**, click **Show token**, then **Copy**.
-
 > HubSpot is a trademark of HubSpot, Inc.
 > This connector is not affiliated with or endorsed by HubSpot, Inc.

--- a/connectors/hubspot/documentation/source/overview.md
+++ b/connectors/hubspot/documentation/source/overview.md
@@ -7,9 +7,19 @@ Using this connector you can read contacts from HubSpot, import them into your d
 
 ## What does it require?
 
-* Any [HubSpot](https://www.hubspot.com/) account.
-* A [HubSpot developer account](https://developers.hubspot.com/).
-* The ability to set environment variables when starting Krenalis.
+* An account with [HubSpot](https://www.hubspot.com/).
+* A HubSpot private app access token with the `crm.objects.contacts.read` and `crm.schemas.contacts.read` scopes.
+
+## How to generate the access token
+
+1. In HubSpot, click the settings icon (⚙) in the top navigation bar.
+2. Go to **Integrations → Legacy Apps** in the left sidebar.
+3. Click **Create legacy app app**.
+4. When HubSpots asks you *What kind of legacy app do you want to create?*, click **Private**
+5. In the **Basic Info** tab, give the app a name (e.g. "Krenalis").
+6. Go to the **Scopes** tab and add: `crm.objects.contacts.read`, `crm.schemas.contacts.read`.
+7. Click **Create app** in the top right and confirm.
+8. In the **Auth** tab of the app details page, in the section **Access token**, click **Show token**, then **Copy**.
 
 > HubSpot is a trademark of HubSpot, Inc.
 > This connector is not affiliated with or endorsed by HubSpot, Inc.

--- a/connectors/hubspot/hubspot.go
+++ b/connectors/hubspot/hubspot.go
@@ -98,6 +98,7 @@ type innerSettings struct {
 
 // ServeUI serves the connector's user interface.
 func (hs *HubSpot) ServeUI(ctx context.Context, event string, settings json.Value, role connectors.Role) (*connectors.UI, error) {
+
 	switch event {
 	case "load":
 		var s innerSettings

--- a/connectors/hubspot/hubspot.go
+++ b/connectors/hubspot/hubspot.go
@@ -12,6 +12,7 @@ package hubspot
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -41,14 +42,16 @@ func init() {
 		Label:      "HubSpot",
 		Categories: connectors.CategorySaaS,
 		AsSource: &connectors.AsApplicationSource{
-			Targets: connectors.TargetUser,
+			Targets:     connectors.TargetUser,
+			HasSettings: true,
 			Documentation: connectors.RoleDocumentation{
 				Summary:  "Import contacts as users from HubSpot",
 				Overview: sourceOverview,
 			},
 		},
 		AsDestination: &connectors.AsApplicationDestination{
-			Targets: connectors.TargetUser,
+			Targets:     connectors.TargetUser,
+			HasSettings: true,
 			Documentation: connectors.RoleDocumentation{
 				Summary:  "Export users as contacts to HubSpot",
 				Overview: destinationOverview,
@@ -59,15 +62,7 @@ func init() {
 			Users:  "Contacts",
 			UserID: "HubSpot ID",
 		},
-		OAuth: connectors.OAuth{
-			AuthURL:           "https://app-eu1.hubspot.com/oauth/authorize",
-			TokenURL:          "https://api.hubapi.com/oauth/v1/token",
-			SourceScopes:      []string{"oauth", "crm.objects.contacts.read", "crm.schemas.contacts.read"},
-			DestinationScopes: []string{"oauth", "crm.objects.contacts.read", "crm.objects.contacts.write", "crm.schemas.contacts.read"},
-			Disallow127_0_0_1: true,
-		},
 		EndpointGroups: []connectors.EndpointGroup{{
-			RequireOAuth: true,
 			// https://developers.hubspot.com/docs/developer-tooling/platform/usage-guidelines
 			RateLimit: connectors.RateLimit{RequestsPerSecond: 11, Burst: 110},
 			// https://developers.hubspot.com/docs/api-reference/error-handling
@@ -83,27 +78,87 @@ func init() {
 // New returns a new connector instance for HubSpot.
 func New(env *connectors.ApplicationEnv) (*HubSpot, error) {
 	c := HubSpot{env: env}
+	if len(env.Settings) > 0 {
+		err := env.Settings.Unmarshal(&c.settings)
+		if err != nil {
+			return nil, errors.New("cannot unmarshal settings of connector for HubSpot")
+		}
+	}
 	return &c, nil
 }
 
 type HubSpot struct {
-	env *connectors.ApplicationEnv
+	env      *connectors.ApplicationEnv
+	settings *innerSettings
 }
 
-// OAuthAccount returns the API's account associated with the OAuth
-// authorization.
-func (hs *HubSpot) OAuthAccount(ctx context.Context) (string, error) {
-	var res struct {
-		PortalId int `json:"portalId"`
+type innerSettings struct {
+	AccessToken string `json:"accessToken"`
+}
+
+// ServeUI serves the connector's user interface.
+func (hs *HubSpot) ServeUI(ctx context.Context, event string, settings json.Value, role connectors.Role) (*connectors.UI, error) {
+	switch event {
+	case "load":
+		var s innerSettings
+		if hs.settings != nil {
+			s = *hs.settings
+		}
+		settings, _ = json.Marshal(s)
+	case "save":
+		return nil, hs.saveSettings(ctx, settings)
+	default:
+		return nil, connectors.ErrUIEventNotExist
 	}
-	err := hs.call(ctx, "GET", "/account-info/v3/details", nil, &res)
+
+	ui := &connectors.UI{
+		Fields: []connectors.Component{
+			&connectors.Input{
+				Name:        "accessToken",
+				Label:       "Access Token",
+				Placeholder: "pat-eu1-9b778d75-f746-23fa-81d2-1c627ed11ca4",
+				Type:        "text",
+				MinLength:   1,
+				MaxLength:   255,
+				HelpText:    "Access token generated in HubSpot (Settings → Integrations → Legacy Apps).",
+			},
+		},
+		Settings: settings,
+	}
+
+	return ui, nil
+}
+
+// saveSettings validates and saves the settings.
+func (hs *HubSpot) saveSettings(ctx context.Context, settings json.Value) error {
+	var s innerSettings
+	err := settings.Unmarshal(&s)
 	if err != nil {
-		return "", err
+		return err
 	}
-	if res.PortalId <= 0 {
-		return "", fmt.Errorf("HubSpot has returned an invalid account (portalId): %d", res.PortalId)
+	if n := len(s.AccessToken); n < 1 || n > 255 {
+		return connectors.NewInvalidSettingsError("Access token length must be in [1, 255]")
 	}
-	return strconv.Itoa(res.PortalId), nil
+	for i := 0; i < len(s.AccessToken); i++ {
+		c := s.AccessToken[i]
+		// ASCII characters with decimal codes from 33 (!) to 126 (~),
+		// inclusive, are printable characters. The space character, having
+		// decimal code 32, is therefore excluded from the range of accepted
+		// characters, and this is intentional.
+		if c < 33 || c > 126 {
+			return connectors.NewInvalidSettingsError("Access token must contain only valid characters")
+		}
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	err = hs.env.SetSettings(ctx, b)
+	if err != nil {
+		return err
+	}
+	hs.settings = &s
+	return nil
 }
 
 var propertyGroups = []struct {
@@ -390,6 +445,7 @@ func (hs *HubSpot) call(ctx context.Context, method, path string, bb *connectors
 	if err != nil {
 		return err
 	}
+	req.Header.Set("Authorization", "Bearer "+hs.settings.AccessToken)
 	res, err := hs.env.HTTPClient.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Commit message

```
connectors/hubspot: use Legacy Apps tokens instead of OAuth

This commit causes the HubSpot connector to authenticate using an access
token generated through "legacy apps" instead of OAuth.

Using these tokens instead of OAuth makes it easier to add a HubSpot
connection, and also avoids the need to modify the Krenalis
configuration by setting the value of environment variables.
```