### PR TITLE
all: simplify and standardize the way to authenticate to AWS Lambda

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,9 +70,6 @@ KRENALIS_MAXMIND_DB_PATH=""
 KRENALIS_TRANSFORMERS_PROVIDER="aws-lambda"
 
 # AWS Lambda.
-KRENALIS_TRANSFORMERS_AWS_LAMBDA_ACCESS_KEY_ID=""            # AWS Lambda access key ID.
-KRENALIS_TRANSFORMERS_AWS_LAMBDA_SECRET_ACCESS_KEY=""        # AWS Lambda secret access key.
-KRENALIS_TRANSFORMERS_AWS_LAMBDA_REGION=""                   # AWS region for Lambda.
 KRENALIS_TRANSFORMERS_AWS_LAMBDA_ROLE=""                     # AWS Lambda role ARN.
 KRENALIS_TRANSFORMERS_AWS_LAMBDA_NODEJS_RUNTIME="nodejs22.x" # Node.js runtime version for AWS Lambda.
 KRENALIS_TRANSFORMERS_AWS_LAMBDA_NODEJS_LAYER=""             # Optional AWS Lambda layer for Node.js.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -79,11 +79,8 @@ type Settings struct {
 }
 
 type LambdaConfig struct {
-	AccessKeyID     string
-	SecretAccessKey string
-	Region          string
-	Role            string
-	NodeJS          struct {
+	Role   string
+	NodeJS struct {
 		Runtime string
 		Layer   string
 	}

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -388,9 +388,6 @@ func parseEnvSettings() (*Settings, error) {
 		settings.Transformers.Local.SudoUser = envVars.Get("KRENALIS_TRANSFORMERS_LOCAL_SUDO_USER")
 		settings.Transformers.Local.DoasUser = envVars.Get("KRENALIS_TRANSFORMERS_LOCAL_DOAS_USER")
 	case "aws-lambda":
-		settings.Transformers.Lambda.AccessKeyID = envVars.Get("KRENALIS_TRANSFORMERS_AWS_LAMBDA_ACCESS_KEY_ID")
-		settings.Transformers.Lambda.SecretAccessKey = envVars.Get("KRENALIS_TRANSFORMERS_AWS_LAMBDA_SECRET_ACCESS_KEY")
-		settings.Transformers.Lambda.Region = envVars.Get("KRENALIS_TRANSFORMERS_AWS_LAMBDA_REGION")
 		settings.Transformers.Lambda.Role = envVars.Get("KRENALIS_TRANSFORMERS_AWS_LAMBDA_ROLE")
 		settings.Transformers.Lambda.NodeJS.Runtime = envVars.Get("KRENALIS_TRANSFORMERS_AWS_LAMBDA_NODEJS_RUNTIME")
 		settings.Transformers.Lambda.NodeJS.Layer = envVars.Get("KRENALIS_TRANSFORMERS_AWS_LAMBDA_NODEJS_LAYER")

--- a/core/core.go
+++ b/core/core.go
@@ -125,11 +125,8 @@ type OAuthCredentials struct {
 }
 
 type LambdaConfig struct {
-	AccessKeyID     string
-	SecretAccessKey string
-	Region          string
-	Role            string
-	NodeJS          struct {
+	Role   string
+	NodeJS struct {
 		Runtime string
 		Layer   string
 	}

--- a/core/internal/transformers/lambda/lambda.go
+++ b/core/internal/transformers/lambda/lambda.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/aws/smithy-go"
@@ -36,11 +36,8 @@ type function struct {
 }
 
 type Settings struct {
-	AccessKeyID     string
-	SecretAccessKey string
-	Region          string
-	Role            string
-	NodeJS          struct {
+	Role   string
+	NodeJS struct {
 		Runtime string
 		Layer   string
 	}
@@ -75,7 +72,10 @@ func (fn *function) Call(ctx context.Context, id, version string, inSchema, outS
 		return err
 	}
 
-	client := fn.lambdaClient()
+	client, err := fn.lambdaClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Marshal the values.
 	payload := make([]byte, 0, 1024)
@@ -194,7 +194,10 @@ func (fn *function) Create(ctx context.Context, name string, language state.Lang
 	if err != nil {
 		return "", "", err
 	}
-	client := fn.lambdaClient()
+	client, err := fn.lambdaClient(ctx)
+	if err != nil {
+		return "", "", err
+	}
 	var runtime string
 	var layers []string
 	switch language {
@@ -249,7 +252,10 @@ func (fn *function) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	client := fn.lambdaClient()
+	client, err := fn.lambdaClient(ctx)
+	if err != nil {
+		return err
+	}
 	_, err = client.DeleteFunction(ctx, &lambda.DeleteFunctionInput{
 		FunctionName: &arn,
 	})
@@ -283,7 +289,10 @@ func (fn *function) Update(ctx context.Context, id, source string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	client := fn.lambdaClient()
+	client, err := fn.lambdaClient(ctx)
+	if err != nil {
+		return "", err
+	}
 	out, err := client.UpdateFunctionCode(ctx, &lambda.UpdateFunctionCodeInput{
 		FunctionName: &arn,
 		Publish:      true,
@@ -405,23 +414,18 @@ def _handler(event, context):
 	return b.Bytes(), nil
 }
 
-// lambdaClient returns the Lambda client.
-func (fn *function) lambdaClient() *lambda.Client {
+// lambdaClient returns the Lambda client, loading the AWS configuration from
+// the environment (IAM role, instance metadata, etc.) on first use.
+func (fn *function) lambdaClient(ctx context.Context) (*lambda.Client, error) {
 	if fn.client != nil {
-		return fn.client
+		return fn.client, nil
 	}
-	cfg := aws.Config{
-		Region: fn.settings.Region,
-		Credentials: aws.NewCredentialsCache(
-			credentials.NewStaticCredentialsProvider(
-				fn.settings.AccessKeyID,
-				fn.settings.SecretAccessKey,
-				"",
-			),
-		),
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("transformers/lambda: cannot load AWS config: %s", err)
 	}
 	fn.client = lambda.NewFromConfig(cfg)
-	return fn.client
+	return fn.client, nil
 }
 
 // pythonEscaper is used by escapePythonSourceCode.

--- a/core/internal/transformers/lambda/lambda.go
+++ b/core/internal/transformers/lambda/lambda.go
@@ -415,7 +415,7 @@ def _handler(event, context):
 }
 
 // lambdaClient returns the Lambda client, loading the AWS configuration from
-// the environment (IAM role, instance metadata, etc.) on first use.
+// the environment (IAM role, etc.) on first call.
 func (fn *function) lambdaClient(ctx context.Context) (*lambda.Client, error) {
 	if fn.client != nil {
 		return fn.client, nil

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/LumenResearch/uasurfer v0.0.0-20260126094926-dace53404a8d
 	github.com/andybalholm/brotli v1.2.1
 	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.89.0
@@ -66,7 +67,6 @@ require (
 	github.com/apache/arrow-go/v18 v18.4.0 // indirect
 	github.com/apache/thrift v0.22.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.21.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect


### PR DESCRIPTION
## TODO

* [x] Test and review
* [x] Document on krenalis.com

## Commit message

```
all: simplify and standardize the way to authenticate to AWS Lambda

Currently, to configure access to AWS Lambda, it is necessary to specify
an access ID and a secret.

This is too complicated when Krenalis runs on AWS EC2, as it's not
necessary to pass the access secret, as access is managed by AWS and its
roles.

For this reason, this commit simplifies access to AWS Lambda by falling
back to the default mechanism implemented by the Amazon SDK, which takes
care of reading the environment to perform access.

Therefore, only the minimum variables needed to run functions on Lambda
have been maintained in Krenalis.
```