### PR TITLE
tools/kms: add region to `aws`

### DIFF
--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -38,13 +38,13 @@ func parseEnvSettings() (*Settings, error) {
 	settings := &Settings{}
 
 	if kms, ok := envVars.Lookup("KRENALIS_KMS"); ok {
-		backend, rawValue, found := strings.Cut(kms, ":")
+		backend, options, found := strings.Cut(kms, ":")
 		if !found {
-			return nil, errors.New("KRENALIS_KMS must be in the form 'key:<base64>' or 'aws:<kms-key-id-or-arn>'")
+			return nil, errors.New("KRENALIS_KMS must be in the form 'key:<base64>' or 'aws:<region>:<key-id>'")
 		}
 		switch backend {
 		case "key":
-			decodedValue, err := base64.RawStdEncoding.DecodeString(strings.TrimSuffix(rawValue, "="))
+			decodedValue, err := base64.RawStdEncoding.DecodeString(strings.TrimSuffix(options, "="))
 			if err != nil {
 				return nil, errors.New("KRENALIS_KMS key value is not valid base64")
 			}
@@ -53,11 +53,11 @@ func parseEnvSettings() (*Settings, error) {
 				return nil, fmt.Errorf("KRENALIS_KMS key value decodes to %d bytes, expected 32", n)
 			}
 		case "aws":
-			if rawValue == "" {
+			if options == "" {
 				return nil, errors.New("KRENALIS_KMS aws value is empty")
 			}
 		default:
-			return nil, errors.New("KRENALIS_KMS must be in the form 'key:<base64>' or 'aws:<kms-key-id-or-arn>'")
+			return nil, errors.New("KRENALIS_KMS must be in the form 'key:<base64>' or 'aws:<region>:<key-id>'")
 		}
 		settings.Kms = kms
 	} else {

--- a/cmd/settings_test.go
+++ b/cmd/settings_test.go
@@ -140,7 +140,7 @@ func TestParseSettings(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected invalid format error, got nil")
 		}
-		if got := err.Error(); got != "KRENALIS_KMS must be in the form 'key:<base64>' or 'aws:<kms-key-id-or-arn>'" {
+		if got := err.Error(); got != "KRENALIS_KMS must be in the form 'key:<base64>' or 'aws:<region>:<key-id>'" {
 			t.Fatalf("unexpected error: %q", got)
 		}
 
@@ -149,14 +149,14 @@ func TestParseSettings(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected unsupported backend error, got nil")
 		}
-		if got := err.Error(); got != "KRENALIS_KMS must be in the form 'key:<base64>' or 'aws:<kms-key-id-or-arn>'" {
+		if got := err.Error(); got != "KRENALIS_KMS must be in the form 'key:<base64>' or 'aws:<region>:<key-id>'" {
 			t.Fatalf("unexpected error: %q", got)
 		}
 
 		t.Setenv("KRENALIS_KMS", "aws:")
 		_, err = parseEnvSettings()
 		if err == nil {
-			t.Fatal("expected empty aws identifier error, got nil")
+			t.Fatal("expected invalid aws identifier error, got nil")
 		}
 		if got := err.Error(); got != "KRENALIS_KMS aws value is empty" {
 			t.Fatalf("unexpected error: %q", got)

--- a/tools/kms/internal/aws/aws.go
+++ b/tools/kms/internal/aws/aws.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -21,16 +22,24 @@ type Kms struct {
 
 // New creates an AWS KMS-backed implementation of the Kms interface.
 //
-// It builds the AWS KMS client using the AWS SDK default configuration chain,
-// so credentials, region, and related settings are resolved through the
-// standard AWS mechanisms.
+// It builds the AWS KMS client using the provided region and the AWS SDK
+// default configuration chain, so credentials and related settings are resolved
+// through the standard AWS mechanisms.
 //
-// keyID identifies the AWS KMS key used to manage data keys.
-func New(ctx context.Context, keyID string) (*Kms, error) {
+// options has the form <region>:<key-id> where <region> is the AWS region and
+// <key-id> identifies the AWS KMS key used to manage data keys.
+func New(ctx context.Context, options string) (*Kms, error) {
+	region, keyID, found := strings.Cut(options, ":")
+	if !found {
+		return nil, errors.New("kms/aws: options must be in the form '<region>:<key-id>'")
+	}
+	if err := validateRegion(region); err != nil {
+		return nil, fmt.Errorf("kms/aws: %s", err)
+	}
 	if keyID == "" {
 		return nil, errors.New("kms/aws: empty key ID")
 	}
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		return nil, fmt.Errorf("kms/aws: %s", err)
 	}
@@ -114,4 +123,20 @@ func (k *Kms) DecryptDataKey(ctx context.Context, encryptedDataKey []byte) ([]by
 	}
 
 	return out.Plaintext, nil
+}
+
+func validateRegion(region string) error {
+	if region == "" {
+		return errors.New("region must not be empty")
+	}
+	for _, r := range region {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-':
+		default:
+			return errors.New("region must be an AWS region code such as 'us-east-1'")
+		}
+	}
+	return nil
 }

--- a/tools/kms/internal/aws/aws_test.go
+++ b/tools/kms/internal/aws/aws_test.go
@@ -24,32 +24,44 @@ import (
 
 const testKeyID = "test-key"
 
-// TestNewEmptyKeyID rejects empty AWS KMS key identifiers.
-func TestNewEmptyKeyID(t *testing.T) {
-	kms, err := New(context.Background(), "")
-	if err == nil {
-		t.Fatal("expected error from New with empty key ID, got nil")
-	}
-	if err.Error() != "kms/aws: empty key ID" {
-		t.Fatalf("expected empty key ID error, got %v", err)
-	}
-	if kms != nil {
-		t.Fatalf("expected nil Kms from New with empty key ID, got %#v", kms)
+// TestNewInvalidOptions rejects invalid AWS KMS options.
+func TestNewInvalidOptions(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		options string
+		want    string
+	}{
+		{name: "missing separator", options: "", want: "kms/aws: options must be in the form '<region>:<key-id>'"},
+		{name: "empty region", options: ":test-key", want: "kms/aws: region must not be empty"},
+		{name: "invalid region", options: "us/east/1:test-key", want: "kms/aws: region must be an AWS region code such as 'us-east-1'"},
+		{name: "empty key ID", options: "us-east-1:", want: "kms/aws: empty key ID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			kms, err := New(context.Background(), tc.options)
+			if err == nil {
+				t.Fatalf("expected error from New(%q), got nil", tc.options)
+			}
+			if err.Error() != tc.want {
+				t.Fatalf("expected error %q from New(%q), got %v", tc.want, tc.options, err)
+			}
+			if kms != nil {
+				t.Fatalf("expected nil Kms from New(%q), got %#v", tc.options, kms)
+			}
+		})
 	}
 }
 
-// TestNewSuccessWithEnv builds a client from minimal AWS environment settings.
-func TestNewSuccessWithEnv(t *testing.T) {
+// TestNewSuccess builds a client from explicit options and AWS credentials.
+func TestNewSuccess(t *testing.T) {
 
 	configDir := t.TempDir()
-	t.Setenv("AWS_REGION", "eu-west-1")
 	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(configDir, "credentials"))
 	t.Setenv("AWS_CONFIG_FILE", filepath.Join(configDir, "config"))
 
-	kms, err := New(context.Background(), testKeyID)
+	kms, err := New(context.Background(), "us-east-1:"+testKeyID)
 	if err != nil {
 		t.Fatalf("expected nil error from New, got %v", err)
 	}

--- a/tools/kms/kms.go
+++ b/tools/kms/kms.go
@@ -10,9 +10,9 @@
 // form of the data key, and later decrypt that stored key to recover the same
 // plaintext key.
 //
-// The package selects an implementation from a URI of the form
-// "<backend>:<identifier>". The standard backends are "key", for a
-// process-local key, and "aws", for AWS KMS.
+// The package selects an implementation from a URI. The standard backends are
+// "key:<base64>", for a process-local key, and "aws:<region>:<key-id>", for AWS
+// KMS.
 //
 // Package kms does not encrypt application data itself; it only manages data
 // encryption keys.
@@ -43,8 +43,7 @@ type Kms interface {
 	GenerateDataKeyWithoutPlaintext(ctx context.Context, keyLen int) (encryptedDataKey []byte, err error)
 }
 
-// New returns a Kms selected by uri, which must have the form
-// "<backend>:<identifier>".
+// New returns a Kms selected by uri.
 func New(ctx context.Context, uri string) (Kms, error) {
 	backend, identifier, found := strings.Cut(uri, ":")
 	if !found {

--- a/tools/kms/kms_test.go
+++ b/tools/kms/kms_test.go
@@ -18,7 +18,8 @@ func TestNewErrors(t *testing.T) {
 	}{
 		{name: "invalid URI", uri: "key", want: "kms: uri is invalid"},
 		{name: "unsupported backend", uri: "gcp:key", want: "kms: unsupported backend"},
-		{name: "empty AWS key ID", uri: "aws:", want: "kms/aws: empty key ID"},
+		{name: "empty AWS options", uri: "aws:", want: "kms/aws: options must be in the form '<region>:<key-id>'"},
+		{name: "empty AWS key ID", uri: "aws:us-east-1:", want: "kms/aws: empty key ID"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			kms, err := New(context.Background(), tc.uri)

--- a/tools/kms/kms_test.go
+++ b/tools/kms/kms_test.go
@@ -19,6 +19,8 @@ func TestNewErrors(t *testing.T) {
 		{name: "invalid URI", uri: "key", want: "kms: uri is invalid"},
 		{name: "unsupported backend", uri: "gcp:key", want: "kms: unsupported backend"},
 		{name: "empty AWS options", uri: "aws:", want: "kms/aws: options must be in the form '<region>:<key-id>'"},
+		{name: "empty AWS region", uri: "aws::test-key", want: "kms/aws: region must not be empty"},
+		{name: "invalid AWS region", uri: "aws:us/east/1:test-key", want: "kms/aws: region must be an AWS region code such as 'us-east-1'"},
 		{name: "empty AWS key ID", uri: "aws:us-east-1:", want: "kms/aws: empty key ID"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
```
tools/kms: add region to `aws`

Require AWS KMS URIs to include the target region:

  aws:<region>:<key-id-or-arn>

Pass the region explicitly to the AWS SDK when building the KMS client,
instead of relying on the default configuration chain.
```