### PR TITLE
core: use `state.AccessKeyType` instead of `core.AccessKeyType`

### DIFF
--- a/core/organization.go
+++ b/core/organization.go
@@ -328,7 +328,7 @@ func (this *Organization) CreateAccessKey(ctx context.Context, name string, work
 	createdAt := time.Now().UTC().Truncate(time.Second)
 	err = this.core.state.Transaction(ctx, func(tx *db.Tx) (any, error) {
 		_, err := tx.Exec(ctx, "INSERT INTO access_keys (id, organization, workspace, name, type, token, created_at) "+
-			"VALUES ($1, $2, NULLIF($3, 0), $4, $5, $6, $7)", n.ID, n.Organization, n.Workspace, name, typ, n.Token, createdAt)
+			"VALUES ($1, $2, NULLIF($3, 0), $4, $5, $6, $7)", n.ID, n.Organization, n.Workspace, name, n.Type, n.Token, createdAt)
 		if err != nil {
 			if db.IsForeignKeyViolation(err) {
 				switch db.ErrConstraintName(err) {


### PR DESCRIPTION
```
core: use `state.AccessKeyType` instead of `core.AccessKeyType`

Replace 'core.AccessKeyType' with 'state.AccessKeyType' when passing it
as an argument to the SQL query that creates an access key.
```