### PR TITLE
core: handle missing datastore stores after workspace deletion

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1244,7 +1244,10 @@ func (core *Core) tryStartPipelineRun(pipelineID int) {
 		// Starts the run.
 		c := pipeline.Connection()
 		ws := c.Workspace()
-		store := core.datastore.Store(ws.ID)
+		store, ok := core.datastore.Store(ws.ID)
+		if !ok {
+			return
+		}
 		connection := &Connection{core: core, store: store, connection: c}
 		p := &Pipeline{core: core, pipeline: pipeline, connection: connection}
 
@@ -1283,7 +1286,10 @@ func (core *Core) tryStartPipelineRun(pipelineID int) {
 func (core *Core) executeAlterProfileSchema(workspace int, opID string, schema types.Type,
 	primarySources map[string]int, operations []warehouses.AlterOperation) {
 	ctx := core.close.ctx
-	store := core.datastore.Store(workspace)
+	store, ok := core.datastore.Store(workspace)
+	if !ok {
+		return
+	}
 	ws, ok := core.state.Workspace(workspace)
 	if !ok {
 		return
@@ -1423,7 +1429,10 @@ Identifiers:
 // until it has completed (with success or with an operation error).
 func (core *Core) executeIdentityResolution(workspace int, opID string) {
 	ctx := core.close.ctx
-	store := core.datastore.Store(workspace)
+	store, ok := core.datastore.Store(workspace)
+	if !ok {
+		return
+	}
 	// Keep calling 'ResolveIdentities' until it (1) returns successfully,
 	// (2) returns with a *warehouses.OperationError, or (3) the context is
 	// canceled.

--- a/core/internal/collector/collector.go
+++ b/core/internal/collector/collector.go
@@ -252,7 +252,7 @@ func (c *Collector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // It is called from New and onCreateWorkspace.
 func (c *Collector) addWorkspace(id int) {
 	c.observers.Store(id, newObserver())
-	store := c.datastore.Store(id)
+	store, _ := c.datastore.Store(id)
 	c.eventWriters.Store(id, store.NewEventWriter())
 }
 

--- a/core/internal/collector/identitywriter.go
+++ b/core/internal/collector/identitywriter.go
@@ -41,7 +41,7 @@ func newIdentityWriter(ds *datastore.Datastore, pipeline *state.Pipeline, provid
 		metrics:  metrics,
 	}
 	ws := pipeline.Connection().Workspace()
-	store := ds.Store(ws.ID)
+	store, _ := ds.Store(ws.ID)
 	iw.writer = store.NewEventIdentityWriter(pipeline.ID)
 	if t := pipeline.Transformation; t.Mapping != nil || t.Function != nil {
 		iw.transformer, _ = transformers.New(pipeline, provider, nil)

--- a/core/internal/datastore/datastore.go
+++ b/core/internal/datastore/datastore.go
@@ -144,12 +144,12 @@ func (ds *Datastore) Initialize(ctx context.Context, platform string, settings j
 	return unavailableError(dw.Close())
 }
 
-func (ds *Datastore) Store(workspace int) *Store {
+func (ds *Datastore) Store(workspace int) (*Store, bool) {
 	ds.mustBeOpen()
 	ds.mu.Lock()
-	store := ds.store[workspace]
+	store, ok := ds.store[workspace]
 	ds.mu.Unlock()
-	return store
+	return store, ok
 }
 
 // ValidateWarehouseSettings validates data warehouse settings and returns them

--- a/core/organization.go
+++ b/core/organization.go
@@ -813,10 +813,14 @@ func (this *Organization) Workspace(id int) (*Workspace, error) {
 	if !ok {
 		return nil, errors.NotFound("workspace %d does not exist", id)
 	}
+	store, ok := this.core.datastore.Store(id)
+	if !ok {
+		return nil, errors.NotFound("workspace %d does not exist", id)
+	}
 	workspace := Workspace{
 		core:                           this.core,
 		organization:                   this,
-		store:                          this.core.datastore.Store(id),
+		store:                          store,
 		workspace:                      ws,
 		ID:                             ws.ID,
 		Name:                           ws.Name,
@@ -834,12 +838,16 @@ func (this *Organization) Workspace(id int) (*Workspace, error) {
 func (this *Organization) Workspaces() []*Workspace {
 	this.core.mustBeOpen()
 	workspaces := this.organization.Workspaces()
-	infos := make([]*Workspace, len(workspaces))
-	for i, ws := range workspaces {
+	infos := make([]*Workspace, 0, len(workspaces))
+	for _, ws := range workspaces {
+		store, ok := this.core.datastore.Store(ws.ID)
+		if !ok {
+			continue
+		}
 		workspace := Workspace{
 			core:                           this.core,
 			organization:                   this,
-			store:                          this.core.datastore.Store(ws.ID),
+			store:                          store,
 			workspace:                      ws,
 			ID:                             ws.ID,
 			Name:                           ws.Name,
@@ -850,7 +858,7 @@ func (this *Organization) Workspaces() []*Workspace {
 			WarehouseMode:                  WarehouseMode(ws.Warehouse.Mode),
 			UIPreferences:                  UIPreferences(ws.UIPreferences),
 		}
-		infos[i] = &workspace
+		infos = append(infos, &workspace)
 	}
 	return infos
 }

--- a/core/pipeline_cleaner.go
+++ b/core/pipeline_cleaner.go
@@ -305,7 +305,10 @@ func (c *pipelineCleaner) purgeWorkspace(id int) {
 		}
 		err := c.complete(func() error {
 
-			store := c.core.datastore.Store(id)
+			store, ok := c.core.datastore.Store(id)
+			if !ok {
+				return nil
+			}
 			err := store.PurgePipelines(c.close.ctx, pipelines)
 			if err != nil {
 				return fmt.Errorf("cannot purge pipelines: %s", err)
@@ -388,7 +391,10 @@ func (c *pipelineCleaner) terminateOrphanedRuns() {
 					}
 					c2 := pipeline.Connection()
 					ws := c2.Workspace()
-					store := c.core.datastore.Store(ws.ID)
+					store, ok := c.core.datastore.Store(ws.ID)
+					if !ok {
+						continue
+					}
 					connection := &Connection{core: c.core, store: store, connection: c2}
 					p := &Pipeline{core: c.core, pipeline: pipeline, connection: connection}
 					go p.endRun(pipelineErr)
@@ -429,7 +435,10 @@ func (c *pipelineCleaner) unsetIdentityProperties(id int) {
 		// Unset the properties.
 		err := c.complete(func() error {
 
-			store := c.core.datastore.Store(pipeline.Connection().Workspace().ID)
+			store, ok := c.core.datastore.Store(pipeline.Connection().Workspace().ID)
+			if !ok {
+				return nil
+			}
 			err := store.UnsetIdentityProperties(c.close.ctx, pipeline.ID, paths)
 			if err != nil {
 				return err

--- a/core/pipeline_scheduler.go
+++ b/core/pipeline_scheduler.go
@@ -236,7 +236,10 @@ func newPipelineExecutor(core *Core, wg *sync.WaitGroup, ctx context.Context) *p
 							continue
 						}
 						connection := pipeline.Connection()
-						store := pe.core.datastore.Store(connection.Workspace().ID)
+						store, ok := pe.core.datastore.Store(connection.Workspace().ID)
+						if !ok {
+							continue
+						}
 						c := &Connection{core: pe.core, connection: connection, store: store}
 						p := &Pipeline{core: pe.core, pipeline: pipeline, connection: c}
 						wg.Go(func() {


### PR DESCRIPTION
```
core: handle missing datastore stores after workspace deletion

Update 'Datastore.Store' to report whether a workspace store exists, and
handle missing stores at call sites that can race with workspace
deletion.

Call sites that run while the state is frozen intentionally ignore the
boolean, because an existing workspace is guaranteed to still have its
store.

Close #2179
```