### PR TITLE
core: return a clear error message when database is not initialized

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -270,7 +270,7 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 	if err != nil {
 		// Return a clear error if the database has not been initialized.
 		if dbpkg.IsUndefinedTable(err) {
-			return nil, errors.New("Krenalis's internal PostgreSQL database has not been initialized. Start Krenalis with the -init-db-if-empty flag to initialize it")
+			return nil, fmt.Errorf("%s (Krenalis's internal PostgreSQL may not be initialized. Try starting Krenalis with the -init-db-if-empty flag)", err)
 		}
 		return nil, err
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -47,7 +47,6 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgconn"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -270,8 +269,7 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 	core.state, err = state.New(ctx, db, kms, connectorsOAuth, sendStats)
 	if err != nil {
 		// Return a clear error if the database has not been initialized.
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
+		if dbpkg.IsUndefinedTable(err) {
 			return nil, errors.New("Krenalis's internal PostgreSQL database has not been initialized. Start Krenalis with the -init-db-if-empty flag to initialize it")
 		}
 		return nil, err

--- a/core/core.go
+++ b/core/core.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -268,6 +269,11 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 	}
 	core.state, err = state.New(ctx, db, kms, connectorsOAuth, sendStats)
 	if err != nil {
+		// Return a clear error if the database has not been initialized.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
+			return nil, errors.New("the PostgreSQL database has not been initialized; start Krenalis with the -init-db-if-empty flag to initialize it")
+		}
 		return nil, err
 	}
 	defer func() {

--- a/core/core.go
+++ b/core/core.go
@@ -272,7 +272,7 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 		// Return a clear error if the database has not been initialized.
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
-			return nil, errors.New("the PostgreSQL database has not been initialized; start Krenalis with the -init-db-if-empty flag to initialize it")
+			return nil, errors.New("Krenalis's internal PostgreSQL database has not been initialized. Start Krenalis with the -init-db-if-empty flag to initialize it")
 		}
 		return nil, err
 	}

--- a/core/internal/db/db.go
+++ b/core/internal/db/db.go
@@ -529,6 +529,12 @@ func IsForeignKeyViolation(err error) bool {
 	return false
 }
 
+// IsUndefinedTable reports whether err is an undefined table error.
+func IsUndefinedTable(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "42P01"
+}
+
 // Quote escapes a value to safely insert it into a query.
 func Quote(value any) string {
 	if value == nil {


### PR DESCRIPTION
## Commit message

```
core: return a clear error message when database is not initialized

Currently, when the PostgreSQL database connected to Krenalis has not
been initialized, this error is shown to the user:

	error: ERROR: relation "metadata" does not exist (SQLSTATE 42P01)

which is unclear and doesn't indicate what needs to be done.

With this change, the error shown to the user in this scenario will
instead be:

	error: the PostgreSQL database has not been initialized; start
	Krenalis with the -init-db-if-empty flag to initialize it
```