### PR TITLE
core/internal/streams/nats: prevents event loss by using WorkQueue

### DIFF
--- a/core/internal/streams/nats/nats.go
+++ b/core/internal/streams/nats/nats.go
@@ -303,7 +303,7 @@ func (s *stream) ensureEventStream(ctx context.Context, opts streamOptions) {
 		Name:        "EVENTS",
 		Subjects:    []string{"events.v1.>"},
 		Replicas:    opts.replicas,
-		Retention:   jetstream.InterestPolicy,
+		Retention:   jetstream.WorkQueuePolicy,
 		Storage:     opts.storage,
 		Compression: opts.compression,
 	}

--- a/test/events_context_test.go
+++ b/test/events_context_test.go
@@ -17,9 +17,6 @@ import (
 
 func TestEventsContext(t *testing.T) {
 
-	// TODO: skipped until https://github.com/krenalis/krenalis/issues/2150 is fixed.
-	t.Skip()
-
 	// Test's header (copy-paste me in other tests).
 	if testing.Short() {
 		t.Skip()

--- a/test/events_test.go
+++ b/test/events_test.go
@@ -21,9 +21,6 @@ import (
 
 func TestEvents(t *testing.T) {
 
-	// TODO: skipped until https://github.com/krenalis/krenalis/issues/2150 is fixed.
-	t.Skip()
-
 	// Test's header (copy-paste me in other tests).
 	if testing.Short() {
 		t.Skip()

--- a/test/import_from_many_connections_test.go
+++ b/test/import_from_many_connections_test.go
@@ -21,9 +21,6 @@ import (
 
 func Test_ImportFromManyConnections(t *testing.T) {
 
-	// TODO: skipped until https://github.com/krenalis/krenalis/issues/2150 is fixed.
-	t.Skip()
-
 	// Determine the storage directory and assert that such directory exists.
 	storageDir, err := filepath.Abs("testdata/import_from_many_connections_test")
 	if err != nil {


### PR DESCRIPTION
```
core/internal/streams/nats: prevents event loss by using WorkQueue

Previously, the stream used the Interest retention policy, which could
cause events to be lost during pipeline startup.

When a pipeline was created, there was a delay before its consumer was
initialized. If events were published to NATS during this window, they
were discarded because no consumer existed yet. This caused intermittent
failures in tests that published events immediately after creating a
pipeline.

Switching to the WorkQueue policy ensures that events are retained even
if no consumer is present at publish time, preventing this issue.

WorkQueue differs from Interest in that it allows only one consumer per
subject. This constraint is compatible with Krenalis, where there is
always a single consumer per subject, even in multi-node deployments.

Note: as already happens today, if a pipeline is disabled or deleted,
its consumer is not removed, and any queued events are not automatically
cleared.

Fixes #2150
```