### PR TITLE
core/internal/state: prevent notification key validation goroutine leak

### DIFF
--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -232,7 +232,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 		return errors.New("missing notification key in metadata table")
 	}
 	notificationKey := state.cipher.Key(kmsEncryptedNotificationKey)
-	validNotificationKeyCh := make(chan error)
+	validNotificationKeyCh := make(chan error, 1)
 	go func() {
 		validNotificationKeyCh <- notificationKey.IsValid(ctx)
 	}()


### PR DESCRIPTION
```
core/internal/state: prevent notification key validation goroutine leak

Buffer 'validNotificationKeyCh' so the validation goroutine can send its
result even when state loading returns early due to an error before the
channel is read.
```