### PR TITLE
warehouses/postgresql/internal/readonlysql: fix license to MIT

### DIFF
--- a/warehouses/postgresql/internal/readonlysql/asciiwordset.go
+++ b/warehouses/postgresql/internal/readonlysql/asciiwordset.go
@@ -1,5 +1,5 @@
 // Copyright 2026 Open2b. All rights reserved.
-// Use of this source code is governed by an Elastic License 2.0
+// Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
 package readonlysql

--- a/warehouses/postgresql/internal/readonlysql/benchmark_test.go
+++ b/warehouses/postgresql/internal/readonlysql/benchmark_test.go
@@ -1,5 +1,5 @@
 // Copyright 2026 Open2b. All rights reserved.
-// Use of this source code is governed by an Elastic License 2.0
+// Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
 package readonlysql

--- a/warehouses/postgresql/internal/readonlysql/errors.go
+++ b/warehouses/postgresql/internal/readonlysql/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2026 Open2b. All rights reserved.
-// Use of this source code is governed by an Elastic License 2.0
+// Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
 package readonlysql

--- a/warehouses/postgresql/internal/readonlysql/lex.go
+++ b/warehouses/postgresql/internal/readonlysql/lex.go
@@ -1,5 +1,5 @@
 // Copyright 2026 Open2b. All rights reserved.
-// Use of this source code is governed by an Elastic License 2.0
+// Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
 package readonlysql

--- a/warehouses/postgresql/internal/readonlysql/policy.go
+++ b/warehouses/postgresql/internal/readonlysql/policy.go
@@ -1,5 +1,5 @@
 // Copyright 2026 Open2b. All rights reserved.
-// Use of this source code is governed by an Elastic License 2.0
+// Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
 package readonlysql

--- a/warehouses/postgresql/internal/readonlysql/validate.go
+++ b/warehouses/postgresql/internal/readonlysql/validate.go
@@ -1,5 +1,5 @@
 // Copyright 2026 Open2b. All rights reserved.
-// Use of this source code is governed by an Elastic License 2.0
+// Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
 // Package readonlysql validates whether a SQL query can be accepted as

--- a/warehouses/postgresql/internal/readonlysql/validate_test.go
+++ b/warehouses/postgresql/internal/readonlysql/validate_test.go
@@ -1,5 +1,5 @@
 // Copyright 2026 Open2b. All rights reserved.
-// Use of this source code is governed by an Elastic License 2.0
+// Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
 package readonlysql


### PR DESCRIPTION
```
warehouses/postgresql/internal/readonlysql: fix license to MIT

The readonly SQL validator is licensed under MIT, not Elastic License
2.0. Update its file headers to reflect the correct license.
```