### PR TITLE
admin: hide the OIDC token field from the warehouse settings

### DIFF
--- a/admin/src/components/routes/DataWarehouse/DataWarehouse.tsx
+++ b/admin/src/components/routes/DataWarehouse/DataWarehouse.tsx
@@ -149,6 +149,7 @@ const WarehouseInfo = ({
 
 	const rows: GridRow[] = [];
 	for (const k in warehouseSettings) {
+		if (k.toLowerCase() === 'oidctoken') continue;
 		let value: ReactNode;
 		if (k === 'Password' || k === 'password') {
 			value = <PasswordToggle password={warehouseSettings[k]} />;
@@ -162,6 +163,7 @@ const WarehouseInfo = ({
 
 	const mcpRows: GridRow[] = [];
 	for (const k in warehouseMCPSettings) {
+		if (k.toLowerCase() === 'oidctoken') continue;
 		let value: ReactNode;
 		if (k === 'Password' || k === 'password') {
 			value = <PasswordToggle password={warehouseMCPSettings[k]} />;


### PR DESCRIPTION
## Commit message

```
admin: hide the OIDC token field from the warehouse settings

The OIDC token for a Snowflake data warehouse can only be set via the
Krenalis API, but currently the Admin still displays the field and
displays it blank (because only the password is actually used).

This commit therefore hides this field from the Admin.
```