### PR TITLE
connectors/snowflake, warehouses/snowflake: fix `Merge` CSV columns

### DIFF
--- a/connectors/snowflake/merge.go
+++ b/connectors/snowflake/merge.go
@@ -214,7 +214,7 @@ func serializeRowsToCSV(columns []connectors.Column, rows [][]any, deleted bool)
 		if i > 0 {
 			b.WriteByte(',')
 		}
-		b.WriteString(strings.ToUpper(c.Name))
+		b.WriteString(csvColumnName(c.Name))
 	}
 	b.WriteString(",$PURGE\n")
 	for i, row := range rows {

--- a/connectors/snowflake/quote.go
+++ b/connectors/snowflake/quote.go
@@ -13,6 +13,11 @@ import (
 	"github.com/krenalis/krenalis/tools/types"
 )
 
+// csvColumnName returns the column name to write in Snowflake CSV headers.
+func csvColumnName(name string) string {
+	return name
+}
+
 // quoteIdent quotes the identifier name.
 func quoteIdent(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`

--- a/connectors/snowflake/snowflake_test.go
+++ b/connectors/snowflake/snowflake_test.go
@@ -143,9 +143,6 @@ func Test_Merge_Query(t *testing.T) {
 		t.Skip()
 	}
 
-	// TODO: skipped, see https://github.com/krenalis/krenalis/issues/2198.
-	t.Skip()
-
 	cols := []struct {
 		DriverType    string
 		DriverValue   any

--- a/warehouses/snowflake/merge.go
+++ b/warehouses/snowflake/merge.go
@@ -214,7 +214,7 @@ func serializeRowsToCSV(columns []warehouses.Column, rows [][]any, deleted bool)
 		if i > 0 {
 			b.WriteByte(',')
 		}
-		b.WriteString(strings.ToUpper(c.Name))
+		b.WriteString(csvColumnName(c.Name))
 	}
 	b.WriteString(",$PURGE\n")
 	for i, row := range rows {

--- a/warehouses/snowflake/quote.go
+++ b/warehouses/snowflake/quote.go
@@ -9,6 +9,11 @@ import (
 	"strings"
 )
 
+// csvColumnName returns the column name to write in Snowflake CSV headers.
+func csvColumnName(name string) string {
+	return strings.ToUpper(name)
+}
+
 // quoteBytes quotes s as a string and writes it into b.
 func quoteBytes(b *strings.Builder, s []byte) {
 	if len(s) == 0 {


### PR DESCRIPTION
```
connectors/snowflake, warehouses/snowflake: fix `Merge` CSV columns

Preserve connector column names in CSV headers so COPY INTO can match
them correctly with MATCH_BY_COLUMN_NAME = CASE_SENSITIVE.

Test_Merge_Query failed because Merge wrote CSV headers using uppercase
column names, but Snowflake matches those headers against case-sensitive
column names.

The Snowflake warehouse intentionally normalizes identifiers to
uppercase as the physical representation of Krenalis-managed tables.
This is internal to the warehouse and is consistent with its quoted SQL
identifiers and CSV headers.

The connector is different: it operates on user-owned Snowflake tables,
so column names must preserve the case reported by the table schema.
Reusing the warehouse uppercase CSV header behavior caused COPY INTO to
miss lowercase or mixed-case quoted columns and load NULL values
instead.

This mismatch was introduced by 03ae9e271, which aligned the Snowflake
connector and warehouse merge code but carried over the warehouse
uppercase column-name behavior to the connector.

Fixes #2198
```