### PR TITLE
connectors,core/internal/collector: support IPv6 collector IPs

### DIFF
--- a/connectors/mixpanel/mixpanel_test.go
+++ b/connectors/mixpanel/mixpanel_test.go
@@ -66,7 +66,7 @@ func TestSendEvents(t *testing.T) {
 				"device": map[string]any{
 					"advertisingId": "6D92078A-8246-4BA4-AE5B-76104861E7DC",
 				},
-				"ip": "192.0.2.1",
+				"ip": "2001:db8:face:12::1",
 				"os": map[string]any{
 					"name":    "macOS",
 					"version": "15.5",
@@ -135,7 +135,7 @@ func TestSendEvents(t *testing.T) {
 					"currency":         "USD",
 					"discount":         20.78,
 					"distinct_id":      event.Received.AnonymousID(),
-					"ip":               "192.0.2.1",
+					"ip":               "2001:db8:face:12::1",
 					"order_id":         "703924",
 					"products":         []map[string]any{{"sku": "G7NZ0I5"}, {"sku": "QN72LVRA"}},
 					"revenue":          198.45,

--- a/connectors/posthog/posthog_test.go
+++ b/connectors/posthog/posthog_test.go
@@ -85,7 +85,7 @@ func TestSendEvents(t *testing.T) {
 			"anonymousId":  anonymousID,
 			"userId":       userID,
 			"context": map[string]any{
-				"ip": "203.0.113.9",
+				"ip": "2001:db8:face:12::1",
 				"session": map[string]any{
 					"id":    int(sessionID),
 					"start": true,
@@ -132,7 +132,7 @@ func TestSendEvents(t *testing.T) {
 					"distinct_id": userID,
 					"properties": map[string]any{
 						"$anon_distinct_id": anonymousID,
-						"$ip":               "203.0.113.9",
+						"$ip":               "2001:db8:face:12::1",
 						"$set": map[string]any{
 							"active":     true,
 							"email":      "sam@example.com",

--- a/core/internal/collector/decoder.go
+++ b/core/internal/collector/decoder.go
@@ -583,9 +583,7 @@ func (d *decoder) decodeEvent(connectionId int, fallbackToRequestIP bool) (event
 			context["ip"] = d.remoteAddr.stronglyAnonymous
 			locationIP = d.remoteAddr.ip
 		default:
-			if addr.Is4In6() {
-				addr = addr.Unmap()
-			}
+			addr = addr.Unmap()
 			if addr.IsMulticast() {
 				return nil, errors.BadRequest("property 'ip' cannot be a multicast IP address")
 			}

--- a/core/internal/collector/decoder.go
+++ b/core/internal/collector/decoder.go
@@ -52,9 +52,9 @@ type decoder struct {
 	receivedAt time.Time
 	remoteAddr struct {
 		ip   netip.Addr
-		ip32 string // es. 192.168.1.42
-		ip24 string // es. 192.168.1.0
-		ip16 string // es. 192.168.0.0
+		ip32 string // e.g. 192.168.1.42 or 2001:db8:face:12::1
+		ip24 string // e.g. 192.168.1.0 (/24) or 2001:db8:face:12:: (/64)
+		ip16 string // e.g. 192.168.0.0 (/16) or 2001:db8:face:: (/48)
 	}
 	sentAt       time.Time
 	writeKey     string
@@ -176,7 +176,7 @@ func (d *decoder) Reset(r *http.Request) error {
 		clientIP = strings.TrimSpace(clientIP)
 		err = d.parseRemoteAddr(clientIP)
 		if err != nil {
-			return errors.BadRequest("address specified in the 'X-Forwarded-For' header is not a valid IPv4 address")
+			return errors.BadRequest("address specified in the 'X-Forwarded-For' header is not a valid IP address")
 		}
 	} else {
 		// The address wasn't provided through the 'X-Forwarded-For' header,
@@ -184,7 +184,7 @@ func (d *decoder) Reset(r *http.Request) error {
 		host, _, _ := net.SplitHostPort(r.RemoteAddr)
 		err = d.parseRemoteAddr(host)
 		if err != nil {
-			return errors.BadRequest("only IP version 4 is supported")
+			return errors.New("unexpected IP address from RemoteAddr")
 		}
 	}
 
@@ -567,11 +567,12 @@ func (d *decoder) decodeEvent(connectionId int, fallbackToRequestIP bool) (event
 	// IP.
 	if ip, ok := context["ip"].(string); ok {
 		addr, err := netip.ParseAddr(ip)
-		if err != nil {
+		if err != nil || addr.Zone() != "" {
 			return nil, errors.BadRequest("property 'ip' is not a valid IP address")
 		}
-		if !addr.Is4() {
-			return nil, errors.BadRequest("property 'ip' is not an IPv4 address")
+		mapped := addr.Is4In6()
+		if mapped {
+			addr = addr.Unmap()
 		}
 		switch addr {
 		case ip0: // 0.0.0.0
@@ -588,6 +589,9 @@ func (d *decoder) decodeEvent(connectionId int, fallbackToRequestIP bool) (event
 		default:
 			if addr.IsMulticast() {
 				return nil, errors.BadRequest("property 'ip' cannot be a multicast IP address")
+			}
+			if mapped {
+				context["ip"] = addr.String()
 			}
 			locationIP = addr
 		}
@@ -1099,21 +1103,25 @@ func (d *decoder) decodeContextSection(section *contextSection, isDefault bool) 
 	return sec, nil
 }
 
-// parseRemoteAddr parses s as an IPv4 address, including IPv4-mapped
+// parseRemoteAddr parses s as an IPv4 or IPv6 address, including IPv4-mapped
 // addresses such as "::ffff:192.0.2.1", and stores the result in d.remoteAddr.
 func (d *decoder) parseRemoteAddr(s string) error {
 	addr, err := netip.ParseAddr(s)
 	if err != nil {
 		return err
 	}
-	addr = addr.Unmap()
-	if !addr.Is4() {
-		return errors.New("not an IPv4 address")
+	if addr.Zone() != "" {
+		return errors.New("invalid scoped IP address")
 	}
-	d.remoteAddr.ip = addr.Unmap()
+	addr = addr.Unmap()
+	bits24, bits16 := 24, 16
+	if addr.Is6() {
+		bits24, bits16 = 64, 48
+	}
+	d.remoteAddr.ip = addr
 	d.remoteAddr.ip32 = d.remoteAddr.ip.String()
-	d.remoteAddr.ip24 = netip.PrefixFrom(addr, 24).Masked().Addr().String()
-	d.remoteAddr.ip16 = netip.PrefixFrom(addr, 16).Masked().Addr().String()
+	d.remoteAddr.ip24 = netip.PrefixFrom(addr, bits24).Masked().Addr().String()
+	d.remoteAddr.ip16 = netip.PrefixFrom(addr, bits16).Masked().Addr().String()
 	return nil
 }
 

--- a/core/internal/collector/decoder.go
+++ b/core/internal/collector/decoder.go
@@ -51,10 +51,10 @@ type decoder struct {
 
 	receivedAt time.Time
 	remoteAddr struct {
-		ip   netip.Addr
-		ip32 string // e.g. 192.168.1.42 or 2001:db8:face:12::1
-		ip24 string // e.g. 192.168.1.0 (/24) or 2001:db8:face:: (/48)
-		ip16 string // e.g. 192.168.0.0 (/16) or 2001:db8:: (/32)
+		ip                 netip.Addr
+		identifiable       string // e.g. 192.168.1.42 or 2001:db8:face:12::1
+		partiallyAnonymous string // e.g. 192.168.1.0 (/24) or 2001:db8:face:: (/48)
+		stronglyAnonymous  string // e.g. 192.168.0.0 (/16) or 2001:db8:: (/32)
 	}
 	sentAt       time.Time
 	writeKey     string
@@ -574,13 +574,13 @@ func (d *decoder) decodeEvent(connectionId int, fallbackToRequestIP bool) (event
 		case ip0: // 0.0.0.0
 			delete(context, "ip")
 		case ip32: // 255.255.255.255
-			context["ip"] = d.remoteAddr.ip32
+			context["ip"] = d.remoteAddr.identifiable
 			locationIP = d.remoteAddr.ip
 		case ip24: // 255.255.255.0
-			context["ip"] = d.remoteAddr.ip24
+			context["ip"] = d.remoteAddr.partiallyAnonymous
 			locationIP = d.remoteAddr.ip
 		case ip16: // 255.255.0.0
-			context["ip"] = d.remoteAddr.ip16
+			context["ip"] = d.remoteAddr.stronglyAnonymous
 			locationIP = d.remoteAddr.ip
 		default:
 			if addr.Is4In6() {
@@ -593,7 +593,7 @@ func (d *decoder) decodeEvent(connectionId int, fallbackToRequestIP bool) (event
 			locationIP = addr
 		}
 	} else if fallbackToRequestIP {
-		context["ip"] = d.remoteAddr.ip32
+		context["ip"] = d.remoteAddr.identifiable
 		locationIP = d.remoteAddr.ip
 	}
 
@@ -1111,14 +1111,15 @@ func (d *decoder) parseRemoteAddr(s string) error {
 		return errors.New("invalid scoped IP address")
 	}
 	addr = addr.Unmap()
-	bits24, bits16 := 24, 16
-	if addr.Is6() {
-		bits24, bits16 = 48, 32
-	}
 	d.remoteAddr.ip = addr
-	d.remoteAddr.ip32 = d.remoteAddr.ip.String()
-	d.remoteAddr.ip24 = netip.PrefixFrom(addr, bits24).Masked().Addr().String()
-	d.remoteAddr.ip16 = netip.PrefixFrom(addr, bits16).Masked().Addr().String()
+	d.remoteAddr.identifiable = d.remoteAddr.ip.String()
+	if addr.Is6() {
+		d.remoteAddr.partiallyAnonymous = netip.PrefixFrom(addr, 48).Masked().Addr().String()
+		d.remoteAddr.stronglyAnonymous = netip.PrefixFrom(addr, 32).Masked().Addr().String()
+	} else {
+		d.remoteAddr.partiallyAnonymous = netip.PrefixFrom(addr, 24).Masked().Addr().String()
+		d.remoteAddr.stronglyAnonymous = netip.PrefixFrom(addr, 16).Masked().Addr().String()
+	}
 	return nil
 }
 

--- a/core/internal/collector/decoder.go
+++ b/core/internal/collector/decoder.go
@@ -570,8 +570,8 @@ func (d *decoder) decodeEvent(connectionId int, fallbackToRequestIP bool) (event
 		if err != nil || addr.Zone() != "" {
 			return nil, errors.BadRequest("property 'ip' is not a valid IP address")
 		}
-		mapped := addr.Is4In6()
-		if mapped {
+		ip4in6 := addr.Is4In6()
+		if ip4in6 {
 			addr = addr.Unmap()
 		}
 		switch addr {
@@ -590,7 +590,7 @@ func (d *decoder) decodeEvent(connectionId int, fallbackToRequestIP bool) (event
 			if addr.IsMulticast() {
 				return nil, errors.BadRequest("property 'ip' cannot be a multicast IP address")
 			}
-			if mapped {
+			if ip4in6 {
 				context["ip"] = addr.String()
 			}
 			locationIP = addr

--- a/core/internal/collector/decoder.go
+++ b/core/internal/collector/decoder.go
@@ -53,8 +53,8 @@ type decoder struct {
 	remoteAddr struct {
 		ip   netip.Addr
 		ip32 string // e.g. 192.168.1.42 or 2001:db8:face:12::1
-		ip24 string // e.g. 192.168.1.0 (/24) or 2001:db8:face:12:: (/64)
-		ip16 string // e.g. 192.168.0.0 (/16) or 2001:db8:face:: (/48)
+		ip24 string // e.g. 192.168.1.0 (/24) or 2001:db8:face:: (/48)
+		ip16 string // e.g. 192.168.0.0 (/16) or 2001:db8:: (/32)
 	}
 	sentAt       time.Time
 	writeKey     string
@@ -1116,7 +1116,7 @@ func (d *decoder) parseRemoteAddr(s string) error {
 	addr = addr.Unmap()
 	bits24, bits16 := 24, 16
 	if addr.Is6() {
-		bits24, bits16 = 64, 48
+		bits24, bits16 = 48, 32
 	}
 	d.remoteAddr.ip = addr
 	d.remoteAddr.ip32 = d.remoteAddr.ip.String()

--- a/core/internal/collector/decoder.go
+++ b/core/internal/collector/decoder.go
@@ -570,10 +570,6 @@ func (d *decoder) decodeEvent(connectionId int, fallbackToRequestIP bool) (event
 		if err != nil || addr.Zone() != "" {
 			return nil, errors.BadRequest("property 'ip' is not a valid IP address")
 		}
-		ip4in6 := addr.Is4In6()
-		if ip4in6 {
-			addr = addr.Unmap()
-		}
 		switch addr {
 		case ip0: // 0.0.0.0
 			delete(context, "ip")
@@ -587,12 +583,13 @@ func (d *decoder) decodeEvent(connectionId int, fallbackToRequestIP bool) (event
 			context["ip"] = d.remoteAddr.ip16
 			locationIP = d.remoteAddr.ip
 		default:
+			if addr.Is4In6() {
+				addr = addr.Unmap()
+			}
 			if addr.IsMulticast() {
 				return nil, errors.BadRequest("property 'ip' cannot be a multicast IP address")
 			}
-			if ip4in6 {
-				context["ip"] = addr.String()
-			}
+			context["ip"] = addr.String()
 			locationIP = addr
 		}
 	} else if fallbackToRequestIP {

--- a/core/internal/collector/decoder_test.go
+++ b/core/internal/collector/decoder_test.go
@@ -1486,7 +1486,7 @@ func TestParseRemoteAddr(t *testing.T) {
 				t.Fatalf("normalization: expected %q, got %q", "192.168.1.42", ra.identifiable)
 			}
 			if ra.partiallyAnonymous != "192.168.1.0" || ra.stronglyAnonymous != "192.168.0.0" {
-				t.Fatalf("masked normalization: expected ip24=%q ip16=%q, got ip24=%q ip16=%q",
+				t.Fatalf("masked normalization: expected partiallyAnonymous=%q stronglyAnonymous=%q, got partiallyAnonymous=%q stronglyAnonymous=%q",
 					"192.168.1.0", "192.168.0.0", ra.partiallyAnonymous, ra.stronglyAnonymous)
 			}
 		}

--- a/core/internal/collector/decoder_test.go
+++ b/core/internal/collector/decoder_test.go
@@ -725,8 +725,8 @@ func TestDecoderContextIPHandling(t *testing.T) {
 
 	const remoteIP = "198.51.100.23"
 	const remoteIPv6 = "2001:db8:face:12::1"
-	const remoteIPv6Prefix64 = "2001:db8:face:12::"
 	const remoteIPv6Prefix48 = "2001:db8:face::"
+	const remoteIPv6Prefix32 = "2001:db8::"
 
 	remoteParts := strings.Split(remoteIP, ".")
 	if len(remoteParts) != 4 {
@@ -899,14 +899,14 @@ func TestDecoderContextIPHandling(t *testing.T) {
 			contextJSON: `{"ip":"255.255.255.0"}`,
 			fallback:    false,
 			remoteIP:    remoteIPv6,
-			wantIP:      expectedIP{present: true, value: remoteIPv6Prefix64},
+			wantIP:      expectedIP{present: true, value: remoteIPv6Prefix48},
 		},
 		{
 			name:        "context-ip-mask-16-with-ipv6-remote",
 			contextJSON: `{"ip":"255.255.0.0"}`,
 			fallback:    false,
 			remoteIP:    remoteIPv6,
-			wantIP:      expectedIP{present: true, value: remoteIPv6Prefix48},
+			wantIP:      expectedIP{present: true, value: remoteIPv6Prefix32},
 		},
 		{
 			name:         "x-forwarded-for-ipv6-overrides-remote-addr",
@@ -1402,7 +1402,7 @@ func TestParseRemoteAddr(t *testing.T) {
 		{"172.16.5.123", "172.16.5.123", "172.16.5.0", "172.16.0.0"},
 		{"8.8.8.8", "8.8.8.8", "8.8.8.0", "8.8.0.0"},
 		{"::ffff:192.0.2.1", "192.0.2.1", "192.0.2.0", "192.0.0.0"},
-		{"2001:db8:face:12::1", "2001:db8:face:12::1", "2001:db8:face:12::", "2001:db8:face::"},
+		{"2001:db8:face:12::1", "2001:db8:face:12::1", "2001:db8:face::", "2001:db8::"},
 		{"::1", "::1", "::", "::"},
 
 		// Edge octet values.

--- a/core/internal/collector/decoder_test.go
+++ b/core/internal/collector/decoder_test.go
@@ -881,6 +881,18 @@ func TestDecoderContextIPHandling(t *testing.T) {
 			wantIP:      expectedIP{present: true, value: remoteIP16},
 		},
 		{
+			name:        "context-ipv4-mapped-ipv6-mask-24",
+			contextJSON: `{"ip":"::ffff:255.255.255.0"}`,
+			fallback:    false,
+			wantIP:      expectedIP{present: true, value: "255.255.255.0"},
+		},
+		{
+			name:        "context-ipv4-mapped-ipv6-multicast",
+			contextJSON: `{"ip":"::ffff:224.0.0.1"}`,
+			fallback:    false,
+			wantErr:     errors.BadRequest("property 'ip' cannot be a multicast IP address"),
+		},
+		{
 			name:        "no-context-ip-ipv6-fallback-enabled",
 			contextJSON: "",
 			fallback:    true,

--- a/core/internal/collector/decoder_test.go
+++ b/core/internal/collector/decoder_test.go
@@ -1403,10 +1403,10 @@ func TestParseRemoteAddr(t *testing.T) {
 
 	// --- valid cases ---
 	valid := []struct {
-		in     string
-		want32 string
-		want24 string
-		want16 string
+		in                     string
+		wantIdentifiable       string
+		wantPartiallyAnonymous string
+		wantStronglyAnonymous  string
 	}{
 		// Common cases.
 		{"192.168.1.42", "192.168.1.42", "192.168.1.0", "192.168.0.0"},
@@ -1435,17 +1435,17 @@ func TestParseRemoteAddr(t *testing.T) {
 			}
 
 			ra := dec.remoteAddr
-			if ra.ip32 != test.want32 {
-				t.Fatalf("ip32: expected %q, got %q", test.want32, ra.ip32)
+			if ra.identifiable != test.wantIdentifiable {
+				t.Fatalf("identifiable: expected %q, got %q", test.wantIdentifiable, ra.identifiable)
 			}
-			if ra.ip24 != test.want24 {
-				t.Fatalf("ip24: expected %q, got %q", test.want24, ra.ip24)
+			if ra.partiallyAnonymous != test.wantPartiallyAnonymous {
+				t.Fatalf("partiallyAnonymous: expected %q, got %q", test.wantPartiallyAnonymous, ra.partiallyAnonymous)
 			}
-			if ra.ip16 != test.want16 {
-				t.Fatalf("ip16: expected %q, got %q", test.want16, ra.ip16)
+			if ra.stronglyAnonymous != test.wantStronglyAnonymous {
+				t.Fatalf("stronglyAnonymous: expected %q, got %q", test.wantStronglyAnonymous, ra.stronglyAnonymous)
 			}
 
-			wantIP := netip.MustParseAddr(test.want32)
+			wantIP := netip.MustParseAddr(test.wantIdentifiable)
 			if wantIP != ra.ip {
 				t.Fatalf("ip: expected %v, got %v", wantIP, ra.ip)
 			}
@@ -1468,7 +1468,7 @@ func TestParseRemoteAddr(t *testing.T) {
 				t.Fatalf("parseRemoteAddr(%q): expected error, got nil", in)
 			}
 			ra := dec.remoteAddr
-			if ra.ip32 != "" || ra.ip24 != "" || ra.ip16 != "" || ra.ip.IsValid() {
+			if ra.identifiable != "" || ra.partiallyAnonymous != "" || ra.stronglyAnonymous != "" || ra.ip.IsValid() {
 				t.Fatalf("parseRemoteAddr(%q): expected zero-value remoteAddr on error, got %+v", in, ra)
 			}
 		})
@@ -1482,12 +1482,12 @@ func TestParseRemoteAddr(t *testing.T) {
 		err := dec.parseRemoteAddr("192.168.001.042")
 		if err == nil {
 			ra := dec.remoteAddr
-			if ra.ip32 != "192.168.1.42" {
-				t.Fatalf("normalization: expected %q, got %q", "192.168.1.42", ra.ip32)
+			if ra.identifiable != "192.168.1.42" {
+				t.Fatalf("normalization: expected %q, got %q", "192.168.1.42", ra.identifiable)
 			}
-			if ra.ip24 != "192.168.1.0" || ra.ip16 != "192.168.0.0" {
+			if ra.partiallyAnonymous != "192.168.1.0" || ra.stronglyAnonymous != "192.168.0.0" {
 				t.Fatalf("masked normalization: expected ip24=%q ip16=%q, got ip24=%q ip16=%q",
-					"192.168.1.0", "192.168.0.0", ra.ip24, ra.ip16)
+					"192.168.1.0", "192.168.0.0", ra.partiallyAnonymous, ra.stronglyAnonymous)
 			}
 		}
 	})

--- a/core/internal/collector/decoder_test.go
+++ b/core/internal/collector/decoder_test.go
@@ -6,6 +6,7 @@ package collector
 
 import (
 	"io"
+	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -723,6 +724,9 @@ func TestDecoderContextIPHandling(t *testing.T) {
 	t.Parallel()
 
 	const remoteIP = "198.51.100.23"
+	const remoteIPv6 = "2001:db8:face:12::1"
+	const remoteIPv6Prefix64 = "2001:db8:face:12::"
+	const remoteIPv6Prefix48 = "2001:db8:face::"
 
 	remoteParts := strings.Split(remoteIP, ".")
 	if len(remoteParts) != 4 {
@@ -744,16 +748,21 @@ func TestDecoderContextIPHandling(t *testing.T) {
 		return base + `,"context":` + contextJSON + `}`
 	}
 
-	decode := func(t *testing.T, body string, fallback bool) events.Event {
+	decode := func(t *testing.T, body string, fallback bool, remoteAddr string, forwardedFor string) (events.Event, error) {
 		t.Helper()
 
+		header := http.Header{
+			"Content-Type": []string{"application/json; charset=utf-8"},
+			"User-Agent":   []string{"DecoderContextIPTest/1.0"},
+		}
+		if forwardedFor != "" {
+			header.Set("X-Forwarded-For", forwardedFor)
+		}
+
 		r := &http.Request{
-			Method: "POST",
-			Header: http.Header{
-				"Content-Type": []string{"application/json; charset=utf-8"},
-				"User-Agent":   []string{"DecoderContextIPTest/1.0"},
-			},
-			RemoteAddr: remoteIP + ":9000",
+			Method:     "POST",
+			Header:     header,
+			RemoteAddr: remoteAddr,
 			URL:        requestURL,
 			Body:       io.NopCloser(strings.NewReader(body)),
 		}
@@ -775,17 +784,14 @@ func TestDecoderContextIPHandling(t *testing.T) {
 			count++
 		}
 
-		if gotErr != nil {
-			t.Fatalf("unexpected event error: %v", gotErr)
-		}
 		if count != 1 {
 			t.Fatalf("expected 1 event, got %d", count)
 		}
-		if gotEvent == nil {
+		if gotErr == nil && gotEvent == nil {
 			t.Fatal("expected non-nil event, got nil")
 		}
 
-		return gotEvent
+		return gotEvent, gotErr
 	}
 
 	type expectedIP struct {
@@ -794,10 +800,13 @@ func TestDecoderContextIPHandling(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		contextJSON string
-		fallback    bool
-		wantIP      expectedIP
+		name         string
+		contextJSON  string
+		fallback     bool
+		remoteIP     string
+		forwardedFor string
+		wantIP       expectedIP
+		wantErr      error
 	}{
 		{
 			name:        "no-context-ip-fallback-disabled",
@@ -824,6 +833,30 @@ func TestDecoderContextIPHandling(t *testing.T) {
 			wantIP:      expectedIP{present: true, value: "198.18.0.1"},
 		},
 		{
+			name:        "context-regular-ipv6",
+			contextJSON: `{"ip":"2001:db8:face:12::1"}`,
+			fallback:    true,
+			wantIP:      expectedIP{present: true, value: "2001:db8:face:12::1"},
+		},
+		{
+			name:        "context-ipv4-mapped-ipv6",
+			contextJSON: `{"ip":"::ffff:192.0.2.1"}`,
+			fallback:    true,
+			wantIP:      expectedIP{present: true, value: "192.0.2.1"},
+		},
+		{
+			name:        "context-scoped-ipv6",
+			contextJSON: `{"ip":"fe80::1%eth0"}`,
+			fallback:    true,
+			wantErr:     errors.BadRequest("property 'ip' is not a valid IP address"),
+		},
+		{
+			name:        "context-multicast-ipv6",
+			contextJSON: `{"ip":"ff02::1"}`,
+			fallback:    true,
+			wantErr:     errors.BadRequest("property 'ip' cannot be a multicast IP address"),
+		},
+		{
 			name:        "context-ip-zero",
 			contextJSON: `{"ip":"0.0.0.0"}`,
 			fallback:    true,
@@ -847,6 +880,48 @@ func TestDecoderContextIPHandling(t *testing.T) {
 			fallback:    false,
 			wantIP:      expectedIP{present: true, value: remoteIP16},
 		},
+		{
+			name:        "no-context-ip-ipv6-fallback-enabled",
+			contextJSON: "",
+			fallback:    true,
+			remoteIP:    remoteIPv6,
+			wantIP:      expectedIP{present: true, value: remoteIPv6},
+		},
+		{
+			name:        "context-ip-mask-32-with-ipv6-remote",
+			contextJSON: `{"ip":"255.255.255.255"}`,
+			fallback:    false,
+			remoteIP:    remoteIPv6,
+			wantIP:      expectedIP{present: true, value: remoteIPv6},
+		},
+		{
+			name:        "context-ip-mask-24-with-ipv6-remote",
+			contextJSON: `{"ip":"255.255.255.0"}`,
+			fallback:    false,
+			remoteIP:    remoteIPv6,
+			wantIP:      expectedIP{present: true, value: remoteIPv6Prefix64},
+		},
+		{
+			name:        "context-ip-mask-16-with-ipv6-remote",
+			contextJSON: `{"ip":"255.255.0.0"}`,
+			fallback:    false,
+			remoteIP:    remoteIPv6,
+			wantIP:      expectedIP{present: true, value: remoteIPv6Prefix48},
+		},
+		{
+			name:         "x-forwarded-for-ipv6-overrides-remote-addr",
+			contextJSON:  "",
+			fallback:     true,
+			forwardedFor: remoteIPv6,
+			wantIP:       expectedIP{present: true, value: remoteIPv6},
+		},
+		{
+			name:         "x-forwarded-for-ipv6-list",
+			contextJSON:  "",
+			fallback:     true,
+			forwardedFor: remoteIPv6 + ", " + remoteIP,
+			wantIP:       expectedIP{present: true, value: remoteIPv6},
+		},
 	}
 
 	for _, tt := range tests {
@@ -854,7 +929,17 @@ func TestDecoderContextIPHandling(t *testing.T) {
 			t.Parallel()
 
 			body := makeBody(tt.contextJSON)
-			event := decode(t, body, tt.fallback)
+			remoteAddr := remoteIP
+			if tt.remoteIP != "" {
+				remoteAddr = tt.remoteIP
+			}
+			event, err := decode(t, body, tt.fallback, net.JoinHostPort(remoteAddr, "9000"), tt.forwardedFor)
+			if !reflect.DeepEqual(tt.wantErr, err) {
+				t.Fatalf("expected error %#v, got error %#v", tt.wantErr, err)
+			}
+			if err != nil {
+				return
+			}
 
 			ctx, ok := event["context"].(map[string]any)
 			if ctx == nil {
@@ -877,6 +962,66 @@ func TestDecoderContextIPHandling(t *testing.T) {
 				if ok {
 					t.Fatalf("expected context.ip to be absent, got %v", ipVal)
 				}
+			}
+		})
+	}
+}
+
+// TestDecoderRemoteAddrValidation verifies request-level validation of IP
+// addresses provided by RemoteAddr and X-Forwarded-For.
+func TestDecoderRemoteAddrValidation(t *testing.T) {
+	t.Parallel()
+
+	requestURL, err := url.Parse("/events/track")
+	if err != nil {
+		t.Fatalf("failed to parse request URL: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		remoteAddr   string
+		forwardedFor string
+		wantErr      error
+	}{
+		{
+			name:         "scoped-ipv6-x-forwarded-for",
+			remoteAddr:   net.JoinHostPort("198.51.100.23", "9000"),
+			forwardedFor: "fe80::1%eth0",
+			wantErr:      errors.BadRequest("address specified in the 'X-Forwarded-For' header is not a valid IP address"),
+		},
+		{
+			name:       "scoped-ipv6-remote-addr",
+			remoteAddr: net.JoinHostPort("fe80::1%eth0", "9000"),
+			wantErr:    errors.New("unexpected IP address from RemoteAddr"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			header := http.Header{
+				"Content-Type": []string{"application/json; charset=utf-8"},
+				"User-Agent":   []string{"DecoderRemoteAddrValidationTest/1.0"},
+			}
+			if tt.forwardedFor != "" {
+				header.Set("X-Forwarded-For", tt.forwardedFor)
+			}
+
+			r := &http.Request{
+				Method:     "POST",
+				Header:     header,
+				RemoteAddr: tt.remoteAddr,
+				URL:        requestURL,
+				Body:       io.NopCloser(strings.NewReader(`{"type":"track","event":"click","anonymousId":"anon-1"}`)),
+			}
+
+			dec, err := newDecoder(r)
+			if !reflect.DeepEqual(tt.wantErr, err) {
+				t.Fatalf("expected error %#v, got error %#v", tt.wantErr, err)
+			}
+			if dec != nil {
+				t.Fatal("unexpected non-nil decoder")
 			}
 		})
 	}
@@ -1257,6 +1402,8 @@ func TestParseRemoteAddr(t *testing.T) {
 		{"172.16.5.123", "172.16.5.123", "172.16.5.0", "172.16.0.0"},
 		{"8.8.8.8", "8.8.8.8", "8.8.8.0", "8.8.0.0"},
 		{"::ffff:192.0.2.1", "192.0.2.1", "192.0.2.0", "192.0.0.0"},
+		{"2001:db8:face:12::1", "2001:db8:face:12::1", "2001:db8:face:12::", "2001:db8:face::"},
+		{"::1", "::1", "::", "::"},
 
 		// Edge octet values.
 		{"0.0.0.0", "0.0.0.0", "0.0.0.0", "0.0.0.0"},
@@ -1296,7 +1443,7 @@ func TestParseRemoteAddr(t *testing.T) {
 	// --- invalid cases ---
 	invalid := []string{
 		"", "   ", "1.2.3", "1.2.3.4.5", "256.1.1.1", "-1.2.3.4", "1.2.3.-4",
-		"abc.def.ghi.jkl", "::1", "2001:db8::1", "1.2.3.4 ", " 1.2.3.4",
+		"abc.def.ghi.jkl", "fe80::1%eth0", "1.2.3.4 ", " 1.2.3.4",
 	}
 
 	for _, in := range invalid {


### PR DESCRIPTION
```
connectors,core/internal/collector: support IPv6 collector IPs

Currently, Krenalis returns HTTP 400 Bad Request when the requester IP
from RemoteAddr, X-Forwarded-For, or context.ip is an IPv6 address.

Fix this by allowing the collector to accept IPv6 addresses from
RemoteAddr, X-Forwarded-For, and context.ip.

Remote address masking preserves the existing IPv4 behavior for the
IPv4 sentinel values 255.255.255.255, 255.255.255.0, and 255.255.0.0,
while applying the IPv6 equivalents /128, /48, and /32 to IPv6 request
IPs.

IPv4-mapped IPv6 addresses are normalized to IPv4, and scoped IPv6
addresses are rejected.

Also update Mixpanel and PostHog connector tests to cover successful
IPv6 IP forwarding.
```