### PR TITLE
connectors/s3: use custom S3 HTTP client tuned for large transfers

### DIFF
--- a/connectors/s3/s3.go
+++ b/connectors/s3/s3.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	_ "embed"
 	"io"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -22,9 +23,10 @@ import (
 	"github.com/krenalis/krenalis/tools/json"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsHTTP "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
-	s3pkg "github.com/aws/aws-sdk-go-v2/service/s3"
+	awsS3 "github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 //go:embed documentation/source/overview.md
@@ -94,7 +96,7 @@ func (s3 *S3) Reader(ctx context.Context, name string) (io.ReadCloser, time.Time
 		return nil, time.Time{}, err
 	}
 	client := s3.client(&s)
-	res, err := client.GetObject(ctx, &s3pkg.GetObjectInput{
+	res, err := client.GetObject(ctx, &awsS3.GetObjectInput{
 		Bucket: aws.String(s.Bucket),
 		Key:    aws.String(name),
 	})
@@ -205,7 +207,7 @@ func (s3 *S3) Write(ctx context.Context, p io.Reader, name, contentType string) 
 }
 
 // client returns a S3 client.
-func (s3 *S3) client(s *innerSettings) *s3pkg.Client {
+func (s3 *S3) client(s *innerSettings) *awsS3.Client {
 	cfg := aws.Config{
 		Region: s.Region,
 		Credentials: aws.NewCredentialsCache(
@@ -215,8 +217,16 @@ func (s3 *S3) client(s *innerSettings) *s3pkg.Client {
 				"",
 			),
 		),
+		HTTPClient: awsHTTP.NewBuildableClient().
+			WithTransportOptions(func(transport *http.Transport) {
+				transport.Proxy = nil
+				transport.MaxConnsPerHost = 2
+				transport.MaxIdleConns = 2
+				transport.MaxIdleConnsPerHost = 2
+				transport.IdleConnTimeout = 10 * time.Second
+			}),
 	}
-	return s3pkg.NewFromConfig(cfg)
+	return awsS3.NewFromConfig(cfg)
 }
 
 // saveSettings validates and saves the settings.

--- a/connectors/s3/s3.go
+++ b/connectors/s3/s3.go
@@ -40,8 +40,8 @@ const (
 	maxConnsPerHost       = 64               // Maximum connections per host.
 	maxIdleConns          = 1024             // Maximum idle keep-alive connections.
 	maxIdleConnsPerHost   = 64               // Maximum idle keep-alive connections per host.
-	idleConnTimeout       = 10 * time.Second // Maximum idle keep-alive connection time.
-	responseHeaderTimeout = 3 * time.Second  // Maximum time to wait for response headers.
+	idleConnTimeout       = 20 * time.Second // Maximum idle keep-alive connection time.
+	responseHeaderTimeout = 10 * time.Second // Maximum time to wait for response headers.
 
 	partSizeBytes = 8 * 1024 * 1024 // Buffer size in bytes for S3 multipart uploads.
 	concurrency   = 2               // Number of goroutines used in parallel for object transfers.

--- a/connectors/s3/s3.go
+++ b/connectors/s3/s3.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/krenalis/krenalis/connectors"
@@ -34,6 +35,15 @@ var sourceOverview string
 
 //go:embed documentation/destination/overview.md
 var destinationOverview string
+
+const (
+	maxConnsPerHost     = 64   // Maximum connections per host.
+	maxIdleConns        = 1024 // Maximum idle keep-alive connections.
+	maxIdleConnsPerHost = 64   // Maximum idle keep-alive connections per host.
+
+	partSizeBytes = 8 * 1024 * 1024 // Buffer size in bytes for S3 multipart uploads.
+	concurrency   = 2               // Number of goroutines used in parallel for object transfers.
+)
 
 func init() {
 	connectors.RegisterFileStorage(connectors.FileStorageSpec{
@@ -194,8 +204,8 @@ func (s3 *S3) Write(ctx context.Context, p io.Reader, name, contentType string) 
 	}
 	client := s3.client(&s)
 	tm := transfermanager.New(client, func(opts *transfermanager.Options) {
-		opts.PartSizeBytes = 8 * 1024 * 1024
-		opts.Concurrency = 2
+		opts.PartSizeBytes = partSizeBytes
+		opts.Concurrency = concurrency
 	})
 	_, err = tm.UploadObject(ctx, &transfermanager.UploadObjectInput{
 		Bucket:      aws.String(s.Bucket),
@@ -217,14 +227,16 @@ func (s3 *S3) client(s *innerSettings) *awsS3.Client {
 				"",
 			),
 		),
-		HTTPClient: awsHTTP.NewBuildableClient().
-			WithTransportOptions(func(transport *http.Transport) {
-				transport.Proxy = nil
-				transport.MaxConnsPerHost = 2
-				transport.MaxIdleConns = 2
-				transport.MaxIdleConnsPerHost = 2
-				transport.IdleConnTimeout = 10 * time.Second
-			}),
+		HTTPClient: sync.OnceValue(func() aws.HTTPClient {
+			return awsHTTP.NewBuildableClient().
+				WithTransportOptions(func(transport *http.Transport) {
+					transport.Proxy = nil
+					transport.MaxConnsPerHost = maxConnsPerHost
+					transport.MaxIdleConns = maxIdleConns
+					transport.MaxIdleConnsPerHost = maxIdleConnsPerHost
+					transport.IdleConnTimeout = 10 * time.Second
+				})
+		})(),
 	}
 	return awsS3.NewFromConfig(cfg)
 }

--- a/connectors/s3/s3.go
+++ b/connectors/s3/s3.go
@@ -37,9 +37,11 @@ var sourceOverview string
 var destinationOverview string
 
 const (
-	maxConnsPerHost     = 64   // Maximum connections per host.
-	maxIdleConns        = 1024 // Maximum idle keep-alive connections.
-	maxIdleConnsPerHost = 64   // Maximum idle keep-alive connections per host.
+	maxConnsPerHost       = 64               // Maximum connections per host.
+	maxIdleConns          = 1024             // Maximum idle keep-alive connections.
+	maxIdleConnsPerHost   = 64               // Maximum idle keep-alive connections per host.
+	idleConnTimeout       = 10 * time.Second // Maximum idle keep-alive connection time.
+	responseHeaderTimeout = 3 * time.Second  // Maximum time to wait for response headers.
 
 	partSizeBytes = 8 * 1024 * 1024 // Buffer size in bytes for S3 multipart uploads.
 	concurrency   = 2               // Number of goroutines used in parallel for object transfers.
@@ -234,7 +236,8 @@ func (s3 *S3) client(s *innerSettings) *awsS3.Client {
 					transport.MaxConnsPerHost = maxConnsPerHost
 					transport.MaxIdleConns = maxIdleConns
 					transport.MaxIdleConnsPerHost = maxIdleConnsPerHost
-					transport.IdleConnTimeout = 10 * time.Second
+					transport.IdleConnTimeout = idleConnTimeout
+					transport.ResponseHeaderTimeout = responseHeaderTimeout
 				})
 		})(),
 	}

--- a/connectors/s3/s3.go
+++ b/connectors/s3/s3.go
@@ -218,6 +218,18 @@ func (s3 *S3) Write(ctx context.Context, p io.Reader, name, contentType string) 
 	return err
 }
 
+var httpClient = sync.OnceValue(func() aws.HTTPClient {
+	return awsHTTP.NewBuildableClient().
+		WithTransportOptions(func(transport *http.Transport) {
+			transport.Proxy = nil
+			transport.MaxConnsPerHost = maxConnsPerHost
+			transport.MaxIdleConns = maxIdleConns
+			transport.MaxIdleConnsPerHost = maxIdleConnsPerHost
+			transport.IdleConnTimeout = idleConnTimeout
+			transport.ResponseHeaderTimeout = responseHeaderTimeout
+		})
+})
+
 // client returns a S3 client.
 func (s3 *S3) client(s *innerSettings) *awsS3.Client {
 	cfg := aws.Config{
@@ -229,17 +241,7 @@ func (s3 *S3) client(s *innerSettings) *awsS3.Client {
 				"",
 			),
 		),
-		HTTPClient: sync.OnceValue(func() aws.HTTPClient {
-			return awsHTTP.NewBuildableClient().
-				WithTransportOptions(func(transport *http.Transport) {
-					transport.Proxy = nil
-					transport.MaxConnsPerHost = maxConnsPerHost
-					transport.MaxIdleConns = maxIdleConns
-					transport.MaxIdleConnsPerHost = maxIdleConnsPerHost
-					transport.IdleConnTimeout = idleConnTimeout
-					transport.ResponseHeaderTimeout = responseHeaderTimeout
-				})
-		})(),
+		HTTPClient: httpClient(),
 	}
 	return awsS3.NewFromConfig(cfg)
 }

--- a/connectors/s3/s3_test.go
+++ b/connectors/s3/s3_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/krenalis/krenalis/tools/json"
 )
 
+// TestHTTPClient checks that the S3 HTTP client is reused.
+func TestHTTPClient(t *testing.T) {
+	if httpClient() != httpClient() {
+		t.Fatal("expected the same HTTP client, got a different one")
+	}
+}
+
+// TestPathConvert checks S3 absolute path conversion.
 func TestPathConvert(t *testing.T) {
 	s3 := &S3{env: &connectors.FileStorageEnv{Settings: newTestSettingsStore(t, innerSettings{Bucket: "my-example-bucket"})}}
 	tests := []testconnector.AbsolutePathTest{


### PR DESCRIPTION
```
connectors/s3: use custom S3 HTTP client

Previously, S3 requests used the default AWS SDK HTTP client. This
change introduces a custom client.

The custom transport disables proxy lookup from environment variables.

NewBuildableClient is used instead of a plain http.Client so the AWS SDK
can still apply its service/default-mode HTTP customizations before the
underlying client and transport are built.
```