### PR TITLE
connectors/sftp: add SFTP host key validation

### DIFF
--- a/connectors/sftp/documentation/destination/overview.md
+++ b/connectors/sftp/documentation/destination/overview.md
@@ -8,3 +8,4 @@ This connector lets you export unified users. These are users that have been con
 ## What does it require?
 
 * A username and password for an SFTP server with write access.
+* Optionally, provide the server host key so Krenalis can verify that it is connecting to the expected server.

--- a/connectors/sftp/documentation/source/overview.md
+++ b/connectors/sftp/documentation/source/overview.md
@@ -8,3 +8,4 @@ This connector lets you import user data from files stored in a SFTP server into
 ## What does it require?
 
 * A username and password for an SFTP server with read access.
+* Optionally, provide the server host key so Krenalis can verify that it is connecting to the expected server.

--- a/connectors/sftp/sftp.go
+++ b/connectors/sftp/sftp.go
@@ -7,6 +7,7 @@
 package sftp
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"errors"
@@ -33,6 +34,8 @@ var sourceOverview string
 
 //go:embed documentation/destination/overview.md
 var destinationOverview string
+
+var errHostKeyMismatch = errors.New("host key mismatch")
 
 func init() {
 	connectors.RegisterFileStorage(connectors.FileStorageSpec{
@@ -62,11 +65,12 @@ type SFTP struct {
 }
 
 type innerSettings struct {
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	Username string `json:"username"`
-	Password string `json:"password"`
-	TempPath string `json:"tempPath"`
+	Host          string `json:"host"`
+	Port          int    `json:"port"`
+	Username      string `json:"username"`
+	Password      string `json:"password"`
+	HostPublicKey string `json:"hostPublicKey"`
+	TempPath      string `json:"tempPath"`
 }
 
 // AbsolutePath returns the absolute representation of the given path name.
@@ -147,6 +151,7 @@ func (sf *SFTP) ServeUI(ctx context.Context, event string, settings json.Value, 
 			&connectors.Input{Name: "port", Label: "Port", Placeholder: "22", Type: "number", OnlyIntegerPart: true, MinLength: 1, MaxLength: 5},
 			&connectors.Input{Name: "username", Label: "Username", Placeholder: "username", Type: "text", MinLength: 1, MaxLength: 200},
 			&connectors.Input{Name: "password", Label: "Password", Placeholder: "password", Type: "password", MinLength: 1, MaxLength: 200},
+			&connectors.Input{Name: "hostPublicKey", Label: "Server public key", Placeholder: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...", HelpText: "Strongly recommended. Ensures the SFTP server identity matches this OpenSSH public key.", Rows: 3, MaxLength: 5000},
 			&connectors.Input{Name: "tempPath", Label: "Temporary directory path", Placeholder: "/", Type: "text", MinLength: 0, MaxLength: 1000, Role: connectors.Destination},
 		},
 		Settings: settings,
@@ -243,6 +248,16 @@ func (sf *SFTP) saveSettings(ctx context.Context, settings json.Value, role conn
 	if n := utf8.RuneCountInString(s.Password); n < 1 || n > 200 {
 		return connectors.NewInvalidSettingsError("password length must be in range [1,200]")
 	}
+	// Validate HostPublicKey.
+	s.HostPublicKey = strings.TrimSpace(s.HostPublicKey)
+	if s.HostPublicKey != "" {
+		if n := utf8.RuneCountInString(s.HostPublicKey); n > 5000 {
+			return connectors.NewInvalidSettingsError("server public key length must be in range [0,5000]")
+		}
+		if err := validateHostPublicKey(s.HostPublicKey); err != nil {
+			return connectors.NewInvalidSettingsError("server public key must be a valid OpenSSH public key")
+		}
+	}
 	// Validate TempPath.
 	if role == connectors.Destination {
 		if n := utf8.RuneCountInString(s.TempPath); n > 1000 {
@@ -304,17 +319,65 @@ func (client *client) close() error {
 	return err2
 }
 
-// openClient opens a client for the SFTP server based on the provided settings.
-// The returned client must be closed using the close method. If the context is
-// canceled before the client is closed, the underlying network connection, not
-// the client, will be automatically closed.
-func openClient(ctx context.Context, s *innerSettings) (*client, error) {
+// hostKeyAlgorithms returns the host key algorithms accepted for the given key.
+//
+// RSA public keys are identified as "ssh-rsa", but SSH servers may use the
+// same key with the stronger rsa-sha2-256 or rsa-sha2-512 signature algorithms
+// during host key verification.
+//
+// For RSA keys, accept both RSA-SHA2 algorithms and the legacy ssh-rsa
+// algorithm to remain compatible with older and newer servers.
+func hostKeyAlgorithms(key ssh.PublicKey) []string {
+	if key.Type() == ssh.KeyAlgoRSA {
+		return []string{ssh.KeyAlgoRSASHA256, ssh.KeyAlgoRSASHA512, ssh.KeyAlgoRSA}
+	}
+	return []string{key.Type()}
+}
+
+// hostKeyValidator returns an SSH HostKeyCallback that verifies the server
+// host key matches the expected key exactly. Connections using a different
+// host key are rejected.
+func hostKeyValidator(key ssh.PublicKey) ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, candidate ssh.PublicKey) error {
+		if key == nil {
+			return errors.New("required host key was nil")
+		}
+		if !bytes.Equal(candidate.Marshal(), key.Marshal()) {
+			return errHostKeyMismatch
+		}
+		return nil
+	}
+}
+
+// newSSHClientConfig returns the SSH client configuration for s.
+func newSSHClientConfig(s *innerSettings) (*ssh.ClientConfig, error) {
 	sshConfig := &ssh.ClientConfig{
 		User: s.Username,
 		Auth: []ssh.AuthMethod{
 			ssh.Password(s.Password),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // TODO(marco) don't use in production
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	if s.HostPublicKey == "" {
+		return sshConfig, nil
+	}
+	hostPublicKey, err := parseHostPublicKey(s.HostPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	sshConfig.HostKeyCallback = hostKeyValidator(hostPublicKey)
+	sshConfig.HostKeyAlgorithms = hostKeyAlgorithms(hostPublicKey)
+	return sshConfig, nil
+}
+
+// openClient opens a client for the SFTP server based on the provided settings.
+// The returned client must be closed using the close method. If the context is
+// canceled before the client is closed, the underlying network connection, not
+// the client, will be automatically closed.
+func openClient(ctx context.Context, s *innerSettings) (*client, error) {
+	sshConfig, err := newSSHClientConfig(s)
+	if err != nil {
+		return nil, err
 	}
 	addr := s.Host + ":" + strconv.Itoa(s.Port)
 	// The ssh package does not implement the ssh.DialContext function
@@ -341,6 +404,9 @@ func openClient(ctx context.Context, s *innerSettings) (*client, error) {
 	}()
 	c, chans, reqs, err := ssh.NewClientConn(conn, addr, sshConfig)
 	if err != nil {
+		if errors.Is(err, errHostKeyMismatch) {
+			return nil, connectors.NewInvalidSettingsError("server public key does not match the server host key")
+		}
 		return nil, err
 	}
 	sshClient := ssh.NewClient(c, chans, reqs)
@@ -353,15 +419,37 @@ func openClient(ctx context.Context, s *innerSettings) (*client, error) {
 	return cl, nil
 }
 
+// parseHostPublicKey parses k as a single-line OpenSSH public key without
+// authorized_keys options. It returns an error if the key is invalid.
+func parseHostPublicKey(k string) (ssh.PublicKey, error) {
+	if strings.ContainsAny(k, "\r\n") {
+		return nil, errors.New("public key must be a single line")
+	}
+	key, _, options, rest, err := ssh.ParseAuthorizedKey([]byte(k))
+	if err != nil {
+		return nil, err
+	}
+	if len(options) != 0 {
+		return nil, errors.New("public key options are not allowed")
+	}
+	if len(rest) != 0 {
+		return nil, errors.New("unexpected trailing data after public key")
+	}
+	return key, nil
+}
+
 // testConnection tests a connection using the provided settings. It returns an
 // error if the connection cannot be established or if the server does not
 // respond within 5 seconds.
 func testConnection(ctx context.Context, settings *innerSettings) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	openCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	client, err := openClient(ctx, settings)
+	client, err := openClient(openCtx, settings)
 	if err != nil {
 		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if openCtx.Err() != nil {
 			return errors.New("sftp: unable to establish a connection within the 5-second limit. Verify the correctness of the settings and the functionality of the server")
 		}
 		return err
@@ -373,4 +461,11 @@ func testConnection(ctx context.Context, settings *innerSettings) error {
 		}
 	}
 	return nil
+}
+
+// validateHostPublicKey checks that k is a single-line OpenSSH public key
+// without authorized_keys options.
+func validateHostPublicKey(k string) error {
+	_, err := parseHostPublicKey(k)
+	return err
 }

--- a/connectors/sftp/sftp.go
+++ b/connectors/sftp/sftp.go
@@ -255,7 +255,7 @@ func (sf *SFTP) saveSettings(ctx context.Context, settings json.Value, role conn
 			return connectors.NewInvalidSettingsError("server public key length must be in range [0,5000]")
 		}
 		if err := validateHostPublicKey(s.HostPublicKey); err != nil {
-			return connectors.NewInvalidSettingsError("server public key must be a valid OpenSSH public key")
+			return connectors.NewInvalidSettingsError(err.Error())
 		}
 	}
 	// Validate TempPath.
@@ -420,14 +420,15 @@ func openClient(ctx context.Context, s *innerSettings) (*client, error) {
 }
 
 // parseHostPublicKey parses k as a single-line OpenSSH public key without
-// authorized_keys options. It returns an error if the key is invalid.
+// authorized_keys options. The returned error messages are suitable for
+// connectors.NewInvalidSettingsError.
 func parseHostPublicKey(k string) (ssh.PublicKey, error) {
 	if strings.ContainsAny(k, "\r\n") {
 		return nil, errors.New("public key must be a single line")
 	}
 	key, _, options, rest, err := ssh.ParseAuthorizedKey([]byte(k))
 	if err != nil {
-		return nil, err
+		return nil, errors.New("server public key must be a valid OpenSSH public key")
 	}
 	if len(options) != 0 {
 		return nil, errors.New("public key options are not allowed")

--- a/connectors/sftp/sftp.go
+++ b/connectors/sftp/sftp.go
@@ -407,7 +407,7 @@ func openClient(ctx context.Context, s *innerSettings) (*client, error) {
 	c, chans, reqs, err := ssh.NewClientConn(conn, addr, sshConfig)
 	if err != nil {
 		if errors.Is(err, errHostKeyMismatch) {
-			return nil, connectors.NewInvalidSettingsError("server public key does not match the server host key")
+			return nil, connectors.NewInvalidSettingsError("remote server does not match the configured server public key")
 		}
 		return nil, err
 	}

--- a/connectors/sftp/sftp.go
+++ b/connectors/sftp/sftp.go
@@ -339,9 +339,6 @@ func hostKeyAlgorithms(key ssh.PublicKey) []string {
 // host key are rejected.
 func hostKeyValidator(key ssh.PublicKey) ssh.HostKeyCallback {
 	return func(hostname string, remote net.Addr, candidate ssh.PublicKey) error {
-		if key == nil {
-			return errors.New("required host key was nil")
-		}
 		c := candidate.Marshal()
 		k := key.Marshal()
 		if !bytes.Equal(c, k) {

--- a/connectors/sftp/sftp.go
+++ b/connectors/sftp/sftp.go
@@ -342,7 +342,9 @@ func hostKeyValidator(key ssh.PublicKey) ssh.HostKeyCallback {
 		if key == nil {
 			return errors.New("required host key was nil")
 		}
-		if !bytes.Equal(candidate.Marshal(), key.Marshal()) {
+		c := candidate.Marshal()
+		k := key.Marshal()
+		if !bytes.Equal(c, k) {
 			return errHostKeyMismatch
 		}
 		return nil

--- a/connectors/sftp/sftp_test.go
+++ b/connectors/sftp/sftp_test.go
@@ -6,13 +6,133 @@ package sftp
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/krenalis/krenalis/connectors"
 	"github.com/krenalis/krenalis/core/testconnector"
 	"github.com/krenalis/krenalis/tools/json"
+
+	"golang.org/x/crypto/ssh"
 )
 
+const testHostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICM4A2h7XwqPj7jY6n4xWm5mWw0kD9Nh9NP7VDaRao7I test@example.com"
+const testRSAHostPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7ER2IzZQHHB5wK6IsXF5vYzC5ICsTrhzWnEnTqRx+d6AqNh+NirjQ8k6tHgGx5v/UtgTiLT2Z3NVvNKY3QBD5VOWAV07MiHZHBsCcK3w6Er4CFSin7raXWcAK/WVhaISx5E6qLuVP84nQW+CIHYHcuQ3StM3y3rbSGTxEEQW0lXavrvwrAyiPFbClmxBgrPYq5HRjMFnndShS6nSMkZgkPdD64sv/9T+2lGusxTS5KFtK7EP9giQmj4sM8PKW/c/c8mBsRcd0DlPrWIeV1spDUg0pvGyZsSo2F0zvCp/+5MRAI0SH7vGXRNYAUhGqz7uqoUuP4m2P97dhU3BhE1sX test@example.com"
+
+type testSettingsStore struct {
+	settings json.Value
+}
+
+// newTestSettingsStore returns a test settings store.
+func newTestSettingsStore(t *testing.T, settings any) *testSettingsStore {
+	t.Helper()
+	data, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatalf("cannot marshal test settings: %s", err)
+	}
+	return &testSettingsStore{settings: data}
+}
+
+// Load unmarshals the stored settings into dst.
+func (s *testSettingsStore) Load(ctx context.Context, dst any) error {
+	return json.Unmarshal(s.settings, dst)
+}
+
+// Store replaces the stored settings with src.
+func (s *testSettingsStore) Store(ctx context.Context, src any) error {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	s.settings = data
+	return nil
+}
+
+// TestHostKeyValidatorMismatch tests host key mismatch detection.
+func TestHostKeyValidatorMismatch(t *testing.T) {
+	expected, err := parseHostPublicKey(testHostPublicKey)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	other, err := parseHostPublicKey("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHK9aX4A6wqTiSEPAxS0x1QF6P6T4L+6vB8m0uY7JYyV test@example.com")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	err = hostKeyValidator(expected)("", nil, other)
+	if !errors.Is(err, errHostKeyMismatch) {
+		t.Fatalf("expected error matching errHostKeyMismatch, got %v", err)
+	}
+}
+
+// TestNewSSHClientConfigPinnedHostKey tests SSH client configuration for a
+// pinned host public key.
+func TestNewSSHClientConfigPinnedHostKey(t *testing.T) {
+	sshConfig, err := newSSHClientConfig(&innerSettings{
+		Username:      "username",
+		Password:      "password",
+		HostPublicKey: testHostPublicKey,
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(sshConfig.HostKeyAlgorithms) != 1 {
+		t.Fatalf("expected HostKeyAlgorithms length 1, got %d", len(sshConfig.HostKeyAlgorithms))
+	}
+	if sshConfig.HostKeyAlgorithms[0] != ssh.KeyAlgoED25519 {
+		t.Fatalf("expected HostKeyAlgorithms[0] %q, got %q", ssh.KeyAlgoED25519, sshConfig.HostKeyAlgorithms[0])
+	}
+}
+
+// TestNewSSHClientConfigPinnedRSAHostKey tests SSH client configuration for a
+// pinned RSA host public key.
+func TestNewSSHClientConfigPinnedRSAHostKey(t *testing.T) {
+	sshConfig, err := newSSHClientConfig(&innerSettings{
+		Username:      "username",
+		Password:      "password",
+		HostPublicKey: testRSAHostPublicKey,
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	expected := []string{ssh.KeyAlgoRSASHA256, ssh.KeyAlgoRSASHA512, ssh.KeyAlgoRSA}
+	if len(sshConfig.HostKeyAlgorithms) != len(expected) {
+		t.Fatalf("expected HostKeyAlgorithms length %d, got %d", len(expected), len(sshConfig.HostKeyAlgorithms))
+	}
+	for i, algo := range expected {
+		if sshConfig.HostKeyAlgorithms[i] != algo {
+			t.Fatalf("expected HostKeyAlgorithms[%d] %q, got %q", i, algo, sshConfig.HostKeyAlgorithms[i])
+		}
+	}
+}
+
+// TestOpenClientRejectsInvalidHostPublicKey tests that openClient rejects host
+// public keys that do not satisfy the connector validation rules.
+func TestOpenClientRejectsInvalidHostPublicKey(t *testing.T) {
+	_, err := openClient(context.Background(), &innerSettings{
+		Host:          "example.com",
+		Port:          22,
+		Username:      "username",
+		Password:      "password",
+		HostPublicKey: `command="echo hi" ` + testHostPublicKey,
+	})
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "public key options are not allowed") {
+		t.Fatalf("expected error containing %q, got %q", "public key options are not allowed", err.Error())
+	}
+}
+
+// TestParseAndValidateHostPublicKey tests host public key parsing and
+// validation.
+func TestParseAndValidateHostPublicKey(t *testing.T) {
+	if _, err := parseHostPublicKey(testHostPublicKey); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+// TestPathConvert tests path conversion to SFTP URLs.
 func TestPathConvert(t *testing.T) {
 	sf := &SFTP{env: &connectors.FileStorageEnv{Settings: newTestSettingsStore(t, innerSettings{Host: "example.com", Port: 22})}}
 	tests := []testconnector.AbsolutePathTest{
@@ -27,29 +147,46 @@ func TestPathConvert(t *testing.T) {
 	}
 }
 
-type testSettingsStore struct {
-	settings json.Value
-}
-
-func newTestSettingsStore(t *testing.T, settings any) *testSettingsStore {
-	t.Helper()
-
-	data, err := json.Marshal(settings)
+// TestSaveSettingsHostPublicKeyValidation tests host public key validation in
+// saveSettings.
+func TestSaveSettingsHostPublicKeyValidation(t *testing.T) {
+	sf := &SFTP{env: &connectors.FileStorageEnv{Settings: newTestSettingsStore(t, innerSettings{})}}
+	settings, err := json.Marshal(innerSettings{
+		Host:          "example.com",
+		Port:          22,
+		Username:      "username",
+		Password:      "password",
+		HostPublicKey: "not a public key",
+	})
 	if err != nil {
-		t.Fatalf("cannot marshal test settings: %s", err)
+		t.Fatalf("cannot marshal settings: %s", err)
 	}
-	return &testSettingsStore{settings: data}
+	err = sf.saveSettings(context.Background(), settings, connectors.Source, true)
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	if err.Error() != "server public key must be a valid OpenSSH public key" {
+		t.Fatalf("expected error %q, got %q", "server public key must be a valid OpenSSH public key", err.Error())
+	}
 }
 
-func (s *testSettingsStore) Load(ctx context.Context, dst any) error {
-	return json.Unmarshal(s.settings, dst)
-}
+// TestValidateHostPublicKey tests host public key validation.
+func TestValidateHostPublicKey(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		if err := validateHostPublicKey(testHostPublicKey); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
 
-func (s *testSettingsStore) Store(ctx context.Context, src any) error {
-	data, err := json.Marshal(src)
-	if err != nil {
-		return err
-	}
-	s.settings = data
-	return nil
+	t.Run("invalid", func(t *testing.T) {
+		if err := validateHostPublicKey("not a public key"); err == nil {
+			t.Fatal("expected non-nil error, got nil")
+		}
+	})
+
+	t.Run("multiline", func(t *testing.T) {
+		if err := validateHostPublicKey(testHostPublicKey + "\n# comment"); err == nil {
+			t.Fatal("expected non-nil error, got nil")
+		}
+	})
 }

--- a/connectors/sftp/sftp_test.go
+++ b/connectors/sftp/sftp_test.go
@@ -49,6 +49,22 @@ func (s *testSettingsStore) Store(ctx context.Context, src any) error {
 	return nil
 }
 
+// TestHostKeyValidatorMatch tests host key match detection.
+func TestHostKeyValidatorMatch(t *testing.T) {
+	expected, err := parseHostPublicKey(testHostPublicKey)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	candidate, err := parseHostPublicKey(testHostPublicKey)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	err = hostKeyValidator(expected)("", nil, candidate)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
 // TestHostKeyValidatorMismatch tests host key mismatch detection.
 func TestHostKeyValidatorMismatch(t *testing.T) {
 	expected, err := parseHostPublicKey(testHostPublicKey)


### PR DESCRIPTION
```
connectors/sftp: add SFTP host key validation

Add an optional SFTP setting for the server public key and use it to
validate the SSH host key during connection setup.

When a host key is configured, restrict accepted SSH host key
algorithms to those compatible with the configured key, including
RSA-SHA2 variants for RSA keys.
```