### PR TITLE
core/internal/collector: accept non-standard X-Forwarded-For headers

### DIFF
--- a/core/internal/collector/decoder.go
+++ b/core/internal/collector/decoder.go
@@ -169,11 +169,25 @@ func (d *decoder) Reset(r *http.Request) error {
 	d.receivedAt = time.Now().UTC()
 	d.remoteAddr.ip = netip.Addr{}
 
-	// If an 'X-Forwarded-For' header was provided, get the request address from
-	// there.
+	// If the 'X-Forwarded-For' header is present, use it to determine
+	// the client's IP address. Also accept non-standard formats such as
+	// bracketed IPv6 addresses and addresses with a ":port" suffix.
 	if ff := r.Header.Get("X-Forwarded-For"); ff != "" {
 		clientIP, _, _ := strings.Cut(ff, ",")
 		clientIP = strings.TrimSpace(clientIP)
+		// If the address starts with '[', assume it is an IPv6 address
+		// and strip the optional port suffix.
+		if strings.HasPrefix(clientIP, "[") {
+			if before, _, found := strings.Cut(clientIP[1:], "]"); found {
+				clientIP = before
+			}
+		} else {
+			// If the address contains a single ':', assume it separates
+			// the host and port, then keep only the host part.
+			if before, after, found := strings.Cut(clientIP, ":"); found && !strings.Contains(after, ":") {
+				clientIP = before
+			}
+		}
 		err = d.parseRemoteAddr(clientIP)
 		if err != nil {
 			return errors.BadRequest("address specified in the 'X-Forwarded-For' header is not a valid IP address")

--- a/core/internal/collector/decoder_test.go
+++ b/core/internal/collector/decoder_test.go
@@ -935,6 +935,13 @@ func TestDecoderContextIPHandling(t *testing.T) {
 			wantIP:       expectedIP{present: true, value: remoteIPv6},
 		},
 		{
+			name:         "x-forwarded-for-ipv4",
+			contextJSON:  "",
+			fallback:     true,
+			forwardedFor: remoteIP,
+			wantIP:       expectedIP{present: true, value: remoteIP},
+		},
+		{
 			name:         "x-forwarded-for-bracketed-ipv6",
 			contextJSON:  "",
 			fallback:     true,

--- a/core/internal/collector/decoder_test.go
+++ b/core/internal/collector/decoder_test.go
@@ -934,6 +934,27 @@ func TestDecoderContextIPHandling(t *testing.T) {
 			forwardedFor: remoteIPv6 + ", " + remoteIP,
 			wantIP:       expectedIP{present: true, value: remoteIPv6},
 		},
+		{
+			name:         "x-forwarded-for-bracketed-ipv6",
+			contextJSON:  "",
+			fallback:     true,
+			forwardedFor: "[" + remoteIPv6 + "]",
+			wantIP:       expectedIP{present: true, value: remoteIPv6},
+		},
+		{
+			name:         "x-forwarded-for-bracketed-ipv6-with-port",
+			contextJSON:  "",
+			fallback:     true,
+			forwardedFor: "[" + remoteIPv6 + "]:1234",
+			wantIP:       expectedIP{present: true, value: remoteIPv6},
+		},
+		{
+			name:         "x-forwarded-for-ipv4-with-port",
+			contextJSON:  "",
+			fallback:     true,
+			forwardedFor: remoteIP + ":1234",
+			wantIP:       expectedIP{present: true, value: remoteIP},
+		},
 	}
 
 	for _, tt := range tests {
@@ -999,6 +1020,12 @@ func TestDecoderRemoteAddrValidation(t *testing.T) {
 			name:         "scoped-ipv6-x-forwarded-for",
 			remoteAddr:   net.JoinHostPort("198.51.100.23", "9000"),
 			forwardedFor: "fe80::1%eth0",
+			wantErr:      errors.BadRequest("address specified in the 'X-Forwarded-For' header is not a valid IP address"),
+		},
+		{
+			name:         "unclosed-bracket-ipv6-x-forwarded-for",
+			remoteAddr:   net.JoinHostPort("198.51.100.23", "9000"),
+			forwardedFor: "[2001:db8:face:12::1",
 			wantErr:      errors.BadRequest("address specified in the 'X-Forwarded-For' header is not a valid IP address"),
 		},
 		{


### PR DESCRIPTION
```
core/internal/collector: accept non-standard X-Forwarded-For headers

Previously, non-standard X-Forwarded-For headers were rejected with a
400 Bad Request error. Some proxies, such as AWS Application Load
Balancer, may append the client port and use bracketed IPv6 addresses.

This change accepts an optional port after the host and bracketed IPv6
addresses, so the following formats are now accepted:

203.0.113.10
203.0.113.10:54321
2001:db8::1
[2001:db8::1]
[2001:db8::1]:54321

The parser is intentionally permissive and may accept additional
formats; only the formats listed above are explicitly supported.
```