### PR TITLE
core/internal/connections: avoid duplicate close warning in log

### DIFF
--- a/core/internal/connections/filestorage.go
+++ b/core/internal/connections/filestorage.go
@@ -134,7 +134,11 @@ func (storage *FileStorage) Read(ctx context.Context, file *state.Connector, nam
 	if err != nil {
 		return nil, nil, nil, connectorError(err)
 	}
-	defer r.Close()
+	defer func() {
+		if r != nil {
+			_ = r.Close()
+		}
+	}()
 	if err = validateUpdatedAt(storageTimestamp); err != nil {
 		return nil, nil, nil, fmt.Errorf("invalid timestamp returned by the storage: %s", err)
 	}
@@ -166,7 +170,9 @@ func (storage *FileStorage) Read(ctx context.Context, file *state.Connector, nam
 	if err != nil && err != errRecordStop {
 		return nil, nil, nil, connectorError(err)
 	}
-	if err = r.Close(); err != nil {
+	err = r.Close()
+	r = nil
+	if err != nil {
 		return nil, nil, nil, connectorError(err)
 	}
 	if recordErr != nil {
@@ -214,12 +220,18 @@ func (storage *FileStorage) Sheets(ctx context.Context, file *state.Connector, n
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
+	defer func() {
+		if r != nil {
+			_ = r.Close()
+		}
+	}()
 	sheets, err := sheetsFile.Sheets(ctx, r)
 	if err != nil {
 		return nil, connectorError(err)
 	}
-	if err = r.Close(); err != nil {
+	err = r.Close()
+	r = nil
+	if err != nil {
 		return nil, err
 	}
 	sheets = slices.DeleteFunc(sheets, func(name string) bool {


### PR DESCRIPTION
```
core/internal/connections: avoid duplicate close warning in log

Disable deferred cleanup after explicitly closing file storage readers
in Read and Sheets.

This prevents Close from being called twice and avoids the resulting
warning in the logs, while keeping cleanup for early returns.
```