### PR TITLE
core: check core state in `Organization.HasMember`

### DIFF
--- a/core/organization.go
+++ b/core/organization.go
@@ -528,6 +528,7 @@ func (this *Organization) DeleteMember(ctx context.Context, id int) error {
 
 // HasMember reports whether the organization has a member with the given ID.
 func (this *Organization) HasMember(id int) bool {
+	this.core.mustBeOpen()
 	return this.organization.HasMember(id)
 }
 


### PR DESCRIPTION
```
core: check core state in `Organization.HasMember`

Previously, the Organization.HasMember method did not check whether the
core was still open, as all public methods in the core package are
required to do.
```