### PR TITLE
core: avoid process panic when workspace is deleted during update

### DIFF
--- a/core/workspace.go
+++ b/core/workspace.go
@@ -1650,6 +1650,9 @@ func (this *Workspace) TestWarehouseUpdate(ctx context.Context, settings, mcpSet
 // must be between 1 and 100 runes long. displayedProperties must contain valid
 // displayed property names. A valid displayed property name is an empty string,
 // or alternatively a valid property name between 1 and 100 runes long.
+//
+// It returns an errors.NotFoundError error if the workspace does not exist
+// anymore.
 func (this *Workspace) Update(ctx context.Context, name string, uiPreferences UIPreferences) error {
 	this.core.mustBeOpen()
 	if err := util.ValidateStringField("name", name, 100); err != nil {
@@ -1665,13 +1668,16 @@ func (this *Workspace) Update(ctx context.Context, name string, uiPreferences UI
 		UIPreferences: state.UIPreferences(uiPreferences),
 	}
 	err := this.core.state.Transaction(ctx, func(tx *db.Tx) (any, error) {
-		_, err := tx.Exec(ctx, "UPDATE workspaces SET name = $1, ui_profile_image = $2, "+
+		result, err := tx.Exec(ctx, "UPDATE workspaces SET name = $1, ui_profile_image = $2, "+
 			"ui_profile_first_name = $3, ui_profile_last_name = $4, "+
 			"ui_profile_extra = $5 WHERE id = $6",
 			n.Name, n.UIPreferences.Profile.Image, n.UIPreferences.Profile.FirstName,
 			n.UIPreferences.Profile.LastName, n.UIPreferences.Profile.Extra, n.Workspace)
 		if err != nil {
 			return nil, err
+		}
+		if result.RowsAffected() == 0 {
+			return nil, errors.NotFound("workspace %d does not exist", n.Workspace)
 		}
 		return n, nil
 	})


### PR DESCRIPTION
```
core: avoid process panic when workspace is deleted during update

Previously, an API request to update a workspace could race with
deletion of the same workspace. If the workspace was deleted while the
request was still in progress, the code could send a notification for a
workspace that no longer existed, causing a panic and terminating the
process.

This commit returns a Not Found error instead.
```