### PR TITLE
core/internal/state: fix stale workspace access keys

### DIFF
--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -941,6 +941,12 @@ func (state *State) deleteWorkspace(n notification) uuid.UUID {
 	// Delete the workspace.
 	delete(state.workspaces, e.ID)
 	delete(organization.workspaces, e.ID)
+	// Delete access keys restricted to the workspace.
+	for hmac, key := range state.accessKeyByHMAC {
+		if key.Workspace == e.ID {
+			delete(state.accessKeyByHMAC, hmac)
+		}
+	}
 	// Delete the connections.
 	for _, c := range e.workspace.connections {
 		for _, key := range c.Keys {


### PR DESCRIPTION
```
core/internal/state: fix stale workspace access keys

Remove workspace-scoped access keys from the in-memory state when a
workspace is deleted.
```