### PR TITLE
core: rename misleading internal password reset error

### DIFF
--- a/core/organization.go
+++ b/core/organization.go
@@ -46,8 +46,6 @@ const invitationTokenMaxAge = 3 * 24 * 60 * 60
 // resetPasswordTokenMaxAge represents the max age of a password token (1 hour).
 const resetPasswordTokenMaxAge = 1 * 60 * 60
 
-var errResetPasswordTokenNotExist = errors.New("The reset password token doesn't exist")
-
 // Organization represents an organization.
 type Organization struct {
 	core         *Core
@@ -648,6 +646,8 @@ func (this *Organization) Members(ctx context.Context) ([]*Member, error) {
 	return members, nil
 }
 
+var errMemberNotFoundOrInvitationPending = errors.New("member not found or invitation pending")
+
 // SendMemberPasswordReset sends a reset password email to the given email
 // address using the given template.
 //
@@ -673,16 +673,16 @@ func (this *Organization) SendMemberPasswordReset(ctx context.Context, email str
 			return nil, err
 		}
 		if !exists {
-			return nil, errResetPasswordTokenNotExist
+			return nil, errMemberNotFoundOrInvitationPending
 		}
 		_, err = tx.Exec(ctx, `UPDATE members SET reset_password_token = $1, reset_password_token_created_at = $2 WHERE organization = $3 AND email = $4`,
 			resetToken, now, this.organization.ID, email)
 		return nil, err
 	})
 	if err != nil {
-		if err == errResetPasswordTokenNotExist {
-			// Do not return errors so that non-logged in users cannot
-			// tell if the email exists or not.
+		if err == errMemberNotFoundOrInvitationPending {
+			// Do not return an error, to avoid revealing whether the email
+			// belongs to an existing member or to a member with a pending invitation.
 			return nil
 		}
 		return err


### PR DESCRIPTION
```
core: rename misleading internal password reset error

Rename the internal error used when a member is not found or has a
pending invitation.

Also improve the related comment.
```