### PR TITLE
cmd,core: validate `Organization.HasMember` parameter

### DIFF
--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -208,9 +208,6 @@ func (s *apisServer) authenticateAdminRequest(r *http.Request) (org *core.Organi
 	if err != nil {
 		return nil, nil, 0, errInvalidSessionCookie
 	}
-	if id := session.Member; id < 1 || id > math.MaxInt32 {
-		return nil, nil, 0, errInvalidSessionCookie
-	}
 
 	// Get the organization.
 	org, err = s.core.Organization(session.Organization)
@@ -221,7 +218,7 @@ func (s *apisServer) authenticateAdminRequest(r *http.Request) (org *core.Organi
 		return nil, nil, 0, err
 	}
 	// Verify that the member still exists.
-	if !org.HasMember(session.Member) {
+	if exists, err := org.HasMember(session.Member); err != nil || !exists {
 		return nil, nil, 0, errInvalidSessionCookie
 	}
 	// If the 'Krenalis-Workspace' header is missing, return with a nil workspace.

--- a/core/organization.go
+++ b/core/organization.go
@@ -522,9 +522,12 @@ func (this *Organization) DeleteMember(ctx context.Context, id int) error {
 }
 
 // HasMember reports whether the organization has a member with the given ID.
-func (this *Organization) HasMember(id int) bool {
+func (this *Organization) HasMember(id int) (bool, error) {
 	this.core.mustBeOpen()
-	return this.organization.HasMember(id)
+	if id < 1 || id > maxInt32 {
+		return false, errors.BadRequest("identifier %d is not a valid member identifier", id)
+	}
+	return this.organization.HasMember(id), nil
 }
 
 // InviteMember sends an invitation email to the given email address using the


### PR DESCRIPTION
```
cmd,core: validate `Organization.HasMember` parameter

Validate the Organization.HasMember parameter, as API methods should
validate their own inputs.

As a result, callers no longer need to validate it before calling
HasMember.
```