### PR TITLE
connectors/mailerlite: implement the connector for MailerLite

### DIFF
--- a/connectors/mailerlite/documentation/destination/overview.md
+++ b/connectors/mailerlite/documentation/destination/overview.md
@@ -1,0 +1,14 @@
+
+MailerLite is an email marketing platform that helps businesses create and send email campaigns, automate workflows, manage subscribers, and grow their audience with landing pages, signup forms, and analytics tools.
+
+## What can you do with this?
+
+Using this connector, you can create and update MailerLite subscribers from Krenalis.
+
+## What does it require?
+
+* A MailerLite account
+* A MailerLite API key
+
+> MailerLite is a trademark of MailerLite Limited.
+> This connector is not affiliated with or endorsed by MailerLite Limited.

--- a/connectors/mailerlite/documentation/source/overview.md
+++ b/connectors/mailerlite/documentation/source/overview.md
@@ -1,0 +1,14 @@
+
+MailerLite is an email marketing platform that helps businesses create and send email campaigns, automate workflows, manage subscribers, and grow their audience with landing pages, signup forms, and analytics tools.
+
+## What can you do with this?
+
+Using this connector you can import MailerLite subscribers into Krenalis as users, including their custom fields and groups.
+
+## What does it require?
+
+* A MailerLite account
+* A MailerLite API key
+
+> MailerLite is a trademark of MailerLite Limited.
+> This connector is not affiliated with or endorsed by MailerLite Limited.

--- a/connectors/mailerlite/mailerlite.go
+++ b/connectors/mailerlite/mailerlite.go
@@ -1,0 +1,559 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+// Package mailerlite provides a connector for MailerLite.
+// (https://developers.mailerlite.com/)
+//
+// MailerLite is a trademark of MailerLite Limited.
+// This connector is not affiliated with or endorsed by MailerLite Limited.
+package mailerlite
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krenalis/krenalis/connectors"
+	"github.com/krenalis/krenalis/tools/decimal"
+	"github.com/krenalis/krenalis/tools/json"
+	"github.com/krenalis/krenalis/tools/types"
+)
+
+//go:embed documentation/source/overview.md
+var sourceOverview string
+
+//go:embed documentation/destination/overview.md
+var destinationOverview string
+
+var apiBaseURL = "https://connect.mailerlite.com/api"
+
+const (
+	apiVersion            = "2026-05-22"
+	legacyAPIKeyLength    = 32
+	subscribersPageLimit  = "100"
+	settingsAPIKeyMaxSize = 4096
+)
+
+const (
+	// Parse MailerLite number fields whenever they fit in Krenalis' decimal representation.
+	numberPrecision = types.MaxDecimalPrecision
+	numberScale     = types.MaxDecimalScale
+)
+
+func init() {
+	connectors.RegisterApplication(connectors.ApplicationSpec{
+		Code:       "mailerlite",
+		Label:      "MailerLite",
+		Categories: connectors.CategorySaaS,
+		AsSource: &connectors.AsApplicationSource{
+			Targets:     connectors.TargetUser,
+			HasSettings: true,
+			Documentation: connectors.RoleDocumentation{
+				Summary:  "Import subscribers as users from MailerLite",
+				Overview: sourceOverview,
+			},
+		},
+		AsDestination: &connectors.AsApplicationDestination{
+			Targets:     connectors.TargetUser,
+			HasSettings: true,
+			Documentation: connectors.RoleDocumentation{
+				Summary:  "Export users as subscribers to MailerLite",
+				Overview: destinationOverview,
+			},
+		},
+		Terms: connectors.ApplicationTerms{
+			User:   "Subscriber",
+			Users:  "Subscribers",
+			UserID: "Subscriber ID",
+		},
+		EndpointGroups: []connectors.EndpointGroup{{
+			// MailerLite documents a global limit of 120 requests/minute.
+			// https://developers.mailerlite.com/docs/#rate-limits
+			RateLimit: connectors.RateLimit{RequestsPerSecond: 2, Burst: 2},
+			RetryPolicy: connectors.RetryPolicy{
+				"429":             connectors.RetryAfterStrategy(),
+				"408 500 502 503": connectors.ExponentialStrategy(connectors.NetFailure, 100*time.Millisecond),
+			},
+		}},
+		TimeLayouts: connectors.TimeLayouts{
+			DateTime: time.DateTime,
+		},
+	}, New)
+}
+
+// New returns a new connector instance for MailerLite.
+func New(env *connectors.ApplicationEnv) (*MailerLite, error) {
+	return &MailerLite{env: env}, nil
+}
+
+type MailerLite struct {
+	env *connectors.ApplicationEnv
+}
+
+type innerSettings struct {
+	APIKey string `json:"apiKey"`
+}
+
+type field struct {
+	Name string `json:"name"`
+	Key  string `json:"key"`
+	Type string `json:"type"`
+}
+
+// RecordSchema returns the schema of the specified target and role.
+func (ml *MailerLite) RecordSchema(ctx context.Context, target connectors.Targets, role connectors.Role) (types.Type, error) {
+
+	callURL := apiBaseURL + "/fields?limit=100&page="
+
+	var fields []types.Property
+
+	for page := 1; ; page++ {
+		var response struct {
+			Data []field `json:"data"`
+			Meta struct {
+				CurrentPage int `json:"current_page"`
+				LastPage    int `json:"last_page"`
+			} `json:"meta"`
+		}
+		err := ml.call(ctx, http.MethodGet, callURL+strconv.Itoa(page), nil, http.StatusOK, &response)
+		if err != nil {
+			return types.Type{}, err
+		}
+	FIELDS:
+		for _, field := range response.Data {
+			if !types.IsValidPropertyName(field.Key) {
+				continue
+			}
+			for _, f := range fields {
+				if f.Name == field.Key {
+					continue FIELDS
+				}
+			}
+			var typ types.Type
+			switch field.Type {
+			case "text":
+				typ = types.String()
+			case "number":
+				typ = types.Decimal(numberPrecision, numberScale)
+			case "date":
+				typ = types.Date()
+			default:
+				continue
+			}
+			fields = append(fields, types.Property{
+				Name:        field.Key,
+				Type:        typ,
+				Nullable:    true,
+				Description: field.Name,
+			})
+		}
+		if response.Meta.LastPage == 0 || response.Meta.CurrentPage >= response.Meta.LastPage {
+			break
+		}
+	}
+
+	var properties []types.Property
+	if role == connectors.Source {
+		properties = append(properties, types.Property{Name: "id", Type: types.String(), Description: "Subscriber ID"})
+	}
+	properties = append(properties,
+		types.Property{Name: "email", Type: types.String(), CreateRequired: true, Description: "Email address, used only when creating a subscriber"},
+		types.Property{Name: "groups", Type: types.Array(types.String()), ReadOptional: true, Description: "Group IDs"},
+	)
+	if len(fields) > 0 {
+		properties = append(properties, types.Property{
+			Name:        "fields",
+			Type:        types.Object(fields),
+			Description: "Subscriber fields",
+		})
+	}
+	properties = append(properties,
+		types.Property{Name: "status", Type: subscriberStatusType(), Description: "Subscriber status"},
+		types.Property{Name: "source", Type: types.String(), ReadOptional: true, Description: "Subscriber source"},
+		types.Property{Name: "sent", Type: types.Int(32), ReadOptional: true, Description: "Number of sent emails"},
+		types.Property{Name: "opens_count", Type: types.Int(32), ReadOptional: true, Description: "Number of opens"},
+		types.Property{Name: "clicks_count", Type: types.Int(32), ReadOptional: true, Description: "Number of clicks"},
+		types.Property{Name: "open_rate", Type: types.Float(64), ReadOptional: true, Description: "Open rate"},
+		types.Property{Name: "click_rate", Type: types.Float(64), ReadOptional: true, Description: "Click rate"},
+		types.Property{Name: "ip_address", Type: types.IP(), Nullable: true, ReadOptional: true, Description: "Subscriber IP address"},
+		types.Property{Name: "subscribed_at", Type: types.DateTime(), Nullable: true, ReadOptional: true, Description: "Subscription timestamp"},
+		types.Property{Name: "unsubscribed_at", Type: types.DateTime(), Nullable: true, ReadOptional: true, Description: "Unsubscribe timestamp"},
+		types.Property{Name: "created_at", Type: types.DateTime(), Description: "Creation timestamp"},
+		types.Property{Name: "updated_at", Type: types.DateTime(), Description: "Last update timestamp"},
+		types.Property{Name: "opted_in_at", Type: types.DateTime(), Nullable: true, ReadOptional: true, Description: "Opt-in timestamp"},
+		types.Property{Name: "optin_ip", Type: types.IP(), Nullable: true, ReadOptional: true, Description: "Opt-in IP address"},
+	)
+	if role == connectors.Destination {
+		properties = append(properties,
+			types.Property{Name: "resubscribe", Type: types.Boolean(), Description: "Resubscribe a previously unsubscribed subscriber when allowed by MailerLite"},
+		)
+	}
+
+	return types.AsRole(types.Object(properties), types.Role(role)), nil
+}
+
+// Records returns the records of the specified target.
+func (ml *MailerLite) Records(ctx context.Context, target connectors.Targets, updatedAt time.Time, cursor string, schema types.Type) ([]connectors.Record, string, error) {
+
+	requestURL := apiBaseURL + "/subscribers?limit=" + subscribersPageLimit + "&include=groups"
+	if cursor != "" {
+		requestURL += "&cursor=" + url.QueryEscape(cursor)
+	}
+
+	var response struct {
+		Data []subscriber `json:"data"`
+		Meta struct {
+			NextCursor string `json:"next_cursor"`
+		} `json:"meta"`
+	}
+	err := ml.call(ctx, http.MethodGet, requestURL, nil, http.StatusOK, &response)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(response.Data) == 0 {
+		return nil, "", io.EOF
+	}
+
+	records := make([]connectors.Record, 0, len(response.Data))
+	for _, subscriber := range response.Data {
+		record := ml.recordFromSubscriber(subscriber, schema)
+		if record.Err != nil || updatedAt.IsZero() || !record.UpdatedAt.Before(updatedAt) {
+			records = append(records, record)
+		}
+	}
+	if response.Meta.NextCursor == "" {
+		return records, "", io.EOF
+	}
+
+	return records, response.Meta.NextCursor, nil
+}
+
+// ServeUI serves the connector's user interface.
+func (ml *MailerLite) ServeUI(ctx context.Context, event string, settings json.Value, role connectors.Role) (*connectors.UI, error) {
+
+	switch event {
+	case "load":
+		var s innerSettings
+		if err := ml.env.Settings.Load(ctx, &s); err != nil {
+			return nil, err
+		}
+		settings, _ = json.Marshal(s)
+	case "save":
+		return nil, ml.saveSettings(ctx, settings)
+	default:
+		return nil, connectors.ErrUIEventNotExist
+	}
+
+	return &connectors.UI{
+		Fields: []connectors.Component{
+			&connectors.Input{
+				Name:      "apiKey",
+				Label:     "API token",
+				Rows:      6,
+				MinLength: legacyAPIKeyLength + 1,
+				MaxLength: settingsAPIKeyMaxSize,
+			},
+		},
+		Settings: settings,
+		Buttons:  []connectors.Button{connectors.SaveButton},
+	}, nil
+}
+
+var datetimePropertyNames = []string{"subscribed_at", "unsubscribed_at", "created_at", "updated_at", "opted_in_at"}
+
+// Upsert updates or creates records in the API for the specified target.
+func (ml *MailerLite) Upsert(ctx context.Context, target connectors.Targets, records connectors.Records, schema types.Type) error {
+
+	record := records.First()
+	if record.IsCreate() {
+		if _, ok := record.Attributes["email"]; !ok {
+			return connectors.RecordsError{0: errors.New("creating a MailerLite subscriber requires email")}
+		}
+	} else {
+		delete(record.Attributes, "email")
+	}
+
+	// Convert time.Time values to strings.
+	for _, name := range datetimePropertyNames {
+		if t, ok := record.Attributes[name]; ok {
+			if t, ok := t.(time.Time); ok {
+				record.Attributes[name] = t.Format(time.DateTime)
+			}
+		}
+	}
+	if fields, ok := record.Attributes["fields"].(map[string]any); ok {
+		for k, v := range fields {
+			if t, ok := v.(time.Time); ok {
+				fields[k] = t.Format(time.DateTime)
+			}
+		}
+	}
+
+	bb := ml.env.HTTPClient.GetBodyBuffer(connectors.NoEncoding)
+	defer bb.Close()
+
+	err := bb.Encode(record.Attributes)
+	if err != nil {
+		return err
+	}
+
+	var requestMethod string
+	var requestURL string
+	var expectedStatus int
+	if record.IsCreate() {
+		requestMethod = http.MethodPost
+		requestURL = apiBaseURL + "/subscribers"
+		expectedStatus = http.StatusCreated
+	} else {
+		requestMethod = http.MethodPut
+		requestURL = apiBaseURL + "/subscribers/" + url.PathEscape(record.ID)
+		expectedStatus = http.StatusOK
+	}
+
+	err = ml.call(ctx, requestMethod, requestURL, bb, expectedStatus, nil)
+	if err != nil {
+		if err, ok := err.(*apiError); ok {
+			switch err.StatusCode {
+			case http.StatusBadRequest, http.StatusNotFound, http.StatusUnprocessableEntity:
+				return connectors.RecordsError{0: err}
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (ml *MailerLite) call(ctx context.Context, method, u string, body *connectors.BodyBuffer, expectedStatus int, response any) error {
+	var s innerSettings
+	if err := ml.env.Settings.Load(ctx, &s); err != nil {
+		return err
+	}
+	return ml.callWithSettings(ctx, s, method, u, body, expectedStatus, response)
+}
+
+func (ml *MailerLite) callWithSettings(ctx context.Context, settings innerSettings, method, u string, body *connectors.BodyBuffer, expectedStatus int, response any) error {
+
+	req, err := body.NewRequest(ctx, method, u)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+settings.APIKey)
+	req.Header.Set("X-Version", apiVersion)
+
+	res, err := ml.env.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != expectedStatus {
+		var apiErr apiError
+		err := json.Decode(res.Body, &apiErr)
+		if err != nil {
+			return err
+		}
+		apiErr.StatusCode = res.StatusCode
+		return &apiErr
+	}
+	if response != nil {
+		return json.Decode(res.Body, response)
+	}
+
+	return nil
+}
+
+func (ml *MailerLite) recordFromSubscriber(s subscriber, schema types.Type) connectors.Record {
+	if s.ID == "" {
+		return connectors.Record{Err: errors.New("MailerLite returned a subscriber without an id")}
+	}
+	record := connectors.Record{
+		ID: s.ID,
+		Attributes: map[string]any{
+			"id":              s.ID,
+			"email":           s.Email,
+			"groups":          subscriberGroupsIDs(s.Groups),
+			"status":          s.Status,
+			"source":          s.Source,
+			"sent":            s.Sent,
+			"opens_count":     s.OpensCount,
+			"clicks_count":    s.ClicksCount,
+			"open_rate":       s.OpenRate,
+			"click_rate":      s.ClickRate,
+			"ip_address":      s.IPAddress,
+			"subscribed_at":   s.SubscribedAt,
+			"unsubscribed_at": s.UnsubscribedAt,
+			"created_at":      s.CreatedAt,
+			"updated_at":      s.UpdatedAt,
+			"opted_in_at":     s.OptedInAt,
+			"optin_ip":        s.OptinIP,
+		},
+	}
+	var err error
+	record.UpdatedAt, err = time.Parse(time.DateTime, s.UpdatedAt)
+	if err != nil {
+		record.Err = err
+		return record
+	}
+	p, ok := schema.Properties().ByName("fields")
+	if !ok {
+		return record
+	}
+	fields := make(map[string]any, p.Type.Properties().Len())
+	for _, f := range p.Type.Properties().All() {
+		if value, ok := s.Fields[f.Name]; ok {
+			if f.Type.Kind() == types.DecimalKind {
+				fields[f.Name] = parseNumber(value)
+			} else {
+				fields[f.Name] = value
+			}
+		} else {
+			fields[f.Name] = nil
+		}
+	}
+	record.Attributes["fields"] = fields
+	return record
+}
+
+func (ml *MailerLite) saveSettings(ctx context.Context, settings json.Value) error {
+	var s innerSettings
+	if err := settings.Unmarshal(&s); err != nil {
+		return err
+	}
+	if s.APIKey == "" {
+		return connectors.NewInvalidSettingsError("apiKey is required")
+	}
+	if len(s.APIKey) > settingsAPIKeyMaxSize {
+		return connectors.NewInvalidSettingsError("apiKey is too long")
+	}
+	for i := 0; i < len(s.APIKey); i++ {
+		if c := s.APIKey[i]; c <= ' ' || c == 0x7f {
+			return connectors.NewInvalidSettingsError("apiKey must not contain spaces or control characters")
+		}
+	}
+	err := ml.callWithSettings(ctx, s, http.MethodGet, apiBaseURL+"/fields?limit=1", nil, http.StatusOK, nil)
+	if err != nil {
+		if err, ok := err.(*apiError); ok && (err.StatusCode == http.StatusUnauthorized || err.StatusCode == http.StatusForbidden) {
+			return connectors.NewInvalidSettingsError("apiKey is not valid or cannot access the MailerLite API")
+		}
+		return err
+	}
+	return ml.env.Settings.Store(ctx, s)
+}
+
+type apiError struct {
+	StatusCode int
+	Message    string              `json:"message"`
+	Errors     map[string][]string `json:"errors"`
+}
+
+func (err *apiError) Error() string {
+	if err == nil {
+		return "<nil>"
+	}
+	if err.Message != "" {
+		return fmt.Sprintf("MailerLite error: %s", err.Message)
+	}
+	return fmt.Sprintf("MailerLite returned HTTP %d", err.StatusCode)
+}
+
+// canonicalNumber removes leading zeros from the integer part of a MailerLite
+// number string.
+func canonicalNumber(s string) string {
+	if s == "" {
+		return s
+	}
+	var sign, integer, fraction, exp string
+	switch s[0] {
+	case '-':
+		sign, s = "-", s[1:]
+	case '+':
+		s = s[1:]
+	}
+	if i := strings.IndexAny(s, "eE"); i >= 0 {
+		s, exp = s[:i], s[i:]
+	}
+	if i := strings.IndexByte(s, '.'); i >= 0 {
+		integer, fraction = s[:i], s[i:]
+	} else {
+		integer = s
+	}
+	integer = strings.TrimLeft(integer, "0")
+	if integer == "" {
+		integer = "0"
+	}
+	return sign + integer + fraction + exp
+}
+
+// parseNumber converts a MailerLite number field to a Krenalis decimal when
+// possible.
+func parseNumber(value any) any {
+	if value == nil {
+		return nil
+	}
+	s, ok := value.(string)
+	if !ok || s == "" {
+		return nil
+	}
+	n, err := decimal.Parse(s, numberPrecision, numberScale)
+	if err != nil {
+		n, err = decimal.Parse(canonicalNumber(s), numberPrecision, numberScale)
+		if err != nil {
+			return nil
+		}
+	}
+	return n
+}
+
+func subscriberGroupsIDs(groups []subscriberGroup) []string {
+	if len(groups) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(groups))
+	for _, group := range groups {
+		if group.ID != "" {
+			ids = append(ids, group.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return ids
+}
+
+type subscriber struct {
+	ID             string            `json:"id"`
+	Email          string            `json:"email"`
+	Status         string            `json:"status"`
+	Source         string            `json:"source"`
+	Sent           int32             `json:"sent"`
+	OpensCount     int32             `json:"opens_count"`
+	ClicksCount    int32             `json:"clicks_count"`
+	OpenRate       float64           `json:"open_rate"`
+	ClickRate      float64           `json:"click_rate"`
+	IPAddress      any               `json:"ip_address"`
+	SubscribedAt   any               `json:"subscribed_at"`
+	UnsubscribedAt any               `json:"unsubscribed_at"`
+	CreatedAt      string            `json:"created_at"`
+	UpdatedAt      string            `json:"updated_at"`
+	Fields         map[string]any    `json:"fields"`
+	Groups         []subscriberGroup `json:"groups"`
+	OptedInAt      any               `json:"opted_in_at"`
+	OptinIP        any               `json:"optin_ip"`
+}
+
+type subscriberGroup struct {
+	ID string `json:"id"`
+}
+
+func subscriberStatusType() types.Type {
+	return types.String().WithValues("active", "unsubscribed", "unconfirmed", "bounced", "junk")
+}

--- a/connectors/mailerlite/mailerlite_test.go
+++ b/connectors/mailerlite/mailerlite_test.go
@@ -1,0 +1,1098 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+package mailerlite
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"iter"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krenalis/krenalis/connectors"
+	"github.com/krenalis/krenalis/core/testconnector"
+	"github.com/krenalis/krenalis/tools/decimal"
+	"github.com/krenalis/krenalis/tools/json"
+	"github.com/krenalis/krenalis/tools/types"
+)
+
+const testAPIKey = "mailerlite-test-token"
+
+// TestSaveSettingsUsesNewAPIAuth checks that settings validation uses the new API.
+func TestSaveSettingsUsesNewAPIAuth(t *testing.T) {
+
+	httpClient := &testHTTPClient{
+		do: func(r *http.Request) (*http.Response, error) {
+			if r.URL.Path != "/api/fields" {
+				t.Fatalf("expected path /api/fields, got %q", r.URL.Path)
+			}
+			if r.URL.Query().Get("limit") != "1" {
+				t.Fatalf("expected limit=1, got raw query %q", r.URL.RawQuery)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer "+testAPIKey {
+				t.Fatalf("expected bearer Authorization header, got %q", auth)
+			}
+			if version := r.Header.Get("X-Version"); version != apiVersion {
+				t.Fatalf("expected X-Version %q, got %q", apiVersion, version)
+			}
+			if accept := r.Header.Get("Accept"); accept != "application/json" {
+				t.Fatalf("expected Accept application/json, got %q", accept)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[]}`), nil
+		},
+	}
+
+	oldAPIBaseURL := apiBaseURL
+	apiBaseURL = "https://connect.mailerlite.test/api"
+	defer func() { apiBaseURL = oldAPIBaseURL }()
+
+	ml := &MailerLite{
+		env: &connectors.ApplicationEnv{
+			Settings:   &testSettingsStore{},
+			HTTPClient: httpClient,
+		},
+	}
+
+	settings, err := json.Marshal(innerSettings{APIKey: testAPIKey})
+	if err != nil {
+		t.Fatalf("expected settings marshal to succeed, got %v", err)
+	}
+
+	ui, err := ml.ServeUI(t.Context(), "save", settings, connectors.Destination)
+	if err != nil {
+		t.Fatalf("expected save settings to succeed, got %v", err)
+	}
+	if ui != nil {
+		t.Fatalf("expected save to return nil UI, got %#v", ui)
+	}
+	if httpClient.calls != 1 {
+		t.Fatalf("expected one HTTP request, got %d", httpClient.calls)
+	}
+
+}
+
+// TestUpsertCreateRequest checks the create request body.
+func TestUpsertCreateRequest(t *testing.T) {
+
+	client := &testHTTPClient{
+		do: func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusCreated, `{"data":{"id":"188181874438309840"}}`), nil
+		},
+	}
+	ml := newTestMailerLite(t, client)
+	schema := upsertTestSchema()
+	ts := time.Date(2026, 5, 25, 10, 11, 12, 0, time.UTC)
+
+	err := ml.Upsert(t.Context(), connectors.TargetUser, newRecordsIterator([]connectors.Record{{
+		Attributes: map[string]any{
+			"email":         "sam@example.com",
+			"status":        "active",
+			"subscribed_at": ts,
+			"resubscribe":   true,
+			"groups":        []any{"123", "456"},
+			"fields": map[string]any{
+				"name":  "Sam",
+				"score": "001",
+			},
+		},
+	}}), schema)
+	if err != nil {
+		t.Fatalf("expected create upsert to succeed, got %v", err)
+	}
+
+	req := client.onlyRequest(t)
+	assertMailerLiteRequest(t, req, http.MethodPost, "/api/subscribers")
+	assertJSONBody(t, req, map[string]any{
+		"email":         "sam@example.com",
+		"status":        "active",
+		"subscribed_at": "2026-05-25 10:11:12",
+		"resubscribe":   true,
+		"groups":        []any{"123", "456"},
+		"fields": map[string]any{
+			"name":  "Sam",
+			"score": "001",
+		},
+	})
+
+}
+
+// TestUpsertCreateRequiresCreatedStatus checks the create status code.
+func TestUpsertCreateRequiresCreatedStatus(t *testing.T) {
+
+	client := &testHTTPClient{
+		do: func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{"data":{"id":"188181874438309840"}}`), nil
+		},
+	}
+	ml := newTestMailerLite(t, client)
+
+	err := ml.Upsert(t.Context(), connectors.TargetUser, newRecordsIterator([]connectors.Record{{
+		Attributes: map[string]any{"email": "sam@example.com"},
+	}}), upsertTestSchema())
+	if err == nil {
+		t.Fatal("expected create upsert with 200 response to fail")
+	}
+	apiErr, ok := err.(*apiError)
+	if !ok {
+		t.Fatalf("expected apiError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusOK {
+		t.Fatalf("expected apiError status 200, got %d", apiErr.StatusCode)
+	}
+
+}
+
+// TestUpsertUpdateRequest checks the update request body.
+func TestUpsertUpdateRequest(t *testing.T) {
+
+	client := &testHTTPClient{
+		do: func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{"data":{"id":"abc/123"}}`), nil
+		},
+	}
+	ml := newTestMailerLite(t, client)
+	schema := upsertTestSchema()
+
+	err := ml.Upsert(t.Context(), connectors.TargetUser, newRecordsIterator([]connectors.Record{{
+		ID: "abc/123",
+		Attributes: map[string]any{
+			"email":  "sam@example.com",
+			"status": "active",
+			"fields": map[string]any{
+				"name": "Sam",
+			},
+		},
+	}}), schema)
+	if err != nil {
+		t.Fatalf("expected update upsert to succeed, got %v", err)
+	}
+
+	req := client.onlyRequest(t)
+	assertMailerLiteRequest(t, req, http.MethodPut, "/api/subscribers/abc%2F123")
+	body := assertJSONBody(t, req, map[string]any{
+		"status": "active",
+		"fields": map[string]any{
+			"name": "Sam",
+		},
+	})
+	if _, ok := body["id"]; ok {
+		t.Fatalf("expected update body not to contain id, got %s", string(req.body))
+	}
+	if _, ok := body["email"]; ok {
+		t.Fatalf("expected update body not to contain email, got %s", string(req.body))
+	}
+
+}
+
+// TestUpsertCreateRequestIncludesEmailAndFields checks the create body.
+func TestUpsertCreateRequestIncludesEmailAndFields(t *testing.T) {
+
+	client := &testHTTPClient{
+		do: func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusCreated, `{"data":{"id":"188181874438309840"}}`), nil
+		},
+	}
+	ml := newTestMailerLite(t, client)
+
+	err := ml.Upsert(t.Context(), connectors.TargetUser, newRecordsIterator([]connectors.Record{{
+		Attributes: map[string]any{
+			"email": "sam@example.com",
+			"fields": map[string]any{
+				"name": "Sam",
+			},
+		},
+	}}), upsertTestSchema())
+	if err != nil {
+		t.Fatalf("expected upsert to succeed, got %v", err)
+	}
+
+	req := client.onlyRequest(t)
+	assertMailerLiteRequest(t, req, http.MethodPost, "/api/subscribers")
+	assertJSONBody(t, req, map[string]any{
+		"email": "sam@example.com",
+		"fields": map[string]any{
+			"name": "Sam",
+		},
+	})
+
+}
+
+// TestUpsertCreateWithoutEmail checks create validation.
+func TestUpsertCreateWithoutEmail(t *testing.T) {
+
+	client := &testHTTPClient{
+		do: func(r *http.Request) (*http.Response, error) {
+			t.Fatal("expected no HTTP request")
+			return nil, nil
+		},
+	}
+	ml := newTestMailerLite(t, client)
+
+	err := ml.Upsert(t.Context(), connectors.TargetUser, newRecordsIterator([]connectors.Record{{
+		Attributes: map[string]any{"status": "active"},
+	}}), upsertTestSchema())
+	if _, ok := err.(connectors.RecordsError); !ok {
+		t.Fatalf("expected RecordsError, got %T: %v", err, err)
+	}
+	if client.calls != 0 {
+		t.Fatalf("expected no HTTP calls, got %d", client.calls)
+	}
+
+}
+
+// TestServeUIUsesMultilineAPIKeyInput checks the settings input widget.
+func TestServeUIUsesMultilineAPIKeyInput(t *testing.T) {
+
+	ml := &MailerLite{
+		env: &connectors.ApplicationEnv{
+			Settings:   &testSettingsStore{},
+			HTTPClient: &testHTTPClient{},
+		},
+	}
+
+	ui, err := ml.ServeUI(t.Context(), "load", nil, connectors.Destination)
+	if err != nil {
+		t.Fatalf("expected load settings UI to succeed, got %v", err)
+	}
+	if len(ui.Fields) != 1 {
+		t.Fatalf("expected one settings field, got %d", len(ui.Fields))
+	}
+	input, ok := ui.Fields[0].(*connectors.Input)
+	if !ok {
+		t.Fatalf("expected API token field to be an Input, got %T", ui.Fields[0])
+	}
+	if input.Rows <= 1 {
+		t.Fatalf("expected API token field to be multiline, got rows=%d", input.Rows)
+	}
+	if input.MinLength != legacyAPIKeyLength+1 {
+		t.Fatalf("expected API token minimum length to reject legacy keys, got %d", input.MinLength)
+	}
+	if input.Type == "password" {
+		t.Fatal("expected multiline API token field not to use password input type")
+	}
+
+}
+
+// TestRecordSchemaEmailAndGroups checks the email and groups schema.
+func TestRecordSchemaEmailAndGroups(t *testing.T) {
+
+	ml := &MailerLite{
+		env: &connectors.ApplicationEnv{
+			Settings:   &testSettingsStore{},
+			HTTPClient: fieldsHTTPClient(t, nil),
+		},
+	}
+
+	sourceSchema, err := ml.RecordSchema(t.Context(), connectors.TargetUser, connectors.Source)
+	if err != nil {
+		t.Fatalf("expected source schema, got %v", err)
+	}
+	destinationSchema, err := ml.RecordSchema(t.Context(), connectors.TargetUser, connectors.Destination)
+	if err != nil {
+		t.Fatalf("expected destination schema, got %v", err)
+	}
+
+	sourceEmail, err := sourceSchema.Properties().ByPath("email")
+	if err != nil {
+		t.Fatalf("expected source email property, got %v", err)
+	}
+	destinationEmail, err := destinationSchema.Properties().ByPath("email")
+	if err != nil {
+		t.Fatalf("expected destination email property, got %v", err)
+	}
+	if !types.Equal(sourceEmail.Type, destinationEmail.Type) {
+		t.Fatalf("expected source and destination email types to match, got %s and %s", sourceEmail.Type, destinationEmail.Type)
+	}
+	if sourceEmail.Nullable != destinationEmail.Nullable {
+		t.Fatalf("expected source and destination email nullability to match, got %t and %t", sourceEmail.Nullable, destinationEmail.Nullable)
+	}
+	if _, err := sourceSchema.Properties().ByPath("groups"); err != nil {
+		t.Fatalf("expected source schema to include groups, got %v", err)
+	}
+	if _, err := destinationSchema.Properties().ByPath("groups"); err != nil {
+		t.Fatalf("expected destination schema to include groups, got %v", err)
+	}
+	if _, err := destinationSchema.Properties().ByPath("id"); err == nil {
+		t.Fatal("expected destination schema not to include id")
+	}
+	if _, err := sourceSchema.Properties().ByPath("id"); err != nil {
+		t.Fatalf("expected source schema to include id, got %v", err)
+	}
+	if got := sourceSchema.Properties().Slice()[0].Name; got != "id" {
+		t.Fatalf("expected id to be the first source property, got %q", got)
+	}
+
+}
+
+// TestRecordSchemaDynamicFields checks custom field mapping.
+func TestRecordSchemaDynamicFields(t *testing.T) {
+
+	fields := json.Value(`[
+		{"id":"1","name":"Text Field","key":"text_field","type":"text"},
+		{"id":"2","name":"Number Field","key":"number_field","type":"number"},
+		{"id":"3","name":"Date Field","key":"date_field","type":"date"},
+		{"id":"4","name":"Invalid Key","key":"invalid-key","type":"text"},
+		{"id":"5","name":"Unknown Field","key":"unknown_field","type":"boolean"}
+	]`)
+	ml := &MailerLite{
+		env: &connectors.ApplicationEnv{
+			Settings:   &testSettingsStore{},
+			HTTPClient: fieldsHTTPClient(t, fields),
+		},
+	}
+
+	for _, role := range []connectors.Role{connectors.Source, connectors.Destination} {
+		schema, err := ml.RecordSchema(t.Context(), connectors.TargetUser, role)
+		if err != nil {
+			t.Fatalf("expected %s schema, got %v", role, err)
+		}
+
+		assertPropertyType(t, schema, "fields.text_field", types.String())
+		assertPropertyType(t, schema, "fields.number_field", types.Decimal(numberPrecision, numberScale))
+		assertPropertyType(t, schema, "fields.date_field", types.Date())
+		assertNoNestedField(t, schema, "invalid-key")
+		assertNoNestedField(t, schema, "unknown_field")
+	}
+
+}
+
+// TestRecordSchemaNoCustomFields checks the empty custom field case.
+func TestRecordSchemaNoCustomFields(t *testing.T) {
+
+	ml := &MailerLite{
+		env: &connectors.ApplicationEnv{
+			Settings:   &testSettingsStore{},
+			HTTPClient: fieldsHTTPClient(t, nil),
+		},
+	}
+
+	for _, role := range []connectors.Role{connectors.Source, connectors.Destination} {
+		schema, err := ml.RecordSchema(t.Context(), connectors.TargetUser, role)
+		if err != nil {
+			t.Fatalf("expected %s schema, got %v", role, err)
+		}
+		assertNoProperty(t, schema, "fields")
+	}
+
+}
+
+// TestRecordsParsing checks subscriber parsing.
+func TestRecordsParsing(t *testing.T) {
+
+	client := mailerLiteFixtureClient(t, map[string]string{
+		"/api/fields":      fieldsFixture(),
+		"/api/subscribers": subscribersPageFixture("188181874438309840", "sam@example.com", "2026-05-22 15:37:00", ""),
+	})
+	ml := newTestMailerLite(t, client)
+
+	schema, err := ml.RecordSchema(t.Context(), connectors.TargetUser, connectors.Source)
+	if err != nil {
+		t.Fatalf("expected source schema, got %v", err)
+	}
+	records, cursor, err := ml.Records(t.Context(), connectors.TargetUser, time.Time{}, "", schema)
+	if err != io.EOF {
+		t.Fatalf("expected EOF with final page, got cursor %q and error %v", cursor, err)
+	}
+	if cursor != "" {
+		t.Fatalf("expected empty cursor, got %q", cursor)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected one record, got %d", len(records))
+	}
+
+	record := records[0]
+	if record.ID != "188181874438309840" {
+		t.Fatalf("unexpected record ID %q", record.ID)
+	}
+	if want := time.Date(2026, 5, 22, 15, 37, 0, 0, time.UTC); !record.UpdatedAt.Equal(want) {
+		t.Fatalf("expected UpdatedAt %s, got %s", want, record.UpdatedAt)
+	}
+	if record.Err != nil {
+		t.Fatalf("expected no record error, got %v", record.Err)
+	}
+	if got := record.Attributes["email"]; got != "sam@example.com" {
+		t.Fatalf("expected email sam@example.com, got %#v", got)
+	}
+	groups, ok := record.Attributes["groups"].([]string)
+	if !ok {
+		t.Fatalf("expected groups slice, got %T %#v", record.Attributes["groups"], record.Attributes["groups"])
+	}
+	if len(groups) != 2 || groups[0] != "123" || groups[1] != "456" {
+		t.Fatalf("expected groups [123 456], got %#v", groups)
+	}
+	if got := record.Attributes["sent"]; got != int32(7) {
+		t.Fatalf("expected sent int32(7), got %T %#v", got, got)
+	}
+	if got := record.Attributes["opens_count"]; got != int32(3) {
+		t.Fatalf("expected opens_count int32(3), got %T %#v", got, got)
+	}
+	if got := record.Attributes["clicks_count"]; got != int32(2) {
+		t.Fatalf("expected clicks_count int32(2), got %T %#v", got, got)
+	}
+	fields, ok := record.Attributes["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fields map, got %T", record.Attributes["fields"])
+	}
+	score, ok := fields["score"].(decimal.Decimal)
+	if !ok {
+		t.Fatalf("expected score decimal, got %T %#v", fields["score"], fields["score"])
+	}
+	if fields["name"] != "Sam" || score.Cmp(decimal.MustInt(1)) != 0 || fields["birthday"] != "1990-01-02" {
+		t.Fatalf("unexpected fields %#v", fields)
+	}
+
+}
+
+// TestRecordsParsingDropsUnrepresentableNumberField checks unrepresentable numbers.
+func TestRecordsParsingDropsUnrepresentableNumberField(t *testing.T) {
+
+	client := mailerLiteFixtureClient(t, map[string]string{
+		"/api/fields":      fieldsFixture(),
+		"/api/subscribers": subscribersPageFixtureWithScore("188181874438309840", "sam@example.com", "2026-05-22 15:37:00", "", "0.00000000000000000000000000000000000001"),
+	})
+	ml := newTestMailerLite(t, client)
+
+	schema, err := ml.RecordSchema(t.Context(), connectors.TargetUser, connectors.Source)
+	if err != nil {
+		t.Fatalf("expected source schema, got %v", err)
+	}
+	records, _, err := ml.Records(t.Context(), connectors.TargetUser, time.Time{}, "", schema)
+	if err != io.EOF {
+		t.Fatalf("expected EOF with final page, got %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected one record, got %d", len(records))
+	}
+	if records[0].Err != nil {
+		t.Fatalf("expected record to remain valid, got %v", records[0].Err)
+	}
+	fields, ok := records[0].Attributes["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fields map, got %T", records[0].Attributes["fields"])
+	}
+	if fields["score"] != nil {
+		t.Fatalf("expected unrepresentable score to be nil, got %T %#v", fields["score"], fields["score"])
+	}
+
+}
+
+// TestParseNumber checks MailerLite number parsing.
+func TestParseNumber(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		value any
+		want  any
+	}{
+		{name: "nil", value: nil, want: nil},
+		{name: "empty", value: "", want: nil},
+		{name: "leading zeros", value: "001", want: decimal.MustInt(1)},
+		{name: "zero fraction", value: "000.12", want: decimal.MustParse("0.12")},
+		{name: "negative leading zeros", value: "-001.20", want: decimal.MustParse("-1.20")},
+		{name: "positive exponent", value: "001e3", want: decimal.MustInt(1000)},
+		{name: "negative exponent", value: "001E-2", want: decimal.MustParse("0.01")},
+		{name: "not representable", value: "0.00000000000000000000000000000000000001", want: nil},
+		{name: "not string", value: float64(1), want: nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := parseNumber(test.value)
+			want, ok := test.want.(decimal.Decimal)
+			if !ok {
+				if got != nil {
+					t.Fatalf("expected nil, got %T %#v", got, got)
+				}
+				return
+			}
+			gotDecimal, ok := got.(decimal.Decimal)
+			if !ok {
+				t.Fatalf("expected decimal, got %T %#v", got, got)
+			}
+			if gotDecimal.Cmp(want) != 0 {
+				t.Fatalf("expected %s, got %s", want, gotDecimal)
+			}
+		})
+	}
+
+}
+
+// TestRecordsPaginationAndUpdatedAt checks pagination and updatedAt filtering.
+func TestRecordsPaginationAndUpdatedAt(t *testing.T) {
+
+	client := mailerLiteFixtureClient(t, map[string]string{
+		"/api/subscribers":                  subscribersPageFixture("old", "old@example.com", "2026-05-22 10:00:00", "next-page"),
+		"/api/subscribers?cursor=next-page": subscribersPageFixture("new", "new@example.com", "2026-05-22 12:00:00", ""),
+	})
+	ml := newTestMailerLite(t, client)
+	schema := types.Object([]types.Property{
+		{Name: "email", Type: types.String(), Description: "Email address, used only when creating a subscriber"},
+		{Name: "updated_at", Type: types.DateTime(), Description: "Last update timestamp"},
+	})
+
+	records, cursor, err := ml.Records(t.Context(), connectors.TargetUser, time.Time{}, "", schema)
+	if err != nil {
+		t.Fatalf("expected first page without error, got %v", err)
+	}
+	if cursor != "next-page" {
+		t.Fatalf("expected next cursor next-page, got %q", cursor)
+	}
+	if len(records) != 1 || records[0].ID != "old" {
+		t.Fatalf("expected first page old record, got %#v", records)
+	}
+
+	records, cursor, err = ml.Records(t.Context(), connectors.TargetUser, time.Time{}, cursor, schema)
+	if err != io.EOF {
+		t.Fatalf("expected EOF on second page, got cursor %q and error %v", cursor, err)
+	}
+	if cursor != "" {
+		t.Fatalf("expected empty final cursor, got %q", cursor)
+	}
+	if len(records) != 1 || records[0].ID != "new" {
+		t.Fatalf("expected second page new record, got %#v", records)
+	}
+
+	client.requests = nil
+	client.calls = 0
+	updatedAt := time.Date(2026, 5, 22, 11, 0, 0, 0, time.UTC)
+	records, cursor, err = ml.Records(t.Context(), connectors.TargetUser, updatedAt, "", schema)
+	if err != nil {
+		t.Fatalf("expected first page to return next cursor without error, got cursor %q and error %v", cursor, err)
+	}
+	if cursor != "next-page" {
+		t.Fatalf("expected next cursor after updatedAt filtering, got %q", cursor)
+	}
+	if len(records) != 0 {
+		t.Fatalf("expected no records after updatedAt filtering, got %#v", records)
+	}
+	if client.calls != 1 {
+		t.Fatalf("expected one HTTP call when first page is filtered out, got %d", client.calls)
+	}
+
+}
+
+// TestUpsertErrorMapping checks API error mapping.
+func TestUpsertErrorMapping(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		statusCode   int
+		recordsError bool
+	}{
+		{name: "bad request", statusCode: http.StatusBadRequest, recordsError: true},
+		{name: "not found", statusCode: http.StatusNotFound, recordsError: true},
+		{name: "unprocessable entity", statusCode: http.StatusUnprocessableEntity, recordsError: true},
+		{name: "unauthorized", statusCode: http.StatusUnauthorized},
+		{name: "forbidden", statusCode: http.StatusForbidden},
+		{name: "too many requests", statusCode: http.StatusTooManyRequests},
+		{name: "server error", statusCode: http.StatusInternalServerError},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &testHTTPClient{
+				do: func(r *http.Request) (*http.Response, error) {
+					return jsonResponse(test.statusCode, `{"message":"MailerLite test error","errors":{"email":["invalid"]}}`), nil
+				},
+			}
+			ml := newTestMailerLite(t, client)
+
+			err := ml.Upsert(t.Context(), connectors.TargetUser, newRecordsIterator([]connectors.Record{{
+				Attributes: map[string]any{"email": "sam@example.com"},
+			}}), upsertTestSchema())
+			if err == nil {
+				t.Fatal("expected upsert error, got nil")
+			}
+			recordsErr, ok := err.(connectors.RecordsError)
+			if test.recordsError {
+				if !ok {
+					t.Fatalf("expected RecordsError, got %T: %v", err, err)
+				}
+				if recordsErr[0] == nil {
+					t.Fatalf("expected RecordsError index 0, got %#v", recordsErr)
+				}
+				return
+			}
+			if ok {
+				t.Fatalf("expected global error, got RecordsError: %v", err)
+			}
+		})
+	}
+
+}
+
+// TestSaveSettingsValidation checks settings validation failures.
+func TestSaveSettingsValidation(t *testing.T) {
+
+	tests := []struct {
+		name               string
+		apiKey             string
+		statusCode         int
+		wantInvalidSetting bool
+		wantHTTPCalls      int
+	}{
+		{name: "empty", apiKey: "", wantInvalidSetting: true},
+		{name: "space", apiKey: "abc def", wantInvalidSetting: true},
+		{name: "control char", apiKey: "abc\ndef", wantInvalidSetting: true},
+		{name: "max length", apiKey: strings.Repeat("a", settingsAPIKeyMaxSize), statusCode: http.StatusOK, wantHTTPCalls: 1},
+		{name: "too long", apiKey: strings.Repeat("a", settingsAPIKeyMaxSize+1), wantInvalidSetting: true},
+		{name: "api unauthorized", apiKey: "valid-shape", statusCode: http.StatusUnauthorized, wantInvalidSetting: true, wantHTTPCalls: 1},
+		{name: "api forbidden", apiKey: "valid-shape", statusCode: http.StatusForbidden, wantInvalidSetting: true, wantHTTPCalls: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &testHTTPClient{
+				do: func(r *http.Request) (*http.Response, error) {
+					assertMailerLiteRequestWithAPIKey(t, capturedRequest{
+						method: r.Method,
+						path:   r.URL.EscapedPath(),
+						header: r.Header,
+					}, http.MethodGet, "/api/fields", test.apiKey)
+					return jsonResponse(test.statusCode, `{"message":"MailerLite test error"}`), nil
+				},
+			}
+			ml := newTestMailerLite(t, client)
+
+			settings, err := json.Marshal(innerSettings{APIKey: test.apiKey})
+			if err != nil {
+				t.Fatalf("expected settings marshal to succeed, got %v", err)
+			}
+			_, err = ml.ServeUI(t.Context(), "save", settings, connectors.Destination)
+			if test.wantInvalidSetting {
+				if _, ok := err.(*connectors.InvalidSettingsError); !ok {
+					t.Fatalf("expected InvalidSettingsError, got %T: %v", err, err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected save settings to succeed, got %v", err)
+			}
+			if client.calls != test.wantHTTPCalls {
+				t.Fatalf("expected %d HTTP calls, got %d", test.wantHTTPCalls, client.calls)
+			}
+		})
+	}
+
+}
+
+// TestLiveMailerLiteAPIKey checks the live API key against MailerLite.
+func TestLiveMailerLiteAPIKey(t *testing.T) {
+
+	apiKey := os.Getenv("KRENALIS_TEST_MAILERLITE_API_KEY")
+	if apiKey == "" {
+		t.Skip("the KRENALIS_TEST_MAILERLITE_API_KEY environment variable is not present")
+	}
+	if strings.ContainsFunc(apiKey, func(r rune) bool { return r <= ' ' || r == 0x7f }) {
+		t.Fatal("expected KRENALIS_TEST_MAILERLITE_API_KEY not to contain spaces or control characters")
+	}
+
+	ml, err := testconnector.NewApplication[*MailerLite]("mailerlite", innerSettings{})
+	if err != nil {
+		t.Fatalf("expected NewApplication to succeed, got %v", err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	settings, err := json.Marshal(innerSettings{APIKey: apiKey})
+	if err != nil {
+		t.Fatalf("expected settings marshal to succeed, got %v", err)
+	}
+	if _, err := ml.ServeUI(ctx, "save", settings, connectors.Destination); err != nil {
+		t.Fatalf("expected MailerLite API token validation to succeed, got %v", err)
+	}
+
+	schema, err := ml.RecordSchema(ctx, connectors.TargetUser, connectors.Source)
+	if err != nil {
+		t.Fatalf("expected MailerLite fields to be readable, got %v", err)
+	}
+	if _, err := schema.Properties().ByPathSlice([]string{"email"}); err != nil {
+		t.Fatalf("expected source schema to include email, got %v", err)
+	}
+
+	records, _, err := ml.Records(ctx, connectors.TargetUser, time.Time{}, "", schema)
+	if err == io.EOF {
+		if os.Getenv("KRENALIS_TEST_MAILERLITE_REQUIRE_SUBSCRIBERS") == "1" {
+			t.Fatal("expected at least one MailerLite subscriber because KRENALIS_TEST_MAILERLITE_REQUIRE_SUBSCRIBERS=1")
+		}
+		t.Skip("the configured MailerLite account has no subscribers")
+	}
+	if err != nil {
+		t.Fatalf("expected MailerLite subscribers to be readable, got %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("expected at least one MailerLite subscriber")
+	}
+	record := records[0]
+	if record.ID == "" {
+		t.Fatal("expected first MailerLite subscriber to have a non-empty Record.ID")
+	}
+	if record.UpdatedAt.IsZero() {
+		t.Fatal("expected first MailerLite subscriber to have a non-zero UpdatedAt")
+	}
+	if record.Err != nil {
+		t.Fatalf("expected first MailerLite subscriber to be valid, got %v", record.Err)
+	}
+	if record.Attributes["email"] == "" {
+		t.Fatalf("expected first MailerLite subscriber to include email, got %#v", record.Attributes["email"])
+	}
+
+}
+
+func fieldsHTTPClient(t *testing.T, fields json.Value) *testHTTPClient {
+	t.Helper()
+	if fields == nil {
+		fields = json.Value(`[]`)
+	}
+	return &testHTTPClient{
+		do: func(r *http.Request) (*http.Response, error) {
+			if r.URL.Path != "/api/fields" {
+				t.Fatalf("expected path /api/fields, got %q", r.URL.Path)
+			}
+			return jsonResponse(http.StatusOK, `{"data":`+string(fields)+`}`), nil
+		},
+	}
+}
+
+type testSettingsStore struct {
+	settings json.Value
+}
+
+func (store *testSettingsStore) Load(ctx context.Context, dst any) error {
+	if store.settings == nil {
+		return nil
+	}
+	return store.settings.Unmarshal(dst)
+}
+
+func (store *testSettingsStore) Store(ctx context.Context, src any) error {
+	settings, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	store.settings = settings
+	return nil
+}
+
+type testHTTPClient struct {
+	calls    int
+	requests []capturedRequest
+	do       func(req *http.Request) (*http.Response, error)
+}
+
+func (client *testHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	client.calls++
+	captured := capturedRequest{
+		method: req.Method,
+		url:    req.URL.String(),
+		path:   req.URL.EscapedPath(),
+		query:  req.URL.Query(),
+		header: req.Header.Clone(),
+	}
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		captured.body = body
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	client.requests = append(client.requests, captured)
+	if client.do == nil {
+		return nil, errors.New("test HTTP client has no Do function")
+	}
+	return client.do(req)
+}
+
+func (client *testHTTPClient) ClientSecret() (string, error) {
+	return "", errors.New("test HTTP client does not support OAuth")
+}
+
+func (client *testHTTPClient) AccessToken(ctx context.Context) (string, error) {
+	return "", errors.New("test HTTP client does not support OAuth")
+}
+
+func (client *testHTTPClient) GetBodyBuffer(enc connectors.ContentEncoding) *connectors.BodyBuffer {
+	return connectors.GetBodyBuffer(enc, 1024)
+}
+
+func jsonResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+type capturedRequest struct {
+	method string
+	url    string
+	path   string
+	query  map[string][]string
+	header http.Header
+	body   []byte
+}
+
+func (client *testHTTPClient) onlyRequest(t *testing.T) capturedRequest {
+	t.Helper()
+	if len(client.requests) != 1 {
+		t.Fatalf("expected one request, got %d", len(client.requests))
+	}
+	return client.requests[0]
+}
+
+func newTestMailerLite(t *testing.T, httpClient *testHTTPClient) *MailerLite {
+	t.Helper()
+	store := &testSettingsStore{}
+	if err := store.Store(t.Context(), innerSettings{APIKey: testAPIKey}); err != nil {
+		t.Fatalf("expected settings store to succeed, got %v", err)
+	}
+	oldAPIBaseURL := apiBaseURL
+	apiBaseURL = "https://connect.mailerlite.test/api"
+	t.Cleanup(func() { apiBaseURL = oldAPIBaseURL })
+	return &MailerLite{
+		env: &connectors.ApplicationEnv{
+			Settings:   store,
+			HTTPClient: httpClient,
+		},
+	}
+}
+
+func assertMailerLiteRequest(t *testing.T, req capturedRequest, method, path string) {
+	t.Helper()
+	assertMailerLiteRequestWithAPIKey(t, req, method, path, testAPIKey)
+}
+
+func assertMailerLiteRequestWithAPIKey(t *testing.T, req capturedRequest, method, path, apiKey string) {
+	t.Helper()
+	if req.method != method {
+		t.Fatalf("expected method %s, got %s", method, req.method)
+	}
+	if req.path != path {
+		t.Fatalf("expected path %s, got %s", path, req.path)
+	}
+	if auth := req.header.Get("Authorization"); auth != "Bearer "+apiKey {
+		t.Fatalf("expected bearer Authorization header, got %q", auth)
+	}
+	if version := req.header.Get("X-Version"); version != apiVersion {
+		t.Fatalf("expected X-Version %q, got %q", apiVersion, version)
+	}
+}
+
+func assertJSONBody(t *testing.T, req capturedRequest, expected map[string]any) map[string]any {
+	t.Helper()
+	var got map[string]any
+	if err := json.Unmarshal(req.body, &got); err != nil {
+		t.Fatalf("expected valid JSON body, got %v; body=%s", err, string(req.body))
+	}
+	if !jsonEqual(got, expected) {
+		t.Fatalf("unexpected JSON body:\nexpected %#v\ngot      %#v\nraw      %s", expected, got, string(req.body))
+	}
+	return got
+}
+
+func assertPropertyType(t *testing.T, schema types.Type, path string, typ types.Type) {
+	t.Helper()
+	property, err := schema.Properties().ByPath(path)
+	if err != nil {
+		t.Fatalf("expected property %q, got %v", path, err)
+	}
+	if !types.Equal(property.Type, typ) {
+		t.Fatalf("expected property %q to have type %s, got %s", path, typ, property.Type)
+	}
+}
+
+func assertNoProperty(t *testing.T, schema types.Type, path string) {
+	t.Helper()
+	if _, err := schema.Properties().ByPath(path); err == nil {
+		t.Fatalf("expected property %q not to exist", path)
+	}
+}
+
+func assertNoNestedField(t *testing.T, schema types.Type, name string) {
+	t.Helper()
+	fields, err := schema.Properties().ByPath("fields")
+	if err != nil {
+		t.Fatalf("expected fields property, got %v", err)
+	}
+	for _, property := range fields.Type.Properties().All() {
+		if property.Name == name {
+			t.Fatalf("expected nested field %q not to exist", name)
+		}
+	}
+}
+
+func jsonEqual(a, b any) bool {
+	aa, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	aa, err = json.Canonicalize(aa)
+	if err != nil {
+		return false
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	bb, err = json.Canonicalize(bb)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(aa, bb)
+}
+
+func upsertTestSchema() types.Type {
+	return types.Object([]types.Property{
+		{Name: "email", Type: types.String(), CreateRequired: true, Description: "Email address, used only when creating a subscriber"},
+		{Name: "status", Type: subscriberStatusType(), Description: "Subscriber status"},
+		{Name: "subscribed_at", Type: types.DateTime(), Nullable: true, Description: "Subscription timestamp"},
+		{Name: "resubscribe", Type: types.Boolean(), Description: "Resubscribe"},
+		{Name: "groups", Type: types.Array(types.String()), Description: "Group IDs"},
+		{Name: "fields", Type: types.Object([]types.Property{
+			{Name: "name", Type: types.String(), Nullable: true, Description: "Name"},
+			{Name: "score", Type: types.String().WithMaxLength(1024), Nullable: true, Description: "Score"},
+		}), Description: "Subscriber custom fields"},
+	})
+}
+
+type recordsIterator struct {
+	records  []connectors.Record
+	consumed bool
+	current  int
+}
+
+func newRecordsIterator(records []connectors.Record) connectors.Records {
+	return &recordsIterator{records: records}
+}
+
+func (it *recordsIterator) All() iter.Seq[connectors.Record] {
+	if it.consumed {
+		panic("Records.All called after records were consumed")
+	}
+	it.consumed = true
+	return func(yield func(connectors.Record) bool) {
+		for i, record := range it.records {
+			it.current = i
+			if !yield(record) {
+				return
+			}
+		}
+	}
+}
+
+func (it *recordsIterator) Discard(err error) {
+	if err == nil {
+		panic("Records.Discard called with nil error")
+	}
+	if !it.consumed {
+		panic("Records.Discard called outside iteration")
+	}
+}
+
+func (it *recordsIterator) First() connectors.Record {
+	if it.consumed {
+		panic("Records.First called after records were consumed")
+	}
+	it.consumed = true
+	if len(it.records) == 0 {
+		panic("Records.First called with no records")
+	}
+	return it.records[0]
+}
+
+func (it *recordsIterator) Peek() (connectors.Record, bool) {
+	if !it.consumed {
+		if len(it.records) == 0 {
+			return connectors.Record{}, false
+		}
+		return it.records[0], true
+	}
+	next := it.current + 1
+	if next >= len(it.records) {
+		return connectors.Record{}, false
+	}
+	return it.records[next], true
+}
+
+func (it *recordsIterator) Postpone() {
+	if !it.consumed {
+		panic("Records.Postpone called outside iteration")
+	}
+}
+
+func (it *recordsIterator) Same() iter.Seq[connectors.Record] {
+	return it.All()
+}
+
+func mailerLiteFixtureClient(t *testing.T, fixtures map[string]string) *testHTTPClient {
+	t.Helper()
+	return &testHTTPClient{
+		do: func(r *http.Request) (*http.Response, error) {
+			key := r.URL.EscapedPath()
+			if cursor := r.URL.Query().Get("cursor"); cursor != "" {
+				key += "?cursor=" + cursor
+			}
+			body, ok := fixtures[key]
+			if !ok {
+				t.Fatalf("unexpected MailerLite test request %s %s", r.Method, r.URL.String())
+			}
+			return jsonResponse(http.StatusOK, body), nil
+		},
+	}
+}
+
+func fieldsFixture() string {
+	return `{
+		"data": [
+			{"id":"1","name":"Name","key":"name","type":"text"},
+			{"id":"2","name":"Score","key":"score","type":"number"},
+			{"id":"3","name":"Birthday","key":"birthday","type":"date"}
+		],
+		"meta": {"current_page":1,"last_page":1}
+	}`
+}
+
+func subscribersPageFixture(id, email, updatedAt, metaNextCursor string) string {
+	return subscribersPageFixtureWithScore(id, email, updatedAt, metaNextCursor, "001")
+}
+
+func subscribersPageFixtureWithScore(id, email, updatedAt, metaNextCursor, score string) string {
+	meta := `{}`
+	if metaNextCursor != "" {
+		meta = `{"next_cursor":` + strconv.Quote(metaNextCursor) + `}`
+	}
+	return `{
+		"data": [{
+			"id": ` + strconv.Quote(id) + `,
+			"email": ` + strconv.Quote(email) + `,
+			"status": "active",
+			"source": "manual",
+			"sent": 7,
+			"opens_count": 3,
+			"clicks_count": 2,
+			"open_rate": 42.5,
+			"click_rate": 28.5,
+			"ip_address": null,
+			"groups": [{"id":"123"}, {"id":"456"}],
+			"subscribed_at": "2026-05-22 15:37:00",
+			"unsubscribed_at": null,
+			"created_at": "2026-05-22 15:37:00",
+			"updated_at": ` + strconv.Quote(updatedAt) + `,
+			"fields": {
+				"name": "Sam",
+				"score": ` + strconv.Quote(score) + `,
+				"birthday": "1990-01-02"
+			},
+			"opted_in_at": null,
+			"optin_ip": null
+		}],
+		"meta": ` + meta + `
+	}`
+}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	_ "github.com/krenalis/krenalis/connectors/json"
 	_ "github.com/krenalis/krenalis/connectors/klaviyo"
 	_ "github.com/krenalis/krenalis/connectors/mailchimp"
+	_ "github.com/krenalis/krenalis/connectors/mailerlite"
 	_ "github.com/krenalis/krenalis/connectors/mixpanel"
 	_ "github.com/krenalis/krenalis/connectors/mysql"
 	_ "github.com/krenalis/krenalis/connectors/parquet"


### PR DESCRIPTION
```
connectors/mailerlite: implement the connector for MailerLite

The connector supports ingesting and activating subscribers on
MailerLite.
```