### PR TITLE
tools/boundedreader: add bounded reader with configurable overflow error

### DIFF
--- a/tools/boundedreader/boundedreader.go
+++ b/tools/boundedreader/boundedreader.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by an Elastic License 2.0
+// that can be found in the LICENSE file.
+
+// Package boundedreader provides a Reader that fails when its input exceeds
+// a configured size limit.
+//
+// Unlike io.LimitedReader, which behaves as if the underlying stream ended
+// at the limit, a BoundedReader reports an error when additional data is
+// encountered beyond the limit.
+//
+// A BoundedReader never returns bytes beyond the configured limit.
+package boundedreader
+
+import (
+	"errors"
+	"io"
+)
+
+type BoundedReader struct {
+	r    io.Reader
+	n    int
+	errf func() error
+	err  error
+}
+
+var ErrTooLarge = errors.New("data is too large")
+
+// New returns a BoundedReader that reads from r and enforces a limit of n
+// bytes.
+func New(r io.Reader, n int) *BoundedReader {
+	if n < 0 {
+		panic("n must be >= 0")
+	}
+	return &BoundedReader{r: r, n: n}
+}
+
+// SetErrorFunc sets the error reported when a read would exceed the
+// configured size limit. The error is obtained by calling f. If f is nil,
+// ErrTooLarge is reported.
+func (br *BoundedReader) SetErrorFunc(f func() error) {
+	br.errf = f
+}
+
+// Read implements io.Reader.
+func (br *BoundedReader) Read(p []byte) (n int, err error) {
+	if br.err != nil {
+		return 0, br.err
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if len(p) > br.n {
+		p = p[:br.n+1]
+	}
+	n, err = br.r.Read(p)
+	if n > br.n {
+		br.n = 0
+		if br.errf != nil {
+			br.err = br.errf()
+		} else {
+			br.err = ErrTooLarge
+		}
+		return n - 1, br.err
+	}
+	br.n -= n
+	return n, err
+}

--- a/tools/boundedreader/boundedreader_test.go
+++ b/tools/boundedreader/boundedreader_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by an Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package boundedreader
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// Reads less than the limit.
+func TestReadLessThanLimit(t *testing.T) {
+	br := New(strings.NewReader("abc"), 5)
+
+	b, err := io.ReadAll(br)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if string(b) != "abc" {
+		t.Fatalf("expected %q, got %q", "abc", b)
+	}
+}
+
+// Reads exactly up to the limit.
+func TestReadExactlyLimit(t *testing.T) {
+	br := New(strings.NewReader("abc"), 3)
+
+	b, err := io.ReadAll(br)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if string(b) != "abc" {
+		t.Fatalf("expected %q, got %q", "abc", b)
+	}
+}
+
+// Reports ErrTooLarge when the limit is exceeded.
+func TestReadBeyondLimit(t *testing.T) {
+	br := New(strings.NewReader("abcd"), 3)
+
+	b, err := io.ReadAll(br)
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("expected ErrTooLarge, got %v", err)
+	}
+	if string(b) != "abc" {
+		t.Fatalf("expected %q, got %q", "abc", b)
+	}
+}
+
+// Detects overflow across multiple reads.
+func TestReadBeyondLimitWithSmallBuffer(t *testing.T) {
+	br := New(strings.NewReader("abcdef"), 5)
+
+	var out []byte
+	buf := make([]byte, 2)
+
+	for {
+		n, err := br.Read(buf)
+		out = append(out, buf[:n]...)
+		if err != nil {
+			if !errors.Is(err, ErrTooLarge) {
+				t.Fatalf("expected ErrTooLarge, got %v", err)
+			}
+			break
+		}
+	}
+
+	if string(out) != "abcde" {
+		t.Fatalf("expected %q, got %q", "abcde", out)
+	}
+}
+
+// Handles an empty input with a zero limit.
+func TestReadZeroLimitEmptyInput(t *testing.T) {
+	br := New(strings.NewReader(""), 0)
+
+	b, err := io.ReadAll(br)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(b) != 0 {
+		t.Fatalf("expected empty output, got %q", b)
+	}
+}
+
+// Reports ErrTooLarge when the limit is zero.
+func TestReadZeroLimitNonEmptyInput(t *testing.T) {
+	br := New(strings.NewReader("a"), 0)
+
+	b, err := io.ReadAll(br)
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("expected ErrTooLarge, got %v", err)
+	}
+	if len(b) != 0 {
+		t.Fatalf("expected empty output, got %q", b)
+	}
+}
+
+// Does not consume data on an empty read.
+func TestReadEmptyBuffer(t *testing.T) {
+	br := New(strings.NewReader("abc"), 3)
+
+	n, err := br.Read(nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected n == 0, got %d", n)
+	}
+
+	b, err := io.ReadAll(br)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if string(b) != "abc" {
+		t.Fatalf("expected %q, got %q", "abc", b)
+	}
+}
+
+// Uses the configured error function.
+func TestSetErrorFunc(t *testing.T) {
+	want := errors.New("custom error")
+
+	br := New(strings.NewReader("abcd"), 3)
+	br.SetErrorFunc(func() error {
+		return want
+	})
+
+	_, err := io.ReadAll(br)
+	if !errors.Is(err, want) {
+		t.Fatalf("expected custom error, got %v", err)
+	}
+}
+
+// Falls back to ErrTooLarge when the error function is nil.
+func TestSetErrorFuncNil(t *testing.T) {
+	br := New(strings.NewReader("abcd"), 3)
+	br.SetErrorFunc(nil)
+
+	_, err := io.ReadAll(br)
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("expected ErrTooLarge, got %v", err)
+	}
+}
+
+// Calls the error function only once.
+func TestErrorFuncCalledOnce(t *testing.T) {
+	want := errors.New("custom error")
+	calls := 0
+
+	br := New(strings.NewReader("abcd"), 3)
+	br.SetErrorFunc(func() error {
+		calls++
+		return want
+	})
+
+	_, err := io.ReadAll(br)
+	if !errors.Is(err, want) {
+		t.Fatalf("expected custom error, got %v", err)
+	}
+
+	_, err = br.Read(make([]byte, 1))
+	if !errors.Is(err, want) {
+		t.Fatalf("expected custom error, got %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("expected error function to be called once, got %d", calls)
+	}
+}
+
+// Propagates errors from the underlying reader.
+func TestUnderlyingReaderError(t *testing.T) {
+	want := errors.New("read error")
+	br := New(errReader{err: want}, 3)
+
+	n, err := br.Read(make([]byte, 1))
+	if n != 0 {
+		t.Fatalf("expected n == 0, got %d", n)
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("expected underlying error, got %v", err)
+	}
+}
+
+// Panics when the limit is negative.
+func TestNewNegativeLimit(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic, got nil")
+		}
+	}()
+
+	New(strings.NewReader(""), -1)
+}
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read([]byte) (int, error) {
+	return 0, r.err
+}


### PR DESCRIPTION
```
tools/boundedreader: add bounded reader with configurable overflow error

Add BoundedReader, an io.Reader that enforces a maximum size and reports
an error when additional data is read beyond the limit.

Unlike io.LimitedReader, BoundedReader does not return EOF at the limit.
Instead, it reports ErrTooLarge or a caller-provided error.
```