### PR TITLE
cmd: prevent truncated request bodies from reaching Sentry

### DIFF
--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -352,9 +352,7 @@ func (s *apisServer) forwardSentryError(w http.ResponseWriter, r *http.Request) 
 	if _, _, _, err := s.authenticateAdminRequest(r); err != nil {
 		return nil, err
 	}
-	lr := &io.LimitedReader{R: r.Body, N: maxRequestSize + 1}
-	payload := norm.NFC.Reader(lr)
-	r.Body = io.NopCloser(payload)
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 	s.sentryTelemetry.errorTunnel.ServeHTTP(w, r)
 	return nil, nil
 }


### PR DESCRIPTION
```
cmd: prevent truncated request bodies from reaching Sentry

This commit replaces io.LimitReader with http.MaxBytesReader for
request body size enforcement.

Requests exceeding the configured limit are now rejected instead of
being silently truncated, preventing partial payloads from being sent
to Sentry.

UTF-8 normalization is no longer applied to content reported to
Sentry. It is now performed only when the content is processed by
Krenalis.
```