### PR TITLE
cmd: simplify `validateRequiredBody` using `http.MaxBytesReader`

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -25,8 +25,8 @@ type api struct {
 // AcceptInvitation accepts the invitation with a given invitation token.
 //
 // Authentication is not required to call AcceptInvitation.
-func (api api) AcceptInvitation(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (api api) AcceptInvitation(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -45,8 +45,8 @@ func (api api) AcceptInvitation(_ http.ResponseWriter, r *http.Request) (any, er
 // reset password token.
 //
 // Authentication is not required to call ChangeMemberPasswordByToken.
-func (api api) ChangeMemberPasswordByToken(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (api api) ChangeMemberPasswordByToken(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -85,11 +85,11 @@ func (api api) Connectors(_ http.ResponseWriter, r *http.Request) (any, error) {
 }
 
 // CreateOrganization creates a new organization.
-func (api api) CreateOrganization(_ http.ResponseWriter, r *http.Request) (any, error) {
+func (api api) CreateOrganization(w http.ResponseWriter, r *http.Request) (any, error) {
 	if err := api.authenticateOrganizationsRequest(r); err != nil {
 		return nil, err
 	}
-	if err := validateRequiredBody(r, false); err != nil {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -126,8 +126,8 @@ func (api api) EventsSettings(w http.ResponseWriter, r *http.Request) (any, erro
 
 // ExpressionsProperties returns all the unique properties contained inside a
 // list of expressions.
-func (api api) ExpressionsProperties(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (api api) ExpressionsProperties(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	if _, _, _, err := api.authenticateAdminRequest(r); err != nil {
@@ -282,8 +282,8 @@ func (api api) PublicMetadata(_ http.ResponseWriter, r *http.Request) (any, erro
 // SendMemberPasswordReset sends a reset password email.
 //
 // Authentication is not required to call SendMemberPasswordReset.
-func (api api) SendMemberPasswordReset(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (api api) SendMemberPasswordReset(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -317,8 +317,8 @@ func (api api) ValidateMemberPasswordResetToken(_ http.ResponseWriter, r *http.R
 
 // TransformData transforms data using a mapping or a function transformation
 // and returns the transformed data.
-func (api api) TransformData(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (api api) TransformData(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	if _, _, _, err := api.authenticateAdminRequest(r); err != nil {
@@ -352,8 +352,8 @@ func (api api) TransformationLanguages(_ http.ResponseWriter, r *http.Request) (
 }
 
 // ValidateExpression validates an expression.
-func (api api) ValidateExpression(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (api api) ValidateExpression(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	if _, _, _, err := api.authenticateAdminRequest(r); err != nil {

--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -352,9 +352,7 @@ func (s *apisServer) forwardSentryError(w http.ResponseWriter, r *http.Request) 
 	if _, _, _, err := s.authenticateAdminRequest(r); err != nil {
 		return nil, err
 	}
-	lr := &io.LimitedReader{R: r.Body, N: maxRequestSize + 1}
-	payload := norm.NFC.Reader(lr)
-	r.Body = io.NopCloser(payload)
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 	s.sentryTelemetry.errorTunnel.ServeHTTP(w, r)
 	return nil, nil
 }

--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -352,7 +352,9 @@ func (s *apisServer) forwardSentryError(w http.ResponseWriter, r *http.Request) 
 	if _, _, _, err := s.authenticateAdminRequest(r); err != nil {
 		return nil, err
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
+	lr := &io.LimitedReader{R: r.Body, N: maxRequestSize + 1}
+	payload := norm.NFC.Reader(lr)
+	r.Body = io.NopCloser(payload)
 	s.sentryTelemetry.errorTunnel.ServeHTTP(w, r)
 	return nil, nil
 }

--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -359,7 +359,7 @@ func (s *apisServer) forwardSentryError(w http.ResponseWriter, r *http.Request) 
 
 // login logs a user in.
 func (s *apisServer) login(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -509,7 +509,7 @@ func validateForbiddenBody(r *http.Request) error {
 // validateRequiredBody validates that the request body is present and is JSON,
 // then applies size limiting and NFC normalization.
 // If allowPlainText is true, it also allows "text/plain" as a content type.
-func validateRequiredBody(r *http.Request, allowPlainText bool) error {
+func validateRequiredBody(w http.ResponseWriter, r *http.Request, allowPlainText bool) error {
 	if r.ContentLength == 0 {
 		return errors.BadRequest("request's body is missing")
 	}
@@ -525,26 +525,15 @@ func validateRequiredBody(r *http.Request, allowPlainText bool) error {
 	if charset, ok := params["charset"]; ok && strings.ToLower(charset) != "utf-8" {
 		return errors.BadRequest("request's content type charset must be 'utf-8'")
 	}
-	lr := &io.LimitedReader{R: r.Body, N: maxRequestSize + 1}
-	normalized := norm.NFC.Reader(lr)
-	r.Body = io.NopCloser(&overLimitReader{
-		r:  normalized,
-		lr: lr,
-	})
-	return nil
-}
-
-type overLimitReader struct {
-	r  io.Reader
-	lr *io.LimitedReader
-}
-
-func (o *overLimitReader) Read(p []byte) (int, error) {
-	n, err := o.r.Read(p)
-	if o.lr != nil && o.lr.N <= 0 {
-		return n, errors.New("request body too large")
+	b := http.MaxBytesReader(w, r.Body, maxRequestSize)
+	r.Body = struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: norm.NFC.Reader(b),
+		Closer: b,
 	}
-	return n, err
+	return nil
 }
 
 // writeSessionCookie writes a session cookie on w. If one already exists,

--- a/cmd/apis_server_test.go
+++ b/cmd/apis_server_test.go
@@ -420,7 +420,7 @@ func TestValidateRequiredBody(t *testing.T) {
 			t.Fatalf("expected error, got nil")
 		}
 		if _, ok := err.(*http.MaxBytesError); !ok {
-			t.Fatalf("expected http.MaxBytesError error, got %t", err)
+			t.Fatalf("expected http.MaxBytesError error, got %T", err)
 		}
 		if len(body) > maxRequestSize {
 			t.Fatalf("expected at most %d bytes, got %d", maxRequestSize, len(body))

--- a/cmd/apis_server_test.go
+++ b/cmd/apis_server_test.go
@@ -290,8 +290,9 @@ func TestValidateRequiredBody(t *testing.T) {
 
 	t.Run("fails when body is missing", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(req, false)
+		err := validateRequiredBody(w, req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -302,8 +303,9 @@ func TestValidateRequiredBody(t *testing.T) {
 
 	t.Run("fails when content type is missing", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
+		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(req, false)
+		err := validateRequiredBody(w, req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -315,8 +317,9 @@ func TestValidateRequiredBody(t *testing.T) {
 	t.Run("fails when content type is not json", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
 		req.Header.Set("Content-Type", "text/plain")
+		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(req, false)
+		err := validateRequiredBody(w, req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -328,8 +331,9 @@ func TestValidateRequiredBody(t *testing.T) {
 	t.Run("fails when content type is not json or plain/text", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
 		req.Header.Set("Content-Type", "application/xml")
+		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(req, true)
+		err := validateRequiredBody(w, req, true)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -341,8 +345,9 @@ func TestValidateRequiredBody(t *testing.T) {
 	t.Run("fails when content type has unsupported parameters", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
 		req.Header.Set("Content-Type", "application/json; charset=utf-8; version=1")
+		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(req, false)
+		err := validateRequiredBody(w, req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -354,8 +359,9 @@ func TestValidateRequiredBody(t *testing.T) {
 	t.Run("fails when charset is not utf8", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
 		req.Header.Set("Content-Type", "application/json; charset=iso-8859-1")
+		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(req, false)
+		err := validateRequiredBody(w, req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -368,8 +374,9 @@ func TestValidateRequiredBody(t *testing.T) {
 		const payload = `{"ok":true}`
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload))
 		req.Header.Set("Content-Type", "Application/Json; Charset=UTF-8")
+		w := httptest.NewRecorder()
 
-		if err := validateRequiredBody(req, false); err != nil {
+		if err := validateRequiredBody(w, req, false); err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 		body, err := io.ReadAll(req.Body)
@@ -385,8 +392,9 @@ func TestValidateRequiredBody(t *testing.T) {
 		const payload = "{\"text\":\"Cafe\u0301\"}"
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload))
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		w := httptest.NewRecorder()
 
-		if err := validateRequiredBody(req, false); err != nil {
+		if err := validateRequiredBody(w, req, false); err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 		body, err := io.ReadAll(req.Body)
@@ -402,19 +410,20 @@ func TestValidateRequiredBody(t *testing.T) {
 		oversized := bytes.Repeat([]byte{'a'}, maxRequestSize+1)
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(oversized))
 		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
 
-		if err := validateRequiredBody(req, false); err != nil {
+		if err := validateRequiredBody(w, req, false); err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 		body, err := io.ReadAll(req.Body)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
-		if err.Error() != "request body too large" {
-			t.Fatalf("expected request body too large, got %q", err.Error())
+		if _, ok := err.(*http.MaxBytesError); !ok {
+			t.Fatalf("expected http.MaxBytesError error, got %t", err)
 		}
-		if len(body) != maxRequestSize {
-			t.Fatalf("expected to read %d bytes, got %d", maxRequestSize, len(body))
+		if len(body) > maxRequestSize {
+			t.Fatalf("expected at most %d bytes, got %d", maxRequestSize, len(body))
 		}
 	})
 

--- a/cmd/connection.go
+++ b/cmd/connection.go
@@ -69,8 +69,8 @@ func (connection connection) AbsolutePath(_ http.ResponseWriter, r *http.Request
 }
 
 // CreatePipeline creates a pipeline.
-func (connection connection) CreatePipeline(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (connection connection) CreatePipeline(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace{connection.apisServer}.workspace(r)
@@ -147,8 +147,8 @@ func (connection connection) DeleteEventWriteKey(_ http.ResponseWriter, r *http.
 }
 
 // ExecQuery executes a query on a database connection.
-func (connection connection) ExecQuery(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (connection connection) ExecQuery(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	c, err := connection.id(r)
@@ -322,8 +322,8 @@ func (connection connection) PipelineTypes(_ http.ResponseWriter, r *http.Reques
 }
 
 // PreviewSendEvent previews sending an event.
-func (connection connection) PreviewSendEvent(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (connection connection) PreviewSendEvent(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	c, err := connection.id(r)
@@ -350,7 +350,7 @@ func (connection connection) PreviewSendEvent(_ http.ResponseWriter, r *http.Req
 // ServeUI serves the user interface for a connection.
 func (connection connection) ServeUI(w http.ResponseWriter, r *http.Request) (any, error) {
 	if r.Method != http.MethodGet {
-		if err := validateRequiredBody(r, false); err != nil {
+		if err := validateRequiredBody(w, r, false); err != nil {
 			return nil, err
 		}
 	}
@@ -459,8 +459,8 @@ func (connection connection) UnlinkConnection(_ http.ResponseWriter, r *http.Req
 }
 
 // Update updates a connection.
-func (connection connection) Update(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (connection connection) Update(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	c, err := connection.id(r)

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -26,8 +26,8 @@ type organization struct {
 // If the ability to add new members without requiring email invitation has not
 // been enabled, it returns an errors.UnprocessableError error with code
 // EmailInvitationRequired.
-func (organization organization) AddMember(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (organization organization) AddMember(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	org, _, _, err := organization.authenticateAdminRequest(r)
@@ -87,8 +87,8 @@ func (organization organization) AccessKeys(_ http.ResponseWriter, r *http.Reque
 }
 
 // CreateAccessKey creates a new access key for an organization.
-func (organization organization) CreateAccessKey(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (organization organization) CreateAccessKey(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	org, _, _, err := organization.authenticateAdminRequest(r)
@@ -128,8 +128,8 @@ func (organization organization) CreateAccessKey(_ http.ResponseWriter, r *http.
 }
 
 // CreateWorkspace creates a workspace for the organization.
-func (organization organization) CreateWorkspace(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (organization organization) CreateWorkspace(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	org, ws, err := organization.authenticateRequest(r)
@@ -214,8 +214,8 @@ func (organization organization) DeleteMember(_ http.ResponseWriter, r *http.Req
 }
 
 // InviteMember sends an invitation email.
-func (organization organization) InviteMember(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (organization organization) InviteMember(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	org, _, memberID, err := organization.authenticateAdminRequest(r)
@@ -258,8 +258,8 @@ func (organization organization) Members(_ http.ResponseWriter, r *http.Request)
 }
 
 // TestWorkspaceCreation tests a workspace creation.
-func (organization organization) TestWorkspaceCreation(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (organization organization) TestWorkspaceCreation(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	org, ws, err := organization.authenticateRequest(r)
@@ -284,8 +284,8 @@ func (organization organization) TestWorkspaceCreation(_ http.ResponseWriter, r 
 }
 
 // UpdateAccessKey updates the name of an access key for an organization.
-func (organization organization) UpdateAccessKey(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (organization organization) UpdateAccessKey(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	org, _, _, err := organization.authenticateAdminRequest(r)
@@ -308,8 +308,8 @@ func (organization organization) UpdateAccessKey(_ http.ResponseWriter, r *http.
 }
 
 // UpdateMember updates the currently logged-in member of the organization.
-func (organization organization) UpdateMember(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (organization organization) UpdateMember(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	org, _, memberID, err := organization.authenticateAdminRequest(r)
@@ -349,11 +349,11 @@ func (organization organization) UpdateMember(_ http.ResponseWriter, r *http.Req
 }
 
 // Update updates the name of the organization with the given identifier.
-func (organization organization) Update(_ http.ResponseWriter, r *http.Request) (any, error) {
+func (organization organization) Update(w http.ResponseWriter, r *http.Request) (any, error) {
 	if err := organization.authenticateOrganizationsRequest(r); err != nil {
 		return nil, err
 	}
-	if err := validateRequiredBody(r, false); err != nil {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	id, ok := parseOrganizationUUID(r.PathValue("id"))

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -30,8 +30,8 @@ func (pipeline pipeline) Delete(_ http.ResponseWriter, r *http.Request) (any, er
 }
 
 // Run runs a pipeline.
-func (pipeline pipeline) Run(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (pipeline pipeline) Run(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	p, err := pipeline.id(r)
@@ -54,7 +54,7 @@ func (pipeline pipeline) Run(_ http.ResponseWriter, r *http.Request) (any, error
 
 // ServeUI serves the UI of a pipeline.
 func (pipeline pipeline) ServeUI(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	_, ws, _, err := pipeline.authenticateAdminRequest(r)
@@ -84,8 +84,8 @@ func (pipeline pipeline) ServeUI(w http.ResponseWriter, r *http.Request) (any, e
 }
 
 // SetSchedulePeriod sets the schedule period of a pipeline.
-func (pipeline pipeline) SetSchedulePeriod(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (pipeline pipeline) SetSchedulePeriod(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	p, err := pipeline.id(r)
@@ -104,8 +104,8 @@ func (pipeline pipeline) SetSchedulePeriod(_ http.ResponseWriter, r *http.Reques
 }
 
 // SetStatus sets the status of a pipeline.
-func (pipeline pipeline) SetStatus(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (pipeline pipeline) SetStatus(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	p, err := pipeline.id(r)
@@ -124,8 +124,8 @@ func (pipeline pipeline) SetStatus(_ http.ResponseWriter, r *http.Request) (any,
 }
 
 // Update updates a pipeline.
-func (pipeline pipeline) Update(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (pipeline pipeline) Update(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	p, err := pipeline.id(r)

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -23,8 +23,8 @@ type workspace struct {
 }
 
 // AlterProfileSchema alters the profile schema of a workspace.
-func (workspace workspace) AlterProfileSchema(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (workspace workspace) AlterProfileSchema(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -86,8 +86,8 @@ func (workspace workspace) Connections(_ http.ResponseWriter, r *http.Request) (
 }
 
 // CreateConnection creates a connection for a workspace.
-func (workspace workspace) CreateConnection(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (workspace workspace) CreateConnection(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -114,8 +114,8 @@ func (workspace workspace) CreateConnection(_ http.ResponseWriter, r *http.Reque
 
 // CreateEventListener creates an event listener for a workspace that listens to
 // events.
-func (workspace workspace) CreateEventListener(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (workspace workspace) CreateEventListener(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -280,7 +280,7 @@ func (workspace workspace) ProfilePropertiesSuitableAsIdentifiers(_ http.Respons
 // IngestEvents ingests a batch of events.
 func (workspace workspace) IngestEvents(w http.ResponseWriter, r *http.Request) (any, error) {
 	// Unlike other endpoints, it allows "text/plain" as a content type.
-	if err := validateRequiredBody(r, true); err != nil {
+	if err := validateRequiredBody(w, r, true); err != nil {
 		return nil, err
 	}
 	// Removes the headers that were set earlier, as ServeEvents handles the response fully.
@@ -676,8 +676,8 @@ func (workspace workspace) PipelineRuns(_ http.ResponseWriter, r *http.Request) 
 // PreviewAlterProfileSchema provides a preview of an alter profile schema
 // operation by returning the queries that would be executed on the warehouse to
 // perform a given alter schema.
-func (workspace workspace) PreviewAlterProfileSchema(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (workspace workspace) PreviewAlterProfileSchema(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -715,7 +715,7 @@ func (workspace workspace) RepairWarehouse(_ http.ResponseWriter, r *http.Reques
 
 // ServeUI serves the user interface for a connector.
 func (workspace workspace) ServeUI(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	_, ws, _, err := workspace.authenticateAdminRequest(r)
@@ -767,8 +767,8 @@ func (workspace workspace) StartIdentityResolution(_ http.ResponseWriter, r *htt
 }
 
 // TestWarehouseUpdate tests a warehouse update.
-func (workspace workspace) TestWarehouseUpdate(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (workspace workspace) TestWarehouseUpdate(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -805,8 +805,8 @@ func (workspace workspace) Attributes(_ http.ResponseWriter, r *http.Request) (a
 }
 
 // Update updates the name and the displayed properties of a workspace.
-func (workspace workspace) Update(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (workspace workspace) Update(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -827,8 +827,8 @@ func (workspace workspace) Update(_ http.ResponseWriter, r *http.Request) (any, 
 
 // UpdateIdentityResolutionSettings updates the identity resolution settings of
 // the workspace.
-func (workspace workspace) UpdateIdentityResolutionSettings(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (workspace workspace) UpdateIdentityResolutionSettings(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -848,8 +848,8 @@ func (workspace workspace) UpdateIdentityResolutionSettings(_ http.ResponseWrite
 }
 
 // UpdateWarehouse updates the warehouse of a workspace.
-func (workspace workspace) UpdateWarehouse(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (workspace workspace) UpdateWarehouse(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -874,8 +874,8 @@ func (workspace workspace) UpdateWarehouse(_ http.ResponseWriter, r *http.Reques
 }
 
 // UpdateWarehouseMode updates the mode of the data warehouse for a workspace.
-func (workspace workspace) UpdateWarehouseMode(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(r, false); err != nil {
+func (workspace workspace) UpdateWarehouseMode(w http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(w, r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)


### PR DESCRIPTION
```
cmd: simplify `validateRequiredBody` using `http.MaxBytesReader`

Previously, validateRequiredBody enforced the request body size limit
using io.LimitedReader and a custom reader type. Using
http.MaxBytesReader is more appropriate because it provides the
standard net/http behavior when the configured limit is exceeded.

Additionally, the previous implementation wrapped the request body with
io.NopCloser, causing Close to become a no-op instead of closing the
underlying request body.
```