### PR TITLE
cmd: fail login when multiple organizations exist

### DIFF
--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -376,7 +376,7 @@ func (s *apisServer) login(w http.ResponseWriter, r *http.Request) (any, error) 
 		return nil, errors.New("there are no organizations")
 	}
 	if len(organizations) > 1 {
-		return nil, errors.New("there are more than one organizations")
+		return nil, errors.New("there is more than one organization")
 	}
 	org := organizations[0]
 	memberID, err := org.AuthenticateMember(r.Context(), body.Email, body.Password)

--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -375,6 +375,9 @@ func (s *apisServer) login(w http.ResponseWriter, r *http.Request) (any, error) 
 	if len(organizations) == 0 {
 		return nil, errors.New("there are no organizations")
 	}
+	if len(organizations) > 1 {
+		return nil, errors.New("there are more than one organizations")
+	}
 	org := organizations[0]
 	memberID, err := org.AuthenticateMember(r.Context(), body.Email, body.Password)
 	if err != nil {

--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -371,7 +371,7 @@ func (s *apisServer) login(w http.ResponseWriter, r *http.Request) (any, error) 
 	}
 
 	// Retrieve the organization and the member.
-	organizations, _ := s.core.Organizations(core.SortByName, 0, 1)
+	organizations, _ := s.core.Organizations(core.SortByName, 0, 2)
 	if len(organizations) == 0 {
 		return nil, errors.New("there are no organizations")
 	}


### PR DESCRIPTION
```
cmd: fail login when multiple organizations exist

The login flow assumes that exactly one organization exists.

Instead of looking up the member in the first organization sorted
alphabetically, fail with an internal error when multiple organizations
are present.
```