### PR TITLE
core: allow members without a name

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -399,7 +399,7 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 
 // AcceptInvitation accepts the invitation with the given invitation token. It
 // sets the member's name and password and removes its token. name's length must
-// be in range [1, 60]. password's length must be at least 8 character long.
+// be in range [0, 45]. password's length must be at least 8 character long.
 //
 // If an invitation with the given token does not exist, it returns a
 // NotFoundError error. If the token is expired it returns an

--- a/core/organization.go
+++ b/core/organization.go
@@ -70,7 +70,7 @@ type Avatar struct {
 
 // MemberToSet represents a member to update with the UpdateMember method.
 type MemberToSet struct {
-	Name     string  `json:"name"`     // Name, in range [1, 60]
+	Name     string  `json:"name"`     // Name, in range [0, 45]
 	Email    string  `json:"email"`    // Email, in range [4,120] and must match `^[\w_\.\+\-\=\?\^\#]+\@(?:[a-zA-Z0-9\-]+\.)+\w+$`
 	Password string  `json:"password"` // Password, at least 8 characters long
 	Avatar   *Avatar `json:"avatar"`
@@ -1077,7 +1077,7 @@ func validateMemberEmail(email string) error {
 // if the member is not valid.
 func validateMemberToSet(member MemberToSet, validateName bool, validateEmail bool, validatePassword bool) error {
 	// Validate name.
-	if validateName {
+	if validateName && member.Name != "" {
 		if err := util.ValidateStringField("name", member.Name, 45); err != nil {
 			return err
 		}


### PR DESCRIPTION
```
core: allow members without a name

Make member names optional at the API level while preserving the
existing maximum length validation.
```