### PR TITLE
core: prevent concurrent runs for the same pipeline

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ func Main(assets fs.FS) {
 	var configStore string
 	var initDBIfEmpty bool
 	var initDockerMember bool
+	var upgradeDB bool
 	flag.BoolVar(&help, "help", false, "print the help for krenalis and exit")
 	flag.StringVar(&configStore, "config-store", "env:",
 		"configuration source: 'env:' to read KRENALIS_* from the environment, or 'aws:<region>:<prefix>' to read from AWS Parameter Store (default: 'env:')")
@@ -45,6 +46,7 @@ func Main(assets fs.FS) {
 	flag.BoolVar(&initDockerMember, "init-docker-member", false,
 		"when initializing the PostgreSQL database, also initialize the Docker member;"+
 			" this flag is primarily intended for automated scenarios involving Docker and testing purposes")
+	flag.BoolVar(&upgradeDB, "upgrade-db", false, "upgrade Krenalis's PostgreSQL database")
 	flag.Parse()
 	if help {
 		flag.Usage()
@@ -70,7 +72,11 @@ func Main(assets fs.FS) {
 		flag.Usage()
 		fatal(1, "the -init-docker-member flag can be provided only when the -init-db-if-empty flag is provided")
 	}
-	if !devMode && assets != nil {
+	if upgradeDB && (initDBIfEmpty || initDockerMember) {
+		flag.Usage()
+		fatal(1, "the -upgrade-db flag cannot be combined with -init-db-if-empty or -init-docker-member")
+	}
+	if !upgradeDB && !devMode && assets != nil {
 		assets, _ = fs.Sub(assets, "admin/assets")
 		_, err := fs.Stat(assets, "index.html.br")
 		if err != nil {
@@ -90,6 +96,13 @@ func Main(assets fs.FS) {
 	conf, err := loadConfig(ctx, configStore)
 	if err != nil {
 		fatal(1, err.Error())
+	}
+	if upgradeDB {
+		err = core.UpgradeDB(ctx, &core.Config{DB: conf.DB})
+		if err != nil {
+			fatal(1, err.Error())
+		}
+		return
 	}
 
 	// Unset the Krenalis environment variables, except for those intended for

--- a/core/core.go
+++ b/core/core.go
@@ -397,6 +397,34 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 	return core, nil
 }
 
+// UpgradeDB upgrades Krenalis's PostgreSQL database.
+func UpgradeDB(ctx context.Context, conf *Config) error {
+	db, err := dbpkg.Open(&dbpkg.Options{
+		Host:           conf.DB.Host,
+		Port:           conf.DB.Port,
+		Username:       conf.DB.Username,
+		Password:       conf.DB.Password,
+		Database:       conf.DB.Database,
+		Schema:         conf.DB.Schema,
+		MaxConnections: max(2, conf.DB.MaxConnections),
+	})
+	if err != nil {
+		return fmt.Errorf("cannot connect to PostgreSQL: %s", err)
+	}
+	defer db.Close()
+
+	pingCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	if err := db.Ping(pingCtx); err != nil {
+		return fmt.Errorf("cannot connect to PostgreSQL: %s", err)
+	}
+
+	if err := initdb.Upgrade(ctx, db); err != nil {
+		return fmt.Errorf("cannot upgrade PostgreSQL database: %s", err)
+	}
+	return nil
+}
+
 // AcceptInvitation accepts the invitation with the given invitation token. It
 // sets the member's name and password and removes its token. name's length must
 // be in range [0, 45]. password's length must be at least 8 character long.

--- a/core/internal/initdb/schema.sql
+++ b/core/internal/initdb/schema.sql
@@ -186,6 +186,10 @@ CREATE INDEX pipelines_runs_function_idx
     ON pipelines_runs (function)
     WHERE function != '' AND end_time IS NOT NULL;
 
+CREATE UNIQUE INDEX pipelines_one_active_run_idx
+    ON pipelines_runs (pipeline)
+    WHERE end_time IS NULL;
+
 CREATE TABLE pipelines_errors (
     pipeline varchar(12) NOT NULL REFERENCES pipelines ON DELETE CASCADE,
     timeslot integer NOT NULL,

--- a/core/internal/initdb/upgrade.go
+++ b/core/internal/initdb/upgrade.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by an Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package initdb
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/krenalis/krenalis/core/internal/db"
+)
+
+const oneActivePipelineRunIndex = "pipelines_one_active_run_idx"
+
+// Upgrade applies idempotent updates to an existing Krenalis PostgreSQL
+// database.
+func Upgrade(ctx context.Context, database *db.DB) error {
+	initialized, err := database.QueryExists(ctx, `
+		SELECT FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = current_schema()
+			AND c.relname = 'pipelines_runs'
+			AND c.relkind = 'r'`)
+	if err != nil {
+		return err
+	}
+	if !initialized {
+		return fmt.Errorf("Krenalis's PostgreSQL database has not been initialized")
+	}
+
+	indexExists, err := database.QueryExists(ctx, `
+		SELECT FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = current_schema()
+			AND c.relname = $1
+			AND c.relkind = 'i'`, oneActivePipelineRunIndex)
+	if err != nil {
+		return err
+	}
+	if indexExists {
+		slog.Info("PostgreSQL database is already up to date")
+		return nil
+	}
+
+	duplicateRuns, err := database.QueryExists(ctx, `
+		SELECT FROM pipelines_runs
+		WHERE end_time IS NULL
+		GROUP BY pipeline
+		HAVING COUNT(*) > 1`)
+	if err != nil {
+		return err
+	}
+	if duplicateRuns {
+		return fmt.Errorf("cannot create %s: multiple active runs exist for the same pipeline", oneActivePipelineRunIndex)
+	}
+
+	_, err = database.Exec(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS `+oneActivePipelineRunIndex+`
+		ON pipelines_runs (pipeline)
+		WHERE end_time IS NULL`)
+	if db.IsUniqueViolation(err) {
+		return fmt.Errorf("cannot create %s: multiple active runs exist for the same pipeline", oneActivePipelineRunIndex)
+	}
+	if err != nil {
+		return err
+	}
+	slog.Info("PostgreSQL database upgraded successfully")
+	return nil
+}

--- a/core/internal/initdb/upgrade_test.go
+++ b/core/internal/initdb/upgrade_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by an Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package initdb
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krenalis/krenalis/core/internal/db"
+	"github.com/krenalis/krenalis/test/testimages"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func TestUpgradeAddsOneActivePipelineRunIndex(t *testing.T) {
+	const (
+		databaseName = "krenalis"
+		user         = "krenalis"
+		password     = "krenalis"
+	)
+
+	ctx := t.Context()
+	container, err := postgres.Run(ctx,
+		testimages.PostgreSQL,
+		postgres.WithDatabase(databaseName),
+		postgres.WithUsername(user),
+		postgres.WithPassword(password),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Error(err)
+		}
+	})
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := container.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.Open(&db.Options{
+		Host:     host,
+		Port:     int(port.Num()),
+		Username: user,
+		Password: password,
+		Database: databaseName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(database.Close)
+
+	_, err = database.Exec(ctx, `CREATE TABLE pipelines_runs (
+		id text PRIMARY KEY,
+		pipeline text NOT NULL,
+		end_time timestamp
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Upgrade(ctx, database); err != nil {
+		t.Fatal(err)
+	}
+	if err := Upgrade(ctx, database); err != nil {
+		t.Fatalf("second upgrade failed: %s", err)
+	}
+
+	_, err = database.Exec(ctx, `INSERT INTO pipelines_runs (id, pipeline) VALUES ('run-1', 'pipeline-1')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = database.Exec(ctx, `INSERT INTO pipelines_runs (id, pipeline, end_time) VALUES ('run-ended', 'pipeline-1', now())`)
+	if err != nil {
+		t.Fatalf("cannot insert completed run: %s", err)
+	}
+	_, err = database.Exec(ctx, `INSERT INTO pipelines_runs (id, pipeline) VALUES ('run-2', 'pipeline-1')`)
+	if !db.IsUniqueViolation(err) || db.ErrConstraintName(err) != oneActivePipelineRunIndex {
+		t.Fatalf("expected violation of %s, got %v", oneActivePipelineRunIndex, err)
+	}
+
+	_, err = database.Exec(ctx, `DROP INDEX `+oneActivePipelineRunIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = database.Exec(ctx, `INSERT INTO pipelines_runs (id, pipeline) VALUES ('run-2', 'pipeline-1')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Upgrade(ctx, database)
+	if err == nil || !strings.Contains(err.Error(), "multiple active runs exist") {
+		t.Fatalf("expected duplicate active runs error, got %v", err)
+	}
+}

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -926,9 +926,14 @@ func (this *Pipeline) createRun(ctx context.Context, incremental *bool) (string,
 			_, err = tx.Exec(ctx, "INSERT INTO pipelines_runs (id, pipeline, function, cursor, incremental, start_time, ping_time)\n"+
 				"VALUES ($1, $2, $3, $4, $5, $6, $6)", n.ID, n.Pipeline, function, n.Cursor, n.Incremental, n.StartTime)
 			if err != nil {
-				if db.IsForeignKeyViolation(err) {
+				switch {
+				case db.IsForeignKeyViolation(err):
 					if db.ErrConstraintName(err) == "pipelines_runs_pipeline_fkey" {
 						err = errors.NotFound("pipeline %s does not exit", n.Pipeline)
+					}
+				case db.IsUniqueViolation(err):
+					if db.ErrConstraintName(err) == "pipelines_one_active_run_idx" {
+						err = errors.Unprocessable(RunInProgress, "pipeline %s is already in progress", this.pipeline.ID)
 					}
 				}
 				return nil, err

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -890,17 +890,11 @@ func (this *Pipeline) createRun(ctx context.Context, incremental *bool) (string,
 		n.ID = generateID[any](nil)
 		err := this.core.state.Transaction(ctx, func(tx *db.Tx) (any, error) {
 			var function string
-			var enabled, inc, executing bool
+			var enabled, inc bool
 			var cursor time.Time
-			// Verify that a run can be created (the pipeline exists, is enabled,
-			// and has no run in progress) and load the settings needed to
-			// initialize it.
-			err := tx.QueryRow(ctx, "SELECT p.enabled, p.transformation_id, p.incremental, p.cursor, e.id IS NOT NULL AND e.end_time IS NULL\n"+
-				"FROM pipelines AS p\n"+
-				"LEFT JOIN pipelines_runs AS e ON p.id = e.pipeline\n"+
-				"WHERE p.id = $1\n"+
-				"ORDER BY e.id DESC\n"+
-				"LIMIT 1", n.Pipeline).Scan(&enabled, &function, &inc, &cursor, &executing)
+			// Verify that the pipeline is enabled and load the settings needed to initialize it.
+			err := tx.QueryRow(ctx, "SELECT enabled, transformation_id, incremental, cursor FROM pipelines WHERE id = $1",
+				n.Pipeline).Scan(&enabled, &function, &inc, &cursor)
 			if err != nil {
 				if err == sql.ErrNoRows {
 					return nil, errors.NotFound("pipeline %s does not exist", n.Pipeline)
@@ -909,9 +903,6 @@ func (this *Pipeline) createRun(ctx context.Context, incremental *bool) (string,
 			}
 			if !enabled {
 				return nil, errors.Unprocessable(PipelineDisabled, "pipeline %s is disabled", this.pipeline.ID)
-			}
-			if executing {
-				return nil, errors.Unprocessable(RunInProgress, "pipeline %s is already in progress", this.pipeline.ID)
 			}
 			if incremental == nil {
 				n.Incremental = inc


### PR DESCRIPTION
```
core: prevent concurrent runs for the same pipeline

Ensure that each pipeline can have at most one active run.

The existing check was insufficient because concurrent transactions
could both observe no active run before inserting their respective runs.
```