### PR TITLE
core: fix discontinued function cleanup index

### DIFF
--- a/core/internal/initdb/schema.sql
+++ b/core/internal/initdb/schema.sql
@@ -184,7 +184,7 @@ CREATE TABLE pipelines_runs (
 
 CREATE INDEX pipelines_runs_function_idx
     ON pipelines_runs (function)
-    WHERE function != '' AND end_time IS NOT NULL;
+    WHERE function != '' AND end_time IS NULL;
 
 CREATE UNIQUE INDEX pipelines_one_active_run_idx
     ON pipelines_runs (pipeline)

--- a/core/internal/initdb/upgrade.go
+++ b/core/internal/initdb/upgrade.go
@@ -13,6 +13,7 @@ import (
 )
 
 const oneActivePipelineRunIndex = "pipelines_one_active_run_idx"
+const pipelineRunsFunctionIndex = "pipelines_runs_function_idx"
 
 // Upgrade applies idempotent updates to an existing Krenalis PostgreSQL
 // database.
@@ -44,21 +45,31 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 		return nil
 	}
 
-	duplicateRuns, err := database.QueryExists(ctx, `
-		SELECT FROM pipelines_runs
-		WHERE end_time IS NULL
-		GROUP BY pipeline
-		HAVING COUNT(*) > 1`)
-	if err != nil {
+	err = database.Transaction(ctx, func(tx *db.Tx) error {
+		duplicateRuns, err := tx.QueryExists(ctx, `
+			SELECT FROM pipelines_runs
+			WHERE end_time IS NULL
+			GROUP BY pipeline
+			HAVING COUNT(*) > 1`)
+		if err != nil {
+			return err
+		}
+		if duplicateRuns {
+			return fmt.Errorf("cannot create %s: multiple active runs exist for the same pipeline", oneActivePipelineRunIndex)
+		}
+		if _, err := tx.Exec(ctx, `DROP INDEX IF EXISTS `+pipelineRunsFunctionIndex); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `CREATE INDEX `+pipelineRunsFunctionIndex+`
+			ON pipelines_runs (function)
+			WHERE function != '' AND end_time IS NULL`); err != nil {
+			return err
+		}
+		_, err = tx.Exec(ctx, `CREATE UNIQUE INDEX `+oneActivePipelineRunIndex+`
+			ON pipelines_runs (pipeline)
+			WHERE end_time IS NULL`)
 		return err
-	}
-	if duplicateRuns {
-		return fmt.Errorf("cannot create %s: multiple active runs exist for the same pipeline", oneActivePipelineRunIndex)
-	}
-
-	_, err = database.Exec(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS `+oneActivePipelineRunIndex+`
-		ON pipelines_runs (pipeline)
-		WHERE end_time IS NULL`)
+	})
 	if db.IsUniqueViolation(err) {
 		return fmt.Errorf("cannot create %s: multiple active runs exist for the same pipeline", oneActivePipelineRunIndex)
 	}

--- a/core/internal/initdb/upgrade.go
+++ b/core/internal/initdb/upgrade.go
@@ -18,6 +18,7 @@ const pipelineRunsFunctionIndex = "pipelines_runs_function_idx"
 // Upgrade applies idempotent updates to an existing Krenalis PostgreSQL
 // database.
 func Upgrade(ctx context.Context, database *db.DB) error {
+
 	initialized, err := database.QueryExists(ctx, `
 		SELECT FROM pg_class c
 		JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -31,32 +32,22 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 		return fmt.Errorf("Krenalis's PostgreSQL database has not been initialized")
 	}
 
-	indexExists, err := database.QueryExists(ctx, `
-		SELECT FROM pg_class c
-		JOIN pg_namespace n ON n.oid = c.relnamespace
-		WHERE n.nspname = current_schema()
-			AND c.relname = $1
-			AND c.relkind = 'i'`, oneActivePipelineRunIndex)
-	if err != nil {
-		return err
-	}
-	if indexExists {
-		slog.Info("PostgreSQL database is already up to date")
-		return nil
-	}
-
 	err = database.Transaction(ctx, func(tx *db.Tx) error {
-		duplicateRuns, err := tx.QueryExists(ctx, `
-			SELECT FROM pipelines_runs
-			WHERE end_time IS NULL
-			GROUP BY pipeline
-			HAVING COUNT(*) > 1`)
-		if err != nil {
+		// core: prevent concurrent runs for the same pipeline.
+		// https://github.com/krenalis/krenalis/pull/2275
+		if _, err := tx.Exec(ctx, `DROP INDEX IF EXISTS `+oneActivePipelineRunIndex); err != nil {
 			return err
 		}
-		if duplicateRuns {
-			return fmt.Errorf("cannot create %s: multiple active runs exist for the same pipeline", oneActivePipelineRunIndex)
+		if _, err = tx.Exec(ctx, `CREATE UNIQUE INDEX `+oneActivePipelineRunIndex+`
+				ON pipelines_runs (pipeline)
+				WHERE end_time IS NULL`); err != nil {
+			if db.IsUniqueViolation(err) {
+				err = fmt.Errorf("cannot create %s: multiple active runs exist for the same pipeline; try it later", oneActivePipelineRunIndex)
+			}
+			return err
 		}
+		// core: fix pipeline run function index.
+		// https://github.com/krenalis/krenalis/pull/2276
 		if _, err := tx.Exec(ctx, `DROP INDEX IF EXISTS `+pipelineRunsFunctionIndex); err != nil {
 			return err
 		}
@@ -65,17 +56,13 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 			WHERE function != '' AND end_time IS NULL`); err != nil {
 			return err
 		}
-		_, err = tx.Exec(ctx, `CREATE UNIQUE INDEX `+oneActivePipelineRunIndex+`
-			ON pipelines_runs (pipeline)
-			WHERE end_time IS NULL`)
-		return err
+		return nil
 	})
-	if db.IsUniqueViolation(err) {
-		return fmt.Errorf("cannot create %s: multiple active runs exist for the same pipeline", oneActivePipelineRunIndex)
-	}
 	if err != nil {
 		return err
 	}
+
 	slog.Info("PostgreSQL database upgraded successfully")
+
 	return nil
 }

--- a/core/internal/initdb/upgrade_test.go
+++ b/core/internal/initdb/upgrade_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-func TestUpgradeAddsOneActivePipelineRunIndex(t *testing.T) {
+func TestUpgradePipelineRunIndexes(t *testing.T) {
 	const (
 		databaseName = "krenalis"
 		user         = "krenalis"
@@ -67,14 +67,32 @@ func TestUpgradeAddsOneActivePipelineRunIndex(t *testing.T) {
 	_, err = database.Exec(ctx, `CREATE TABLE pipelines_runs (
 		id text PRIMARY KEY,
 		pipeline text NOT NULL,
+		function text NOT NULL DEFAULT '',
 		end_time timestamp
-	)`)
+	);
+	CREATE INDEX pipelines_runs_function_idx
+		ON pipelines_runs (function)
+		WHERE function != '' AND end_time IS NOT NULL`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if err := Upgrade(ctx, database); err != nil {
 		t.Fatal(err)
+	}
+	var predicate string
+	err = database.QueryRow(ctx, `
+		SELECT pg_get_expr(i.indpred, i.indrelid)
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indexrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = current_schema() AND c.relname = $1`,
+		pipelineRunsFunctionIndex).Scan(&predicate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(predicate, "end_time IS NULL") || strings.Contains(predicate, "end_time IS NOT NULL") {
+		t.Fatalf("unexpected %s predicate: %s", pipelineRunsFunctionIndex, predicate)
 	}
 	if err := Upgrade(ctx, database); err != nil {
 		t.Fatalf("second upgrade failed: %s", err)


### PR DESCRIPTION
```
core: fix discontinued function cleanup index

The cleanup query targets active pipeline runs, but the index covered
completed ones. Change the predicate to match
pipelineCleaner.deleteDiscontinuedFunctions.
```