### PR TITLE
core: fix active pipeline run detection after Base58 migration

### DIFF
--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -895,12 +895,10 @@ func (this *Pipeline) createRun(ctx context.Context, incremental *bool) (string,
 			// Verify that a run can be created (the pipeline exists, is enabled,
 			// and has no run in progress) and load the settings needed to
 			// initialize it.
-			err := tx.QueryRow(ctx, "SELECT p.enabled, p.transformation_id, p.incremental, p.cursor, e.id IS NOT NULL AND e.end_time IS NULL\n"+
+			err := tx.QueryRow(ctx, "SELECT p.enabled, p.transformation_id, p.incremental, p.cursor, r.id IS NOT NULL\n"+
 				"FROM pipelines AS p\n"+
-				"LEFT JOIN pipelines_runs AS e ON p.id = e.pipeline\n"+
-				"WHERE p.id = $1\n"+
-				"ORDER BY e.id DESC\n"+
-				"LIMIT 1", n.Pipeline).Scan(&enabled, &function, &inc, &cursor, &executing)
+				"LEFT JOIN pipelines_runs AS r ON p.id = r.pipeline AND r.end_time IS NULL\n"+
+				"WHERE p.id = $1", n.Pipeline).Scan(&enabled, &function, &inc, &cursor, &executing)
 			if err != nil {
 				if err == sql.ErrNoRows {
 					return nil, errors.NotFound("pipeline %s does not exist", n.Pipeline)


### PR DESCRIPTION
```
core: fix active pipeline run detection after Base58 migration

Commit 6c9d1fc73 introduced random Base58 identifiers for pipeline runs,
but createRun still assumed that the highest ID corresponded to the most
recent run. As a result, it could select a completed run and miss an
active one. Detect active runs by checking for a NULL end time instead
of relying on ID ordering.

While at it, rename the pipelines_runs alias from "e" to "r" for
clarity.
```