### PR TITLE
core: fix scheduler executor restart after leadership loss

### DIFF
--- a/core/pipeline_scheduler.go
+++ b/core/pipeline_scheduler.go
@@ -96,11 +96,11 @@ func (ps *pipelineScheduler) onDeleteConnection(n state.DeleteConnection) {
 	if pipelines == nil {
 		return
 	}
-	go func() {
+	go func(e *pipelineExecutor) {
 		for _, pipeline := range pipelines {
-			ps.executor.RemovePipeline(pipeline)
+			e.RemovePipeline(pipeline)
 		}
-	}()
+	}(ps.executor)
 }
 
 // onDeleteOrganization is called when an organization is deleted from the
@@ -122,11 +122,11 @@ func (ps *pipelineScheduler) onDeleteOrganization(n state.DeleteOrganization) {
 	if pipelines == nil {
 		return
 	}
-	go func() {
+	go func(e *pipelineExecutor) {
 		for _, pipeline := range pipelines {
-			ps.executor.RemovePipeline(pipeline)
+			e.RemovePipeline(pipeline)
 		}
-	}()
+	}(ps.executor)
 }
 
 // onDeleteWorkspace is called when a workspace is deleted from the state.
@@ -145,11 +145,11 @@ func (ps *pipelineScheduler) onDeleteWorkspace(n state.DeleteWorkspace) {
 	if pipelines == nil {
 		return
 	}
-	go func() {
+	go func(e *pipelineExecutor) {
 		for _, pipeline := range pipelines {
-			ps.executor.RemovePipeline(pipeline)
+			e.RemovePipeline(pipeline)
 		}
-	}()
+	}(ps.executor)
 }
 
 // onDeletePipeline is called when a pipeline is deleted from the state.
@@ -157,16 +157,18 @@ func (ps *pipelineScheduler) onDeletePipeline(n state.DeletePipeline) {
 	if ps.executor == nil {
 		return
 	}
-	go func() {
-		ps.executor.RemovePipeline(n.ID)
-	}()
+	go func(e *pipelineExecutor) {
+		e.RemovePipeline(n.ID)
+	}(ps.executor)
 }
 
 // onElectLeader is called when a leader is elected.
 func (ps *pipelineScheduler) onElectLeader(n state.ElectLeader) {
 	if ps.executor != nil {
 		if !ps.core.state.IsLeader() {
-			go ps.executor.Close()
+			e := ps.executor
+			ps.executor = nil
+			go e.Close()
 		}
 		return
 	}


### PR DESCRIPTION
```
core: fix scheduler executor restart after leadership loss

Previously, the pipeline scheduler kept a reference to its executor
after a node lost leadership, so the same node could not create a new
executor if it became leader again.

This change clears the executor reference when leadership is lost. Since
the executor can now be nil after leadership changes, it also captures
the current executor before starting asynchronous removal operations.
```