### PR TITLE
core: remove obsolete state freeze in pipeline scheduler close

### DIFF
--- a/core/pipeline_scheduler.go
+++ b/core/pipeline_scheduler.go
@@ -61,8 +61,6 @@ func newPipelineScheduler(core *Core) *pipelineScheduler {
 // Close closes the pipeline scheduler closing the executors and interrupting
 // pipeline runs.
 func (ps *pipelineScheduler) Close() {
-	ps.core.state.Freeze()
-	ps.core.state.Unfreeze()
 	if ps.executor != nil {
 		ps.executor.Close()
 	}


### PR DESCRIPTION
```
core: remove obsolete state freeze in pipeline scheduler close

Commit 2adb638 (core/state: enforce listener call order and prevent
removal) removed the state listener removal logic, but left behind the
now-unused state freeze in pipelineScheduler.Close.

This commit removes that obsolete Freeze/Unfreeze pair.
```