### PR TITLE
core: prevent pipeline scheduler work after close

### DIFF
--- a/core/pipeline_scheduler.go
+++ b/core/pipeline_scheduler.go
@@ -35,9 +35,11 @@ func periodIndex(period int16) int8 {
 type pipelineScheduler struct {
 	core     *Core
 	executor *pipelineExecutor
-	ctx      context.Context    // context passes to the pipeline runs.
-	cancel   context.CancelFunc // function to cancel the pipeline runs.
-	wg       sync.WaitGroup     // waiting group that includes the schedulers and pipeline runs.
+	close    struct {
+		ctx    context.Context
+		cancel context.CancelFunc
+		sync.WaitGroup
+	}
 }
 
 // newPipelineScheduler returns a new pipeline scheduler.
@@ -45,7 +47,7 @@ func newPipelineScheduler(core *Core) *pipelineScheduler {
 	ps := &pipelineScheduler{
 		core: core,
 	}
-	ps.ctx, ps.cancel = context.WithCancel(context.Background())
+	ps.close.ctx, ps.close.cancel = context.WithCancel(context.Background())
 	core.state.Freeze()
 	core.state.AddListener(ps.onCreatePipeline)
 	core.state.AddListener(ps.onDeleteConnection)
@@ -64,8 +66,8 @@ func (ps *pipelineScheduler) Close() {
 	if ps.executor != nil {
 		ps.executor.Close()
 	}
-	ps.cancel()
-	ps.wg.Wait()
+	ps.close.cancel()
+	ps.close.Wait()
 }
 
 // onCreatePipeline is called when a pipeline is created.
@@ -173,7 +175,7 @@ func (ps *pipelineScheduler) onElectLeader(n state.ElectLeader) {
 	if !ps.core.state.IsLeader() {
 		return
 	}
-	ps.executor = newPipelineExecutor(ps.core, &ps.wg, ps.ctx)
+	ps.executor = newPipelineExecutor(ps.core, &ps.close.WaitGroup, ps.close.ctx)
 }
 
 // onSetPipelineSchedulePeriod is called when the schedule period of a pipeline

--- a/core/pipeline_scheduler.go
+++ b/core/pipeline_scheduler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/krenalis/krenalis/core/internal/state"
@@ -38,6 +39,7 @@ type pipelineScheduler struct {
 	close    struct {
 		ctx    context.Context
 		cancel context.CancelFunc
+		atomic.Bool
 		sync.WaitGroup
 	}
 }
@@ -62,10 +64,20 @@ func newPipelineScheduler(core *Core) *pipelineScheduler {
 
 // Close closes the pipeline scheduler closing the executors and interrupting
 // pipeline runs.
+// If ps is already closed, it does nothing and returns immediately.
 func (ps *pipelineScheduler) Close() {
-	if ps.executor != nil {
-		ps.executor.Close()
+	if ps.close.Swap(true) {
+		return
 	}
+	// Detach the executor before closing it so state notifications cannot use it.
+	ps.core.state.Freeze()
+	e := ps.executor
+	ps.executor = nil
+	ps.core.state.Unfreeze()
+	if e != nil {
+		e.Close()
+	}
+	// Cancel scheduled pipeline runs.
 	ps.close.cancel()
 	ps.close.Wait()
 }
@@ -164,6 +176,9 @@ func (ps *pipelineScheduler) onDeletePipeline(n state.DeletePipeline) {
 
 // onElectLeader is called when a leader is elected.
 func (ps *pipelineScheduler) onElectLeader(n state.ElectLeader) {
+	if ps.close.Load() {
+		return
+	}
 	if ps.executor != nil {
 		if !ps.core.state.IsLeader() {
 			e := ps.executor


### PR DESCRIPTION
```
core: prevent pipeline scheduler work after close

Previously, pipelineScheduler.Close read and closed the executor without
synchronizing with state notifications. This could race with
onElectLeader when it updated the executor, and could leave a closed
executor attached to the scheduler for later notification handlers to
use.

Make Close idempotent, detach the executor while the state is frozen,
and ignore leader election notifications after close so shutdown cannot
race with executor updates or recreate an executor.
```