### PR TITLE
Revert "test: temporarily bypass VCS stamping"

### DIFF
--- a/test/krenalistester/build_run_krenalis.go
+++ b/test/krenalistester/build_run_krenalis.go
@@ -62,7 +62,7 @@ func buildKrenalis(t *testing.T, repo, krenalisDir string) {
 
 	// Build Krenalis, putting the output into the krenalisDir, where it will be
 	// executed by the tests.
-	execCmd(t, tmpdir, "go", "build", "-buildvcs=false", "-o", filepath.Join(krenalisDir, krenalisExecFilename()))
+	execCmd(t, tmpdir, "go", "build", "-o", filepath.Join(krenalisDir, krenalisExecFilename()))
 
 }
 


### PR DESCRIPTION
```
test: revert "test: temporarily bypass VCS stamping"

This reverts commit 8a1d85c3925e8bdadb4b57cff036663beb4552a2.

Revert reason: the build failure was caused by an empty "/tmp/.git"
directory. Removing that directory fixed the issue, so the temporary
-buildvcs=false workaround is no longer needed.

Close #2280
```