### PR TITLE
core: prevent cleaner from ending the wrong pipeline run

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1297,7 +1297,7 @@ func (core *Core) tryStartPipelineRun(pipelineID string) {
 		}
 
 		// Mark the run as ended.
-		p.endRun(err)
+		p.endRun(run.ID, err)
 
 		// Stop pinging as it is no longer required.
 		stopPing()

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -964,15 +964,10 @@ func (this *Pipeline) database() *connections.Database {
 	return this.core.connections.Database(p.Connection())
 }
 
-// endRun marks a pipeline run as completed, setting the specified error if any.
-func (this *Pipeline) endRun(err error) {
+// endRun marks the given run as completed, setting err if non-nil.
+func (this *Pipeline) endRun(id string, err error) {
 
 	ctx := this.core.close.ctx
-
-	run, ok := this.pipeline.Run()
-	if !ok {
-		return
-	}
 
 	endTime := time.Now().UTC()
 
@@ -988,7 +983,7 @@ func (this *Pipeline) endRun(err error) {
 				errorMessage = "run has been canceled"
 			} else {
 				errorMessage = "an internal error has occurred"
-				slog.Error("core: cannot run pipeline", "pipeline", this.pipeline.ID, "run", run.ID, "error", err)
+				slog.Error("core: cannot run pipeline", "pipeline", this.pipeline.ID, "run", id, "error", err)
 			}
 		}
 		this.core.metrics.Failed(errorStep, this.pipeline.ID, 0, errorMessage)
@@ -998,7 +993,7 @@ func (this *Pipeline) endRun(err error) {
 	this.core.metrics.WaitStore()
 
 	n := state.EndPipelineRun{
-		ID:       run.ID,
+		ID:       id,
 		Pipeline: this.pipeline.ID,
 		Health:   state.Healthy,
 	}
@@ -1024,7 +1019,7 @@ func (this *Pipeline) endRun(err error) {
 					" failed_3 = e.failed_3 + s.failed_3, failed_4 = e.failed_4 + s.failed_4, failed_5 = e.failed_5 + s.failed_5,"+
 					" error = $4\n"+
 					"FROM s\n"+
-					"WHERE id = $1 AND end_time IS NULL", run.ID, this.pipeline.ID, endTime, errorMessage)
+					"WHERE id = $1 AND pipeline = $2 AND end_time IS NULL", id, this.pipeline.ID, endTime, errorMessage)
 			if err != nil {
 				return nil, err
 			}

--- a/core/pipeline_cleaner.go
+++ b/core/pipeline_cleaner.go
@@ -377,11 +377,11 @@ func (c *pipelineCleaner) terminateOrphanedRuns() {
 		case <-tick.C:
 		}
 		pingTime := time.Now().UTC().Add(-15 * time.Second)
-		err := c.core.db.QueryScan(ctx, "SELECT pipeline FROM pipelines_runs WHERE end_time IS NULL AND ping_time < $1",
+		err := c.core.db.QueryScan(ctx, "SELECT id, pipeline FROM pipelines_runs WHERE end_time IS NULL AND ping_time < $1",
 			pingTime, func(rows *db.Rows) error {
-				var pipelineID string
+				var id, pipelineID string
 				for rows.Next() {
-					if err := rows.Scan(&pipelineID); err != nil {
+					if err := rows.Scan(&id, &pipelineID); err != nil {
 						return err
 					}
 					pipeline, ok := c.core.state.Pipeline(pipelineID)
@@ -396,7 +396,7 @@ func (c *pipelineCleaner) terminateOrphanedRuns() {
 					}
 					connection := &Connection{core: c.core, store: store, connection: c2}
 					p := &Pipeline{core: c.core, pipeline: pipeline, connection: connection}
-					go p.endRun(pipelineErr)
+					go p.endRun(id, pipelineErr)
 				}
 				return nil
 			})


### PR DESCRIPTION
```
core: prevent cleaner from ending the wrong pipeline run

Previously, the pipeline cleaner could end a run that started after the
one it intended to end.

This could happen if the stale run completed naturally and a new run for
the same pipeline started before the cleaner goroutine looked up the
current run from the pipeline state.

This change passes the selected run ID to endRun, so the cleaner ends
that specific run instead of whichever run is current for the pipeline.

While here, also add the pipeline ID to the run metrics update
predicate. This is not strictly required because the run ID is already
unique, but it makes the intended ownership check explicit.
```