### PR TITLE
core: avoid duplicate orphaned run termination

### DIFF
--- a/core/pipeline_cleaner.go
+++ b/core/pipeline_cleaner.go
@@ -370,6 +370,11 @@ func (c *pipelineCleaner) terminateOrphanedRuns() {
 	pipelineErr := newPipelineError(metrics.ReceiveStep, errors.New("pipeline has been terminated because the node became unresponsive"))
 	ctx := c.close.ctx
 	tick := time.NewTicker(15 * time.Second)
+	var ending struct {
+		sync.Mutex
+		runs map[string]struct{}
+	}
+	ending.runs = map[string]struct{}{}
 	for {
 		select {
 		case <-ctx.Done():
@@ -379,10 +384,16 @@ func (c *pipelineCleaner) terminateOrphanedRuns() {
 		pingTime := time.Now().UTC().Add(-15 * time.Second)
 		err := c.core.db.QueryScan(ctx, "SELECT id, pipeline FROM pipelines_runs WHERE end_time IS NULL AND ping_time < $1",
 			pingTime, func(rows *db.Rows) error {
+				ending.Lock()
+				defer ending.Unlock()
 				var id, pipelineID string
 				for rows.Next() {
 					if err := rows.Scan(&id, &pipelineID); err != nil {
 						return err
+					}
+					// Don't start a second termination if one is already in progress.
+					if _, ok := ending.runs[id]; ok {
+						continue
 					}
 					pipeline, ok := c.core.state.Pipeline(pipelineID)
 					if !ok {
@@ -394,9 +405,15 @@ func (c *pipelineCleaner) terminateOrphanedRuns() {
 					if !ok {
 						continue
 					}
+					ending.runs[id] = struct{}{}
 					connection := &Connection{core: c.core, store: store, connection: c2}
 					p := &Pipeline{core: c.core, pipeline: pipeline, connection: connection}
-					go p.endRun(id, pipelineErr)
+					go func(id string) {
+						p.endRun(id, pipelineErr)
+						ending.Lock()
+						delete(ending.runs, id)
+						ending.Unlock()
+					}(id)
 				}
 				return nil
 			})


### PR DESCRIPTION
```
core: avoid duplicate orphaned run termination

Previously, the pipeline cleaner could start multiple goroutines to
terminate the same run.

This did not cause correctness issues because endRun is idempotent at
the database level, and it was unlikely to happen in practice. Still,
starting duplicate termination goroutines was unnecessary work and made
the cleaner behavior less explicit.
```