### PR TITLE
core: avoid terminating unassigned pipeline runs

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1195,9 +1195,10 @@ func (core *Core) tryStartPipelineRun(pipelineID string) {
 		// Attempt to acquire the run. If already acquired by another node, return early.
 		bo := backoff.New(200)
 		for bo.Next(ctx) {
+			pingTime := time.Now().UTC()
 			result, err := core.db.Exec(core.close.ctx,
-				"UPDATE pipelines_runs\nSET node = $1\nWHERE id = $2 AND node IS NULL",
-				core.state.ID(), run.ID)
+				"UPDATE pipelines_runs SET node = $1, ping_time = $2 WHERE id = $3 AND node IS NULL",
+				core.state.ID(), pingTime, run.ID)
 			if err != nil {
 				if ctx.Err() == nil {
 					slog.Error("core: cannot start pipeline run; retrying", "retry_after", bo.WaitTime(), "error", err)

--- a/core/pipeline_cleaner.go
+++ b/core/pipeline_cleaner.go
@@ -377,7 +377,7 @@ func (c *pipelineCleaner) terminateOrphanedRuns() {
 		case <-tick.C:
 		}
 		pingTime := time.Now().UTC().Add(-15 * time.Second)
-		err := c.core.db.QueryScan(ctx, "SELECT id, pipeline FROM pipelines_runs WHERE end_time IS NULL AND ping_time < $1",
+		err := c.core.db.QueryScan(ctx, "SELECT id, pipeline FROM pipelines_runs WHERE node IS NOT NULL AND end_time IS NULL AND ping_time < $1",
 			pingTime, func(rows *db.Rows) error {
 				var id, pipelineID string
 				for rows.Next() {


### PR DESCRIPTION
```
core: avoid terminating unassigned pipeline runs

Previously, the pipeline cleaner could terminate a pipeline run before
any node had acquired it.

This change makes orphaned-run cleanup consider only runs that have
already been assigned to a node. When a node acquires a run, it now
refreshes the run's ping time in the same database update, preventing
newly acquired runs from being immediately treated as stale.
```