### PR TITLE
core: avoid starting the wrong pipeline run

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1284,7 +1284,7 @@ func (core *Core) tryStartPipelineRun(run *state.PipelineRun) {
 		}
 
 		// Mark the run as ended.
-		p.endRun(run.ID, err)
+		p.endLiveRun(run.ID, err)
 
 		// Stop pinging as it is no longer required.
 		stopPing()

--- a/core/core.go
+++ b/core/core.go
@@ -385,12 +385,10 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 	core.state.AddListener(core.onUpdateWarehouse)
 	core.state.Unfreeze()
 
-	// Try to start pending pipeline runs.
-	for _, pipeline := range core.state.Pipelines() {
-		if run, ok := pipeline.Run(); ok {
-			if _, ok := run.Node(); !ok {
-				core.tryStartPipelineRun(pipeline.ID)
-			}
+	// Try to start live runs that have not started yet.
+	for _, run := range core.state.LiveRuns() {
+		if _, ok := run.Node(); !ok {
+			core.tryStartPipelineRun(run)
 		}
 	}
 
@@ -1151,7 +1149,9 @@ func (core *Core) mustBeOpen() {
 
 // onRunPipeline is called when a pipeline run starts.
 func (core *Core) onRunPipeline(n state.RunPipeline) {
-	core.tryStartPipelineRun(n.Pipeline)
+	p, _ := core.state.Pipeline(n.Pipeline)
+	run, _ := p.Run()
+	core.tryStartPipelineRun(run)
 }
 
 // pipelineError represents a pipeline error.
@@ -1168,29 +1168,15 @@ func (err pipelineError) Error() string {
 	return err.err.Error()
 }
 
-// tryStartPipelineRun attempts to start a pipeline run.
+// tryStartPipelineRun attempts to start the given pipeline run.
 // It returns immediately and spawns a new goroutine to handle the run.
-func (core *Core) tryStartPipelineRun(pipelineID string) {
+func (core *Core) tryStartPipelineRun(run *state.PipelineRun) {
 
 	core.close.Go(func() {
 
 		ctx := core.close.ctx
 
-		var pipeline *state.Pipeline
-		var run *state.PipelineRun
-
-		var ok bool
-		pipeline, ok = core.state.Pipeline(pipelineID)
-		if !ok {
-			return
-		}
-		run, ok = pipeline.Run()
-		if !ok {
-			return
-		}
-		if _, ok := run.Node(); ok {
-			return
-		}
+		pipeline := run.Pipeline()
 
 		// Attempt to acquire the run. If already acquired by another node, return early.
 		bo := backoff.New(200)

--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -619,7 +619,6 @@ func (state *State) createWorkspace(n notification) string {
 	ws := Workspace{
 		mu:                             &sync.Mutex{},
 		connections:                    map[string]*Connection{},
-		runs:                           map[string]*PipelineRun{},
 		ID:                             e.ID,
 		organization:                   organization,
 		Name:                           e.Name,
@@ -1065,16 +1064,14 @@ func (state *State) endPipelineRun(n notification) string {
 	if !decodeNotification(n, &e) {
 		return ""
 	}
-	p := state.pipelines[e.Pipeline]
-	ws := p.connection.workspace
-	ws.mu.Lock()
-	delete(ws.runs, e.ID)
-	ws.mu.Unlock()
-	state.replacePipeline(p.ID, func(p *Pipeline) {
+	state.mu.Lock()
+	delete(state.liveRuns, e.ID)
+	state.mu.Unlock()
+	p := state.replacePipeline(e.Pipeline, func(p *Pipeline) {
 		p.run = nil
 		p.Health = e.Health
 	})
-	return ws.organization.ID
+	return p.organization.ID
 }
 
 // LinkConnection is the event sent when two unlinked connections are linked.
@@ -1169,7 +1166,6 @@ func (state *State) runPipeline(n notification) string {
 		return ""
 	}
 	p := state.pipelines[e.Pipeline]
-	ws := p.connection.workspace
 	run := &PipelineRun{
 		mu:          &sync.Mutex{},
 		ID:          e.ID,
@@ -1178,14 +1174,14 @@ func (state *State) runPipeline(n notification) string {
 		Cursor:      e.Cursor,
 		StartTime:   e.StartTime,
 	}
-	ws.mu.Lock()
-	ws.runs[run.ID] = run
-	ws.mu.Unlock()
 	p.mu.Lock()
 	p.run = run
 	p.mu.Unlock()
+	state.mu.Lock()
+	state.liveRuns[run.ID] = run
+	state.mu.Unlock()
 	dispatchNotification(state, e)
-	return ws.organization.ID
+	return p.organization.ID
 }
 
 // SeeLeader is the event sent when the leader is seen.

--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -307,7 +307,6 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 				ws := &Workspace{
 					mu:          new(sync.Mutex),
 					connections: map[string]*Connection{},
-					runs:        map[string]*PipelineRun{},
 					accounts:    map[int]*Account{},
 				}
 				var settingsKey, mcpSettingsKey []byte
@@ -563,8 +562,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 				pipeline := state.pipelines[pipelineID]
 				run.pipeline = pipeline
 				pipeline.run = &run
-				ws := run.pipeline.connection.workspace
-				ws.runs[run.ID] = &run
+				state.liveRuns[run.ID] = &run
 			}
 			return nil
 		})

--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -546,7 +546,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 		return fmt.Errorf("cannot load pipelines: %s", err)
 	}
 
-	// Read pipeline runs in progress.
+	// Read live pipeline runs.
 	err = tx.QueryScan(ctx, "SELECT id, pipeline, cursor, incremental, start_time\n"+
 		"FROM pipelines_runs\nWHERE end_time IS NULL",
 		func(rows *db.Rows) error {

--- a/core/internal/state/state.go
+++ b/core/internal/state/state.go
@@ -64,6 +64,7 @@ type State struct {
 
 	mu               *sync.Mutex              // for the 'pipelines', ..., and 'workspaces' fields
 	pipelines        map[string]*Pipeline     // protected by mu
+	liveRuns         map[string]*PipelineRun  // live pipeline runs, i.e. runs that have not ended; protected by mu
 	connections      map[string]*Connection   // protected by mu
 	connectionsByKey map[string]*Connection   // protected by mu
 	accessKeyByHMAC  map[string]*AccessKey    // protected by mu
@@ -113,6 +114,7 @@ func New(ctx context.Context, db *db.DB, kms kms.Kms, credentials map[string]*OA
 		connections:      map[string]*Connection{},
 		connectionsByKey: map[string]*Connection{},
 		pipelines:        map[string]*Pipeline{},
+		liveRuns:         map[string]*PipelineRun{},
 		sendStats:        sendStats,
 	}
 
@@ -286,6 +288,31 @@ func (state *State) IsLeader() bool {
 	election := state.election
 	state.mu.Unlock()
 	return election.leader == state.id
+}
+
+// LiveRun returns the live pipeline run with the given id.
+// The boolean return value indicates whether the live run exists.
+func (state *State) LiveRun(id string) (*PipelineRun, bool) {
+	state.mu.Lock()
+	run, ok := state.liveRuns[id]
+	state.mu.Unlock()
+	return run, ok
+}
+
+// LiveRuns returns all the live pipeline runs.
+func (state *State) LiveRuns() []*PipelineRun {
+	state.mu.Lock()
+	runs := make([]*PipelineRun, len(state.liveRuns))
+	i := 0
+	for _, run := range state.liveRuns {
+		runs[i] = run
+		i++
+	}
+	state.mu.Unlock()
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].ID < runs[j].ID
+	})
+	return runs
 }
 
 // OAuthKey returns the key used to encrypt and decrypt OAuth keys.
@@ -615,7 +642,6 @@ type Workspace struct {
 		mcpSettingsKey *cipher.Key
 	}
 	connections                    map[string]*Connection
-	runs                           map[string]*PipelineRun // pipeline runs in progress.
 	ID                             string
 	organization                   *Organization
 	Name                           string
@@ -762,15 +788,6 @@ func (workspace *Workspace) PipelinesToPurge() []string {
 	pipelines := workspace.pipelinesToPurge
 	workspace.mu.Unlock()
 	return slices.Clone(pipelines)
-}
-
-// Run returns the pipeline run in the workspace with the given id.
-// The boolean return value indicates whether the run exists.
-func (workspace *Workspace) Run(id string) (*PipelineRun, bool) {
-	workspace.mu.Lock()
-	exe, ok := workspace.runs[id]
-	workspace.mu.Unlock()
-	return exe, ok
 }
 
 // WarehouseSettings returns the warehouse settings.

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -964,8 +964,8 @@ func (this *Pipeline) database() *connections.Database {
 	return this.core.connections.Database(p.Connection())
 }
 
-// endRun marks the given run as completed, setting err if non-nil.
-func (this *Pipeline) endRun(id string, err error) {
+// endLiveRun marks the given live run as completed, setting err if non-nil.
+func (this *Pipeline) endLiveRun(id string, err error) {
 
 	ctx := this.core.close.ctx
 

--- a/core/pipeline_cleaner.go
+++ b/core/pipeline_cleaner.go
@@ -409,7 +409,7 @@ func (c *pipelineCleaner) terminateOrphanedRuns() {
 					connection := &Connection{core: c.core, store: store, connection: c2}
 					p := &Pipeline{core: c.core, pipeline: pipeline, connection: connection}
 					go func(id string) {
-						p.endRun(id, pipelineErr)
+						p.endLiveRun(id, pipelineErr)
 						ending.Lock()
 						delete(ending.runs, id)
 						ending.Unlock()

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -1147,11 +1147,16 @@ func (this *Workspace) PipelineRun(ctx context.Context, id string) (*PipelineRun
 	if !IsValidID(id) {
 		return nil, errors.BadRequest("identifier %q is not a valid run identifier", id)
 	}
-	// Check whether the run is in progress.
-	if run, ok := this.workspace.Run(id); ok {
+	// Check whether the run is live.
+	if run, ok := this.core.state.LiveRun(id); ok {
+		pipeline := run.Pipeline()
+		ws := pipeline.Connection().Workspace()
+		if ws.ID != this.workspace.ID {
+			return nil, errors.NotFound("pipeline run %s does not exist", id)
+		}
 		return &PipelineRun{
 			ID:        run.ID,
-			Pipeline:  run.Pipeline().ID,
+			Pipeline:  pipeline.ID,
 			StartTime: run.StartTime,
 		}, nil
 	}


### PR DESCRIPTION
```
core: avoid starting the wrong pipeline run

Previously, a delayed pipeline startup goroutine could start the wrong 
run if a pipeline completed and another run for the same pipeline
started before the goroutine looked up the current pipeline run.

Start pipeline runs using the active run, now called the live run,
selected by the notification or startup scan, so the goroutine keeps
targeting the same run. To support this, track live runs in shared state
by run ID and rename the run completion helper to match that flow.
```