### PR TITLE
core: rename active pipeline run index to live

### DIFF
--- a/core/internal/initdb/schema.sql
+++ b/core/internal/initdb/schema.sql
@@ -189,7 +189,7 @@ CREATE INDEX pipelines_runs_function_idx
     ON pipelines_runs (function)
     WHERE function != '' AND end_time IS NULL;
 
-CREATE UNIQUE INDEX pipelines_one_active_run_idx
+CREATE UNIQUE INDEX pipelines_one_live_run_idx
     ON pipelines_runs (pipeline)
     WHERE end_time IS NULL;
 

--- a/core/internal/initdb/upgrade.go
+++ b/core/internal/initdb/upgrade.go
@@ -41,7 +41,7 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 		if _, err := tx.Exec(ctx, `DROP INDEX IF EXISTS `+oneActivePipelineRunIndex); err != nil {
 			return err
 		}
-		// core,core/internal/inidb: Rename active pipeline run index to live
+		// core: rename active pipeline run index to live
 		// https://github.com/krenalis/krenalis/pull/2308
 		if _, err := tx.Exec(ctx, `DROP INDEX IF EXISTS `+oneLivePipelineRunIndex); err != nil {
 			return err

--- a/core/internal/initdb/upgrade.go
+++ b/core/internal/initdb/upgrade.go
@@ -12,7 +12,10 @@ import (
 	"github.com/krenalis/krenalis/core/internal/db"
 )
 
-const oneActivePipelineRunIndex = "pipelines_one_active_run_idx"
+const (
+	oneActivePipelineRunIndex = "pipelines_one_active_run_idx"
+	oneLivePipelineRunIndex   = "pipelines_one_live_run_idx"
+)
 const pipelineRunsFunctionIndex = "pipelines_runs_function_idx"
 
 // Upgrade applies idempotent updates to an existing Krenalis PostgreSQL
@@ -38,11 +41,16 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 		if _, err := tx.Exec(ctx, `DROP INDEX IF EXISTS `+oneActivePipelineRunIndex); err != nil {
 			return err
 		}
-		if _, err = tx.Exec(ctx, `CREATE UNIQUE INDEX `+oneActivePipelineRunIndex+`
+		// core,core/internal/inidb: Rename active pipeline run index to live
+		// https://github.com/krenalis/krenalis/pull/2308
+		if _, err := tx.Exec(ctx, `DROP INDEX IF EXISTS `+oneLivePipelineRunIndex); err != nil {
+			return err
+		}
+		if _, err = tx.Exec(ctx, `CREATE UNIQUE INDEX `+oneLivePipelineRunIndex+`
 				ON pipelines_runs (pipeline)
 				WHERE end_time IS NULL`); err != nil {
 			if db.IsUniqueViolation(err) {
-				err = fmt.Errorf("cannot create %s: multiple active runs exist for the same pipeline; try it later", oneActivePipelineRunIndex)
+				err = fmt.Errorf("cannot create %s: multiple live runs exist for the same pipeline; try it later", oneLivePipelineRunIndex)
 			}
 			return err
 		}

--- a/core/internal/initdb/upgrade_test.go
+++ b/core/internal/initdb/upgrade_test.go
@@ -107,11 +107,11 @@ func TestUpgradePipelineRunIndexes(t *testing.T) {
 		t.Fatalf("cannot insert completed run: %s", err)
 	}
 	_, err = database.Exec(ctx, `INSERT INTO pipelines_runs (id, pipeline) VALUES ('run-2', 'pipeline-1')`)
-	if !db.IsUniqueViolation(err) || db.ErrConstraintName(err) != oneActivePipelineRunIndex {
-		t.Fatalf("expected violation of %s, got %v", oneActivePipelineRunIndex, err)
+	if !db.IsUniqueViolation(err) || db.ErrConstraintName(err) != oneLivePipelineRunIndex {
+		t.Fatalf("expected violation of %s, got %v", oneLivePipelineRunIndex, err)
 	}
 
-	_, err = database.Exec(ctx, `DROP INDEX `+oneActivePipelineRunIndex)
+	_, err = database.Exec(ctx, `DROP INDEX `+oneLivePipelineRunIndex)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestUpgradePipelineRunIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = Upgrade(ctx, database)
-	if err == nil || !strings.Contains(err.Error(), "multiple active runs exist") {
-		t.Fatalf("expected duplicate active runs error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "multiple live runs exist") {
+		t.Fatalf("expected duplicate live runs error, got %v", err)
 	}
 }

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -936,7 +936,7 @@ func (this *Pipeline) createRun(ctx context.Context, incremental *bool) (string,
 						err = errors.NotFound("pipeline %s does not exit", n.Pipeline)
 					}
 				case db.IsUniqueViolation(err):
-					if db.ErrConstraintName(err) == "pipelines_one_active_run_idx" {
+					if db.ErrConstraintName(err) == "pipelines_one_live_run_idx" {
 						err = errors.Unprocessable(RunInProgress, "pipeline %s is already in progress", this.pipeline.ID)
 					}
 				}


### PR DESCRIPTION
```
core: rename active pipeline run index to live

Rename the partial unique index that prevents concurrent pipeline runs
from pipelines_one_active_run_idx to pipelines_one_live_run_idx.
```