### PR TITLE
core: cancel live runs when owning resources are removed or disabled

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -389,11 +389,14 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 	// Listen to state changes.
 	core.state.Freeze()
 	core.state.AddListener(core.onCreateWorkspace)
+	core.state.AddListener(core.onDeleteConnection)
 	core.state.AddListener(core.onDeleteOrganization)
+	core.state.AddListener(core.onDeletePipeline)
 	core.state.AddListener(core.onDeleteWorkspace)
 	core.state.AddListener(core.onElectLeader)
 	core.state.AddListener(core.onEndPipelineRun)
 	core.state.AddListener(core.onRunPipeline)
+	core.state.AddListener(core.onSetOrganizationStatus)
 	core.state.AddListener(core.onStartAlterProfileSchema)
 	core.state.AddListener(core.onStartIdentityResolution)
 	core.state.AddListener(core.onUpdateWarehouse)
@@ -1174,6 +1177,24 @@ func (core *Core) WarehousePlatforms() []WarehousePlatform {
 	return warehousePlatforms
 }
 
+// cancelConnectionLocalLiveRuns cancels any local live runs in the provided
+// connection.
+func (core *Core) cancelConnectionLocalLiveRuns(c *state.Connection) {
+	for _, p := range c.Pipelines() {
+		if run, ok := p.Run(); ok {
+			core.localLiveRuns.Cancel(run.ID)
+		}
+	}
+}
+
+// cancelWorkspaceLocalLiveRuns cancels any local live runs in the provided
+// workspace.
+func (core *Core) cancelWorkspaceLocalLiveRuns(ws *state.Workspace) {
+	for _, c := range ws.Connections() {
+		core.cancelConnectionLocalLiveRuns(c)
+	}
+}
+
 // decryptAuthorizedOAuthAccount decrypts an authorized OAuth account encrypted
 // with encryptAuthorizedOAuthAccount.
 func (core *Core) decryptAuthorizedOAuthAccount(ctx context.Context, account string) (authorizedOAuthAccount, error) {
@@ -1274,15 +1295,14 @@ func (core *Core) endLiveRun(ctx context.Context, run *state.PipelineRun, reason
 				}
 			}
 			// Update the pipeline's cursor.
-			var exists bool
-			err = tx.QueryRow(ctx, "UPDATE pipelines SET cursor = (SELECT cursor FROM pipelines_runs WHERE id = $1 LIMIT 1), health = $2 WHERE id = $3 RETURNING true",
-				n.ID, n.Health, pipeline).Scan(&exists)
+			res, err = tx.Exec(ctx, "UPDATE pipelines SET cursor = (SELECT cursor FROM pipelines_runs WHERE id = $1), health = $2 WHERE id = $3",
+				n.ID, n.Health, pipeline)
 			if err != nil {
-				if err == sql.ErrNoRows {
-					// The pipeline does not exist anymore.
-					return nil, nil
-				}
 				return nil, err
+			}
+			if res.RowsAffected() == 0 {
+				// The pipeline does not exist anymore.
+				return nil, nil
 			}
 			return n, nil
 		})
@@ -1719,16 +1739,34 @@ func (core *Core) onCreateWorkspace(n state.CreateWorkspace) {
 	core.mcpMu.Unlock()
 }
 
+// onDeleteConnection is called when a connection is deleted.
+func (core *Core) onDeleteConnection(n state.DeleteConnection) {
+	core.cancelConnectionLocalLiveRuns(n.Connection())
+}
+
 // onDeleteOrganization is called when an organization is deleted.
 func (core *Core) onDeleteOrganization(n state.DeleteOrganization) {
-	for _, ws := range n.Organization().Workspaces() {
+	org := n.Organization()
+	for _, ws := range org.Workspaces() {
 		core.removeMCPWarehouse(ws.ID)
+		core.cancelWorkspaceLocalLiveRuns(ws)
+	}
+}
+
+// onDeletePipeline is called when a pipeline is deleted.
+func (core *Core) onDeletePipeline(n state.DeletePipeline) {
+	p := n.Pipeline()
+	// Cancel any local live runs.
+	if run, ok := p.Run(); ok {
+		core.localLiveRuns.Cancel(run.ID)
 	}
 }
 
 // onDeleteWorkspace is called when a workspace is deleted.
 func (core *Core) onDeleteWorkspace(n state.DeleteWorkspace) {
+	ws := n.Workspace()
 	core.removeMCPWarehouse(n.ID)
+	core.cancelWorkspaceLocalLiveRuns(ws)
 }
 
 // onElectLeader is called when a leader is elected.
@@ -1749,6 +1787,16 @@ func (core *Core) onElectLeader(n state.ElectLeader) {
 				ws.AlterProfileSchema.Schema, ws.AlterProfileSchema.PrimarySources,
 				ws.AlterProfileSchema.Operations)
 		}
+	}
+}
+
+// onSetOrganizationStatus is called when an organization status is set.
+func (core *Core) onSetOrganizationStatus(n state.SetOrganizationStatus) {
+	if n.Enabled {
+		return
+	}
+	for _, run := range n.EndedLiveRuns() {
+		core.localLiveRuns.Cancel(run.ID)
 	}
 }
 

--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	stdjson "encoding/json"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -1326,8 +1327,17 @@ func (state *State) setPipelineSchedulePeriod(n notification) string {
 // SetOrganizationStatus is the event sent when the status of an organization is
 // set.
 type SetOrganizationStatus struct {
-	ID      string
-	Enabled bool
+	ID            string
+	Enabled       bool
+	endedLiveRuns []*PipelineRun
+}
+
+// EndedLiveRuns returns the organization's live runs that were ended.
+func (n SetOrganizationStatus) EndedLiveRuns() []*PipelineRun {
+	if n.endedLiveRuns == nil {
+		return []*PipelineRun{}
+	}
+	return n.endedLiveRuns
 }
 
 // setOrganizationStatus sets the status of an organization.
@@ -1339,6 +1349,33 @@ func (state *State) setOrganizationStatus(n notification) string {
 	o := state.replaceOrganization(e.ID, func(p *Organization) {
 		p.Enabled = e.Enabled
 	})
+	// End the organization's live pipeline runs.
+	if !e.Enabled {
+		e.endedLiveRuns = []*PipelineRun{}
+		for _, ws := range o.workspaces {
+			for _, c := range ws.connections {
+				for _, p := range c.pipelines {
+					if p.run != nil {
+						state.replacePipeline(p.ID, func(p *Pipeline) {
+							p.run = nil
+							p.Health = Healthy
+						})
+						e.endedLiveRuns = append(e.endedLiveRuns, p.run)
+					}
+				}
+			}
+		}
+		if len(e.endedLiveRuns) > 0 {
+			slices.SortFunc(e.endedLiveRuns, func(a, b *PipelineRun) int {
+				return strings.Compare(a.ID, b.ID)
+			})
+			state.mu.Lock()
+			for _, run := range e.endedLiveRuns {
+				delete(state.liveRuns, run.ID)
+			}
+			state.mu.Unlock()
+		}
+	}
 	dispatchNotification(state, e)
 	return o.ID
 }

--- a/core/organization.go
+++ b/core/organization.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/krenalis/krenalis/core/internal/datastore"
 	"github.com/krenalis/krenalis/core/internal/db"
+	"github.com/krenalis/krenalis/core/internal/metrics"
 	"github.com/krenalis/krenalis/core/internal/state"
 	"github.com/krenalis/krenalis/core/internal/util"
 	"github.com/krenalis/krenalis/tools/errors"
@@ -775,9 +776,14 @@ func (this *Organization) SendMemberPasswordReset(ctx context.Context, email str
 // SetStatus sets the status of the organization.
 func (this *Organization) SetStatus(ctx context.Context, enabled bool) error {
 	this.core.mustBeOpen()
+
 	if enabled == this.organization.Enabled {
 		return nil
 	}
+
+	// Waits for the metrics to be saved.
+	this.core.metrics.WaitStore()
+
 	n := state.SetOrganizationStatus{
 		ID:      this.organization.ID,
 		Enabled: enabled,
@@ -790,10 +796,87 @@ func (this *Organization) SetStatus(ctx context.Context, enabled bool) error {
 		if result.RowsAffected() == 0 {
 			return nil, nil
 		}
+		// Terminate the organization's live pipeline runs.
+		if !n.Enabled {
+			endTime := time.Now().UTC()
+			errorMessage := "organization has been disabled"
+			// Mark the live runs as terminated and update the related pipeline state.
+			_, err = tx.Exec(ctx, endOrganizationLiveRunsQuery,
+				n.ID, endTime, errorMessage, metrics.TimeSlotFromTime(endTime), metrics.ReceiveStep)
+			if err != nil {
+				return nil, fmt.Errorf("cannot terminate organization live runs: %s", err)
+			}
+		}
 		return n, nil
 	})
+
 	return err
 }
+
+// endOrganizationLiveRunsQuery ends all live pipeline runs for an organization.
+// For each run it terminates, it records the final metrics, advances the related
+// pipeline cursor, marks the pipeline as healthy, and records the termination error.
+const endOrganizationLiveRunsQuery = `
+WITH live_runs AS (
+	SELECT r.id, r.pipeline
+	FROM pipelines_runs AS r
+	INNER JOIN pipelines AS p ON r.pipeline = p.id
+	INNER JOIN connections AS c ON p.connection = c.id
+	INNER JOIN workspaces AS w ON c.workspace = w.id
+	WHERE w.organization = $1 AND r.end_time IS NULL
+),
+s AS (
+	SELECT r.id,
+		COALESCE(SUM(m.passed_0), 0) AS passed_0,
+		COALESCE(SUM(m.passed_1), 0) AS passed_1,
+		COALESCE(SUM(m.passed_2), 0) AS passed_2,
+		COALESCE(SUM(m.passed_3), 0) AS passed_3,
+		COALESCE(SUM(m.passed_4), 0) AS passed_4,
+		COALESCE(SUM(m.passed_5), 0) AS passed_5,
+		COALESCE(SUM(m.failed_0), 0) AS failed_0,
+		COALESCE(SUM(m.failed_1), 0) AS failed_1,
+		COALESCE(SUM(m.failed_2), 0) AS failed_2,
+		COALESCE(SUM(m.failed_3), 0) AS failed_3,
+		COALESCE(SUM(m.failed_4), 0) AS failed_4,
+		COALESCE(SUM(m.failed_5), 0) AS failed_5
+	FROM live_runs AS r
+	LEFT JOIN pipelines_metrics AS m ON m.pipeline = r.pipeline
+	GROUP BY r.id
+),
+ended_runs AS (
+	UPDATE pipelines_runs AS r
+	SET function = '',
+		end_time = $2,
+		passed_0 = r.passed_0 + s.passed_0,
+		passed_1 = r.passed_1 + s.passed_1,
+		passed_2 = r.passed_2 + s.passed_2,
+		passed_3 = r.passed_3 + s.passed_3,
+		passed_4 = r.passed_4 + s.passed_4,
+		passed_5 = r.passed_5 + s.passed_5,
+		failed_0 = r.failed_0 + s.failed_0,
+		failed_1 = r.failed_1 + s.failed_1,
+		failed_2 = r.failed_2 + s.failed_2,
+		failed_3 = r.failed_3 + s.failed_3,
+		failed_4 = r.failed_4 + s.failed_4,
+		failed_5 = r.failed_5 + s.failed_5,
+		error = $3
+	FROM s
+	WHERE r.id = s.id AND r.end_time IS NULL
+	RETURNING r.pipeline, r.cursor
+),
+updated_pipelines AS (
+	UPDATE pipelines AS p
+	SET cursor = ended_runs.cursor,
+		health = 'Healthy'::health
+	FROM ended_runs
+	WHERE p.id = ended_runs.pipeline
+	RETURNING p.id
+)
+INSERT INTO pipelines_errors (pipeline, timeslot, step, count, message)
+SELECT ended_runs.pipeline, $4, $5, 0, $3::text
+FROM ended_runs
+INNER JOIN updated_pipelines AS p ON ended_runs.pipeline = p.id
+`
 
 // TestWorkspaceCreation tests a workspace creation. It tests that a warehouse
 // with the provided platform and settings can be initialized.

--- a/test/organization_disabled_test.go
+++ b/test/organization_disabled_test.go
@@ -102,8 +102,65 @@ func TestOrganizationDisabled(t *testing.T) {
 	// Create an API key while the organization is still enabled.
 	apiKey := k.CreateWorkspaceRestrictedAPIKey("Events ingestion key")
 
+	longRunningPipelineParams := func(name string) krenalistester.PipelineToSet {
+		return krenalistester.PipelineToSet{
+			Name:    name,
+			Enabled: true,
+			InSchema: types.Object([]types.Property{
+				{Name: "email", Type: types.String(), Nullable: true},
+				{Name: "firstName", Type: types.String(), Nullable: true},
+			}),
+			OutSchema: types.Object([]types.Property{
+				{Name: "email", Type: types.String().WithMaxLength(300), ReadOptional: true},
+				{Name: "first_name", Type: types.String().WithMaxLength(300), ReadOptional: true},
+			}),
+			Transformation: &krenalistester.Transformation{
+				Mapping: map[string]string{
+					"email":      "email",
+					"first_name": "firstName",
+				},
+			},
+		}
+	}
+	longRunningDummy1 := k.CreateDummyWithSettings("Long-running Dummy 1 (source)", krenalistester.Source, krenalistester.DummySettings{
+		OperationDelay: "2m",
+	})
+	longRunningPipeline1 := k.CreatePipeline(longRunningDummy1, "User", longRunningPipelineParams("Long-running import users from Dummy 1"))
+	longRunningDummy2 := k.CreateDummyWithSettings("Long-running Dummy 2 (source)", krenalistester.Source, krenalistester.DummySettings{
+		OperationDelay: "2m",
+	})
+	longRunningPipeline2 := k.CreatePipeline(longRunningDummy2, "User", longRunningPipelineParams("Long-running import users from Dummy 2"))
+	longRunningRuns := []string{
+		k.StartPipelineRun(longRunningPipeline1),
+		k.StartPipelineRun(longRunningPipeline2),
+	}
+
 	// Disable the organization.
 	k.SetOrganizationStatus(orgID, false)
+
+	t.Run("live runs are interrupted when disabled", func(t *testing.T) {
+		deadline := time.Now().Add(10 * time.Second)
+		for _, run := range longRunningRuns {
+			for {
+				var completed bool
+				k.QueryRowTestDatabase(t.Context(), &completed,
+					"SELECT end_time IS NOT NULL FROM pipelines_runs WHERE id = $1", run)
+				if completed {
+					var runError string
+					k.QueryRowTestDatabase(t.Context(), &runError,
+						"SELECT error FROM pipelines_runs WHERE id = $1", run)
+					if runError != "organization has been disabled" {
+						t.Fatalf("expected run error %q for run %s, got %q", "organization has been disabled", run, runError)
+					}
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("run %s was not interrupted after disabling the organization", run)
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	})
 
 	// The organization endpoint must still be reachable and must report the new
 	// status.


### PR DESCRIPTION
```
core: cancel live runs for deleted owners and disabled organizations

Previously, live pipeline runs could keep executing after their owning
pipeline, connection, workspace, or organization was removed from state.
Disabling an organization also prevented new work from starting, but did
not explicitly stop runs that were already live.

Cancel live runs when their owning resources are deleted. When an
organization is disabled, close its live runs in the database as part of
the same transaction. Then update state from the notification and cancel
the matching local executions so connectors can stop promptly.

Closes #2250
```