### PR TITLE
core: preserve pipeline cursor after failed import

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,7 +98,7 @@ func Main(assets fs.FS) {
 		fatal(1, err.Error())
 	}
 	if upgradeDB {
-		err = core.UpgradeDB(ctx, &core.Config{DB: conf.DB})
+		err = core.UpgradeDB(ctx, &core.Config{DB: conf.DB, KMS: conf.KMS})
 		if err != nil {
 			fatal(1, err.Error())
 		}

--- a/connectors/dummy/dummy.go
+++ b/connectors/dummy/dummy.go
@@ -85,6 +85,8 @@ var (
 //go:embed customers.json
 var jsonCustomers []byte
 
+const maxOperationDelay = 24 * time.Hour // maximum operation delay
+
 func newDummyId() string {
 	b := make([]rune, 12)
 	for i := range b {
@@ -100,7 +102,10 @@ func (dummy *Dummy) EventTypeSchema(ctx context.Context, eventType string) (type
 	if err != nil {
 		return types.Type{}, err
 	}
-	dummy.simulateHTTPDelay(&s)
+	err = dummy.applyOperationDelay(ctx, s.OperationDelay)
+	if err != nil {
+		return types.Type{}, err
+	}
 	switch eventType {
 	case "send_add_to_cart":
 		return types.Object([]types.Property{
@@ -139,7 +144,10 @@ func (dummy *Dummy) EventTypes(ctx context.Context) ([]*connectors.EventType, er
 	if err != nil {
 		return nil, err
 	}
-	dummy.simulateHTTPDelay(&s)
+	err = dummy.applyOperationDelay(ctx, s.OperationDelay)
+	if err != nil {
+		return nil, err
+	}
 	return []*connectors.EventType{
 		{
 			ID:          "send_add_to_cart",
@@ -182,7 +190,10 @@ func (dummy *Dummy) RecordSchema(ctx context.Context, target connectors.Targets,
 	if err != nil {
 		return types.Type{}, err
 	}
-	dummy.simulateHTTPDelay(&s)
+	err = dummy.applyOperationDelay(ctx, s.OperationDelay)
+	if err != nil {
+		return types.Type{}, err
+	}
 	var properties []types.Property
 	if role == connectors.Source {
 		properties = append(properties, types.Property{Name: "dummyId", Type: types.String(), Description: "Dummy ID"})
@@ -216,7 +227,10 @@ func (dummy *Dummy) Records(ctx context.Context, target connectors.Targets, upda
 	if err != nil {
 		return nil, "", err
 	}
-	dummy.simulateHTTPDelay(&s)
+	err = dummy.applyOperationDelay(ctx, s.OperationDelay)
+	if err != nil {
+		return nil, "", err
+	}
 	select {
 	case <-ctx.Done():
 		return nil, "", ctx.Err()
@@ -276,8 +290,8 @@ func init() {
 
 type innerSettings struct {
 	CustomerExportFailPercentage int    `json:"customerExportFailPercentage"`
+	OperationDelay               string `json:"operationDelay"`
 	URLForDispatchingEvents      string `json:"urlForDispatchingEvents"`
-	SimulateHTTPDelay            bool   `json:"simulateHTTPDelay"`
 }
 
 // SendEvents sends events to the API.
@@ -321,10 +335,12 @@ func (dummy *Dummy) ServeUI(ctx context.Context, event string, settings json.Val
 				Placeholder: "http://127.0.0.1:1234",
 				Role:        connectors.Destination,
 			},
-			&connectors.Checkbox{
-				Name:  "simulateHTTPDelay",
-				Label: "Pretend that Dummy operates via HTTP calls, introducing fictitious delays",
-				Role:  connectors.Both,
+			&connectors.Input{
+				Name:        "operationDelay",
+				Label:       "Operation delay",
+				Placeholder: "500ms",
+				HelpText:    "If set, Dummy adds the specified delay to each operation. Examples: 500ms, 2s, 1m.",
+				Role:        connectors.Both,
 			},
 		},
 		Settings: settings,
@@ -347,7 +363,10 @@ func (dummy *Dummy) Upsert(ctx context.Context, target connectors.Targets, recor
 		return err
 	}
 
-	dummy.simulateHTTPDelay(&s)
+	err = dummy.applyOperationDelay(ctx, s.OperationDelay)
+	if err != nil {
+		return err
+	}
 
 	recordsError := make(connectors.RecordsError)
 
@@ -416,6 +435,23 @@ func (dummy *Dummy) Upsert(ctx context.Context, target connectors.Targets, recor
 	return nil
 }
 
+// applyOperationDelay applies an operation delay.
+func (dummy *Dummy) applyOperationDelay(ctx context.Context, operationDelay string) error {
+	if operationDelay == "" {
+		return nil
+	}
+	delay, _ := time.ParseDuration(operationDelay)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		prometheus.Increment("Dummy.applyOperationDelay.applied_delays", 1)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // customerExportRandomlyFails determines whether exporting (i.e., writing to
 // Dummy) a customer should randomly fail, based on the settings.
 func (dummy *Dummy) customerExportRandomlyFails(s *innerSettings) bool {
@@ -439,18 +475,22 @@ func (dummy *Dummy) saveSettings(ctx context.Context, settings json.Value) error
 	if s.CustomerExportFailPercentage < 0 || s.CustomerExportFailPercentage > 100 {
 		return connectors.NewInvalidSettingsError("percentage must be in range [0, 100]")
 	}
-	return dummy.env.Settings.Store(ctx, s)
-}
-
-// simulateHTTPDelay simulates an HTTP delay. If the settings indicate not to
-// simulate delay, this method does nothing.
-func (dummy *Dummy) simulateHTTPDelay(s *innerSettings) {
-	if !s.SimulateHTTPDelay {
-		return
+	if s.OperationDelay != "" {
+		delay, err := time.ParseDuration(s.OperationDelay)
+		if err != nil {
+			return connectors.NewInvalidSettingsError("operation delay must be a valid duration")
+		}
+		if delay < 0 {
+			return connectors.NewInvalidSettingsError("operation delay cannot be negative")
+		}
+		if delay > maxOperationDelay {
+			return connectors.NewInvalidSettingsError("operation delay must be less than or equal to 24h")
+		}
+		if delay == 0 {
+			s.OperationDelay = ""
+		}
 	}
-	latency := rand.Float64()*1.3 + 1.5 // seconds.
-	time.Sleep(time.Duration(latency * 1e9))
-	prometheus.Increment("Dummy.simulateHTTPDelay.simulated_delays", 1)
+	return dummy.env.Settings.Store(ctx, s)
 }
 
 // sendEvents sends the given events to the API and returns the sent HTTP
@@ -486,6 +526,10 @@ func (dummy *Dummy) sendEvents(ctx context.Context, events connectors.Events, pr
 	req.Header["Idempotency-Key"] = nil
 	if preview {
 		return req, nil
+	}
+	err = dummy.applyOperationDelay(ctx, s.OperationDelay)
+	if err != nil {
+		return nil, err
 	}
 	res, err := dummy.env.HTTPClient.Do(req)
 	if err != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -1282,15 +1282,14 @@ func (core *Core) endLiveRun(ctx context.Context, run *state.PipelineRun, reason
 				return nil, nil
 			}
 			// Update the pipeline's cursor.
-			var exists bool
-			err = tx.QueryRow(ctx, "UPDATE pipelines SET cursor = (SELECT cursor FROM pipelines_runs WHERE id = $1 LIMIT 1), health = $2 WHERE id = $3 RETURNING true",
-				n.ID, n.Health, pipeline).Scan(&exists)
+			res, err = tx.Exec(ctx, "UPDATE pipelines SET cursor = (SELECT cursor FROM pipelines_runs WHERE id = $1), health = $2 WHERE id = $3",
+				n.ID, n.Health, pipeline)
 			if err != nil {
-				if err == sql.ErrNoRows {
-					// The pipeline does not exist anymore.
-					return nil, nil
-				}
 				return nil, err
+			}
+			if res.RowsAffected() == 0 {
+				// The pipeline does not exist anymore.
+				return nil, nil
 			}
 			return n, nil
 		})

--- a/core/core.go
+++ b/core/core.go
@@ -420,7 +420,11 @@ func UpgradeDB(ctx context.Context, conf *Config) error {
 		return fmt.Errorf("cannot connect to PostgreSQL: %s", err)
 	}
 
-	if err := initdb.Upgrade(ctx, db); err != nil {
+	k, err := kms.New(ctx, conf.KMS)
+	if err != nil {
+		return fmt.Errorf("cannot initialize KMS: %s", err)
+	}
+	if err := initdb.Upgrade(ctx, db, k); err != nil {
 		return fmt.Errorf("cannot upgrade PostgreSQL database: %s", err)
 	}
 	return initdb.UpgradeWorkOS(ctx, db)

--- a/core/core.go
+++ b/core/core.go
@@ -1281,9 +1281,14 @@ func (core *Core) endLiveRun(ctx context.Context, run *state.PipelineRun, reason
 			if res.RowsAffected() == 0 {
 				return nil, nil
 			}
-			// Update the pipeline's cursor.
-			res, err = tx.Exec(ctx, "UPDATE pipelines SET cursor = (SELECT cursor FROM pipelines_runs WHERE id = $1), health = $2 WHERE id = $3",
-				n.ID, n.Health, pipeline)
+			// Update the pipeline's cursor only when the run completed normally.
+			if reason == nil {
+				res, err = tx.Exec(ctx, "UPDATE pipelines SET cursor = (SELECT cursor FROM pipelines_runs WHERE id = $1), health = $2 WHERE id = $3",
+					n.ID, n.Health, pipeline)
+			} else {
+				res, err = tx.Exec(ctx, "UPDATE pipelines SET health = $1 WHERE id = $2",
+					n.Health, pipeline)
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/core/core.go
+++ b/core/core.go
@@ -378,11 +378,14 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 	// Listen to state changes.
 	core.state.Freeze()
 	core.state.AddListener(core.onCreateWorkspace)
+	core.state.AddListener(core.onDeleteConnection)
 	core.state.AddListener(core.onDeleteOrganization)
+	core.state.AddListener(core.onDeletePipeline)
 	core.state.AddListener(core.onDeleteWorkspace)
 	core.state.AddListener(core.onElectLeader)
 	core.state.AddListener(core.onEndPipelineRun)
 	core.state.AddListener(core.onRunPipeline)
+	core.state.AddListener(core.onSetOrganizationStatus)
 	core.state.AddListener(core.onStartAlterProfileSchema)
 	core.state.AddListener(core.onStartIdentityResolution)
 	core.state.AddListener(core.onUpdateWarehouse)
@@ -1167,6 +1170,24 @@ func (core *Core) WarehousePlatforms() []WarehousePlatform {
 	return warehousePlatforms
 }
 
+// cancelConnectionLocalLiveRuns cancels any local live runs in the provided
+// connection.
+func (core *Core) cancelConnectionLocalLiveRuns(c *state.Connection) {
+	for _, p := range c.Pipelines() {
+		if run, ok := p.Run(); ok {
+			core.localLiveRuns.Cancel(run.ID)
+		}
+	}
+}
+
+// cancelWorkspaceLocalLiveRuns cancels any local live runs in the provided
+// workspace.
+func (core *Core) cancelWorkspaceLocalLiveRuns(ws *state.Workspace) {
+	for _, c := range ws.Connections() {
+		core.cancelConnectionLocalLiveRuns(c)
+	}
+}
+
 // decryptAuthorizedOAuthAccount decrypts an authorized OAuth account encrypted
 // with encryptAuthorizedOAuthAccount.
 func (core *Core) decryptAuthorizedOAuthAccount(ctx context.Context, account string) (authorizedOAuthAccount, error) {
@@ -1706,16 +1727,34 @@ func (core *Core) onCreateWorkspace(n state.CreateWorkspace) {
 	core.mcpMu.Unlock()
 }
 
+// onDeleteConnection is called when a connection is deleted.
+func (core *Core) onDeleteConnection(n state.DeleteConnection) {
+	core.cancelConnectionLocalLiveRuns(n.Connection())
+}
+
 // onDeleteOrganization is called when an organization is deleted.
 func (core *Core) onDeleteOrganization(n state.DeleteOrganization) {
-	for _, ws := range n.Organization().Workspaces() {
+	org := n.Organization()
+	for _, ws := range org.Workspaces() {
 		core.removeMCPWarehouse(ws.ID)
+		core.cancelWorkspaceLocalLiveRuns(ws)
+	}
+}
+
+// onDeletePipeline is called when a pipeline is deleted.
+func (core *Core) onDeletePipeline(n state.DeletePipeline) {
+	p := n.Pipeline()
+	// Cancel any local live runs.
+	if run, ok := p.Run(); ok {
+		core.localLiveRuns.Cancel(run.ID)
 	}
 }
 
 // onDeleteWorkspace is called when a workspace is deleted.
 func (core *Core) onDeleteWorkspace(n state.DeleteWorkspace) {
+	ws := n.Workspace()
 	core.removeMCPWarehouse(n.ID)
+	core.cancelWorkspaceLocalLiveRuns(ws)
 }
 
 // onElectLeader is called when a leader is elected.
@@ -1736,6 +1775,16 @@ func (core *Core) onElectLeader(n state.ElectLeader) {
 				ws.AlterProfileSchema.Schema, ws.AlterProfileSchema.PrimarySources,
 				ws.AlterProfileSchema.Operations)
 		}
+	}
+}
+
+// onSetOrganizationStatus is called when an organization status is set.
+func (core *Core) onSetOrganizationStatus(n state.SetOrganizationStatus) {
+	if n.Enabled {
+		return
+	}
+	for _, run := range n.EndedLiveRuns() {
+		core.localLiveRuns.Cancel(run.ID)
 	}
 }
 

--- a/core/internal/initdb/upgrade.go
+++ b/core/internal/initdb/upgrade.go
@@ -9,18 +9,26 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/krenalis/krenalis/core/internal/cipher"
 	"github.com/krenalis/krenalis/core/internal/db"
+	"github.com/krenalis/krenalis/tools/json"
+	"github.com/krenalis/krenalis/tools/kms"
 )
 
 const (
 	oneActivePipelineRunIndex = "pipelines_one_active_run_idx"
 	oneLivePipelineRunIndex   = "pipelines_one_live_run_idx"
 )
-const pipelineRunsFunctionIndex = "pipelines_runs_function_idx"
+const (
+	pipelineRunsFunctionIndex       = "pipelines_runs_function_idx"
+	legacyDummyOperationDelay       = "2s"
+	legacyDummySimulateHTTPDelayKey = "simulateHTTPDelay"
+	dummyOperationDelayKey          = "operationDelay"
+)
 
 // Upgrade applies idempotent updates to an existing Krenalis PostgreSQL
 // database.
-func Upgrade(ctx context.Context, database *db.DB) error {
+func Upgrade(ctx context.Context, database *db.DB, kms kms.Kms) error {
 
 	initialized, err := database.QueryExists(ctx, `
 		SELECT FROM pg_class c
@@ -35,6 +43,8 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 		return fmt.Errorf("Krenalis's PostgreSQL database has not been initialized")
 	}
 
+	c := cipher.New(kms)
+	defer c.Close()
 	err = database.Transaction(ctx, func(tx *db.Tx) error {
 		// core: prevent concurrent runs for the same pipeline.
 		// https://github.com/krenalis/krenalis/pull/2275
@@ -64,6 +74,11 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 			WHERE function != '' AND end_time IS NULL`); err != nil {
 			return err
 		}
+		// connectors/dummy: replace simulated HTTP delay with `operationDelay`.
+		// https://github.com/krenalis/krenalis/pull/2316
+		if err := upgradeDummyOperationDelaySettings(ctx, tx, c); err != nil {
+			return err
+		}
 		return nil
 	})
 	if err != nil {
@@ -73,4 +88,79 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 	slog.Info("PostgreSQL database upgraded successfully")
 
 	return nil
+}
+
+// upgradeDummyOperationDelaySettings converts Dummy connections from the legacy
+// simulated HTTP delay settings to the operation delay setting.
+func upgradeDummyOperationDelaySettings(ctx context.Context, tx *db.Tx, c *cipher.Cipher) error {
+	type update struct {
+		connection string
+		settings   []byte
+	}
+	updates := []update{}
+	err := tx.QueryScan(ctx, `
+		SELECT id, settings, kms_encrypted_settings_key
+		FROM connections
+		WHERE connector = 'dummy' AND settings IS NOT NULL`, func(rows *db.Rows) error {
+		for rows.Next() {
+			var id string
+			var encryptedSettings, settingsKey []byte
+			if err := rows.Scan(&id, &encryptedSettings, &settingsKey); err != nil {
+				return err
+			}
+			settings, changed, err := upgradeDummyOperationDelaySetting(ctx, c, encryptedSettings, settingsKey)
+			if err != nil {
+				return fmt.Errorf("cannot upgrade Dummy settings for connection %s: %s", id, err)
+			}
+			if !changed {
+				continue
+			}
+			updates = append(updates, update{id, settings})
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for _, update := range updates {
+		if _, err := tx.Exec(ctx, "UPDATE connections SET settings = $1 WHERE id = $2", update.settings, update.connection); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// upgradeDummyOperationDelaySetting upgrades one Dummy connection setting.
+func upgradeDummyOperationDelaySetting(ctx context.Context, c *cipher.Cipher, encryptedSettings, settingsKey []byte) ([]byte, bool, error) {
+	settings, err := c.Decrypt(ctx, encryptedSettings, settingsKey)
+	if err != nil {
+		return nil, false, err
+	}
+	defer clear(settings)
+	var s map[string]any
+	if err := json.Unmarshal(settings, &s); err != nil {
+		return nil, false, err
+	}
+	_, hasOperationDelay := s[dummyOperationDelayKey]
+	changed := false
+	if v, ok := s[legacyDummySimulateHTTPDelayKey]; ok {
+		changed = true
+		delete(s, legacyDummySimulateHTTPDelayKey)
+		if enabled, ok := v.(bool); ok && enabled && !hasOperationDelay {
+			s[dummyOperationDelayKey] = legacyDummyOperationDelay
+		}
+	}
+	if !changed {
+		return nil, false, nil
+	}
+	updated, err := json.Marshal(s)
+	if err != nil {
+		return nil, false, err
+	}
+	defer clear(updated)
+	encrypted, err := c.EncryptWithExistingKey(ctx, updated, settingsKey)
+	if err != nil {
+		return nil, false, err
+	}
+	return encrypted, true, nil
 }

--- a/core/internal/initdb/upgrade_test.go
+++ b/core/internal/initdb/upgrade_test.go
@@ -5,12 +5,15 @@
 package initdb
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/krenalis/krenalis/core/internal/cipher"
 	"github.com/krenalis/krenalis/core/internal/db"
 	"github.com/krenalis/krenalis/test/testimages"
+	"github.com/krenalis/krenalis/tools/kms"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -70,6 +73,12 @@ func TestUpgradePipelineRunIndexes(t *testing.T) {
 		function text NOT NULL DEFAULT '',
 		end_time timestamp
 	);
+	CREATE TABLE connections (
+		id text PRIMARY KEY,
+		connector text NOT NULL,
+		settings bytea,
+		kms_encrypted_settings_key bytea NOT NULL
+	);
 	CREATE INDEX pipelines_runs_function_idx
 		ON pipelines_runs (function)
 		WHERE function != '' AND end_time IS NOT NULL`)
@@ -77,7 +86,8 @@ func TestUpgradePipelineRunIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Upgrade(ctx, database); err != nil {
+	testKMS := newUpgradeTestKMS(t)
+	if err := Upgrade(ctx, database, testKMS); err != nil {
 		t.Fatal(err)
 	}
 	var predicate string
@@ -94,7 +104,7 @@ func TestUpgradePipelineRunIndexes(t *testing.T) {
 	if !strings.Contains(predicate, "end_time IS NULL") || strings.Contains(predicate, "end_time IS NOT NULL") {
 		t.Fatalf("unexpected %s predicate: %s", pipelineRunsFunctionIndex, predicate)
 	}
-	if err := Upgrade(ctx, database); err != nil {
+	if err := Upgrade(ctx, database, testKMS); err != nil {
 		t.Fatalf("second upgrade failed: %s", err)
 	}
 
@@ -119,8 +129,133 @@ func TestUpgradePipelineRunIndexes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = Upgrade(ctx, database)
+	err = Upgrade(ctx, database, testKMS)
 	if err == nil || !strings.Contains(err.Error(), "multiple live runs exist") {
 		t.Fatalf("expected duplicate live runs error, got %v", err)
 	}
+}
+
+func TestUpgradeDummyOperationDelaySettings(t *testing.T) {
+	ctx := t.Context()
+	database := openUpgradeTestDB(t)
+	_, err := database.Exec(ctx, `CREATE TABLE pipelines_runs (
+		id text PRIMARY KEY,
+		pipeline text NOT NULL,
+		function text NOT NULL DEFAULT '',
+		end_time timestamp
+	);
+	CREATE TABLE connections (
+		id text PRIMARY KEY,
+		connector text NOT NULL,
+		settings bytea,
+		kms_encrypted_settings_key bytea NOT NULL
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testKMS := newUpgradeTestKMS(t)
+	c := cipher.New(testKMS)
+	t.Cleanup(c.Close)
+	insertConnection := func(id, settings string) {
+		t.Helper()
+		encryptedSettings, settingsKey, err := c.Encrypt(ctx, []byte(settings))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = database.Exec(ctx, "INSERT INTO connections (id, connector, settings, kms_encrypted_settings_key) VALUES ($1, 'dummy', $2, $3)",
+			id, encryptedSettings, settingsKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	insertConnection("enabled", `{"simulateHTTPDelay":true}`)
+	insertConnection("disabled", `{"simulateHTTPDelay":false}`)
+	insertConnection("existing", `{"simulateHTTPDelay":true,"operationDelay":"3s"}`)
+	insertConnection("untouched", `{"operationDelay":"777ms"}`)
+
+	if err := Upgrade(ctx, database, testKMS); err != nil {
+		t.Fatal(err)
+	}
+	if err := Upgrade(ctx, database, testKMS); err != nil {
+		t.Fatalf("second upgrade failed: %s", err)
+	}
+
+	assertSettings := func(id, want string) {
+		t.Helper()
+		var encryptedSettings, settingsKey []byte
+		err := database.QueryRow(ctx, "SELECT settings, kms_encrypted_settings_key FROM connections WHERE id = $1", id).
+			Scan(&encryptedSettings, &settingsKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		settings, err := c.Decrypt(ctx, encryptedSettings, settingsKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(settings) != want {
+			t.Fatalf("settings for connection %s = %s, want %s", id, settings, want)
+		}
+	}
+	assertSettings("enabled", `{"operationDelay":"2s"}`)
+	assertSettings("disabled", `{}`)
+	assertSettings("existing", `{"operationDelay":"3s"}`)
+	assertSettings("untouched", `{"operationDelay":"777ms"}`)
+}
+
+func openUpgradeTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	const (
+		databaseName = "krenalis"
+		user         = "krenalis"
+		password     = "krenalis"
+	)
+	ctx := t.Context()
+	container, err := postgres.Run(ctx,
+		testimages.PostgreSQL,
+		postgres.WithDatabase(databaseName),
+		postgres.WithUsername(user),
+		postgres.WithPassword(password),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Error(err)
+		}
+	})
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := container.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	database, err := db.Open(&db.Options{
+		Host:     host,
+		Port:     int(port.Num()),
+		Username: user,
+		Password: password,
+		Database: databaseName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(database.Close)
+	return database
+}
+
+func newUpgradeTestKMS(t *testing.T) kms.Kms {
+	t.Helper()
+	kms, err := kms.New(t.Context(), "key:"+base64.RawStdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return kms
 }

--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	stdjson "encoding/json"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -1326,8 +1327,17 @@ func (state *State) setPipelineSchedulePeriod(n notification) string {
 // SetOrganizationStatus is the event sent when the status of an organization is
 // set.
 type SetOrganizationStatus struct {
-	ID      string
-	Enabled bool
+	ID            string
+	Enabled       bool
+	endedLiveRuns []*PipelineRun
+}
+
+// EndedLiveRuns returns the organization's live runs that were ended.
+func (n SetOrganizationStatus) EndedLiveRuns() []*PipelineRun {
+	if n.endedLiveRuns == nil {
+		return []*PipelineRun{}
+	}
+	return n.endedLiveRuns
 }
 
 // setOrganizationStatus sets the status of an organization.
@@ -1339,6 +1349,33 @@ func (state *State) setOrganizationStatus(n notification) string {
 	o := state.replaceOrganization(e.ID, func(p *Organization) {
 		p.Enabled = e.Enabled
 	})
+	// End the organization's live pipeline runs.
+	if !e.Enabled {
+		e.endedLiveRuns = []*PipelineRun{}
+		for _, ws := range o.workspaces {
+			for _, c := range ws.connections {
+				for _, p := range c.pipelines {
+					if p.run != nil {
+						state.replacePipeline(p.ID, func(p *Pipeline) {
+							p.run = nil
+							p.Health = Healthy
+						})
+						e.endedLiveRuns = append(e.endedLiveRuns, p.run)
+					}
+				}
+			}
+		}
+		if len(e.endedLiveRuns) > 0 {
+			slices.SortFunc(e.endedLiveRuns, func(a, b *PipelineRun) int {
+				return strings.Compare(a.ID, b.ID)
+			})
+			state.mu.Lock()
+			for _, run := range e.endedLiveRuns {
+				delete(state.liveRuns, run.ID)
+			}
+			state.mu.Unlock()
+		}
+	}
 	dispatchNotification(state, e)
 	return o.ID
 }

--- a/core/organization.go
+++ b/core/organization.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/krenalis/krenalis/core/internal/datastore"
 	"github.com/krenalis/krenalis/core/internal/db"
+	"github.com/krenalis/krenalis/core/internal/metrics"
 	"github.com/krenalis/krenalis/core/internal/state"
 	"github.com/krenalis/krenalis/core/internal/util"
 	"github.com/krenalis/krenalis/tools/errors"
@@ -775,9 +776,14 @@ func (this *Organization) SendMemberPasswordReset(ctx context.Context, email str
 // SetStatus sets the status of the organization.
 func (this *Organization) SetStatus(ctx context.Context, enabled bool) error {
 	this.core.mustBeOpen()
+
 	if enabled == this.organization.Enabled {
 		return nil
 	}
+
+	// Waits for the metrics to be saved.
+	this.core.metrics.WaitStore()
+
 	n := state.SetOrganizationStatus{
 		ID:      this.organization.ID,
 		Enabled: enabled,
@@ -790,10 +796,101 @@ func (this *Organization) SetStatus(ctx context.Context, enabled bool) error {
 		if result.RowsAffected() == 0 {
 			return nil, nil
 		}
+		// Terminate the organization's live pipeline runs.
+		if !n.Enabled {
+			endTime := time.Now().UTC()
+			errorMessage := "organization has been disabled"
+			// Mark the live runs as terminated.
+			result, err = tx.Exec(ctx, endOrganizationLiveRunsQuery, n.ID, endTime, errorMessage)
+			if err != nil {
+				return nil, fmt.Errorf("cannot terminate organization live runs: %s", err)
+			}
+			if result.RowsAffected() > 0 {
+				// Update the pipelines for the terminated live runs.
+				const pipelinesQuery = "WITH ended_runs AS (\n" +
+					"SELECT r.pipeline, r.cursor\n" +
+					"FROM pipelines_runs AS r\n" +
+					"INNER JOIN pipelines AS p ON r.pipeline = p.id\n" +
+					"INNER JOIN connections AS c ON p.connection = c.id\n" +
+					"INNER JOIN workspaces AS w ON c.workspace = w.id\n" +
+					"WHERE w.organization = $1 AND r.end_time = $2 AND r.error = $3::text\n" +
+					")\n" +
+					"UPDATE pipelines AS p\n" +
+					"SET cursor = ended_runs.cursor, health = 'Healthy'::health\n" +
+					"FROM ended_runs\n" +
+					"WHERE p.id = ended_runs.pipeline"
+				_, err = tx.Exec(ctx, pipelinesQuery, n.ID, endTime, errorMessage)
+				if err != nil {
+					return nil, fmt.Errorf("cannot update pipelines for terminated organization live runs: %s", err)
+				}
+				// Record the termination error for the live runs.
+				const errorsQuery = "INSERT INTO pipelines_errors (pipeline, timeslot, step, count, message)\n" +
+					"SELECT r.pipeline, $2, $3, 0, $4::text\n" +
+					"FROM pipelines_runs AS r\n" +
+					"INNER JOIN pipelines AS p ON r.pipeline = p.id\n" +
+					"INNER JOIN connections AS c ON p.connection = c.id\n" +
+					"INNER JOIN workspaces AS w ON c.workspace = w.id\n" +
+					"WHERE w.organization = $1 AND r.end_time = $5 AND r.error = $4::text"
+				_, err = tx.Exec(ctx, errorsQuery, n.ID, metrics.TimeSlotFromTime(endTime), metrics.ReceiveStep, errorMessage, endTime)
+				if err != nil {
+					return nil, fmt.Errorf("cannot record errors for terminated organization live runs: %s", err)
+				}
+			}
+		}
 		return n, nil
 	})
+
 	return err
 }
+
+// endOrganizationLiveRunsQuery ends all live pipeline runs for an organization,
+// recording their final metrics.
+const endOrganizationLiveRunsQuery = `
+WITH live_runs AS (
+	SELECT r.id, r.pipeline
+	FROM pipelines_runs AS r
+	INNER JOIN pipelines AS p ON r.pipeline = p.id
+	INNER JOIN connections AS c ON p.connection = c.id
+	INNER JOIN workspaces AS w ON c.workspace = w.id
+	WHERE w.organization = $1 AND r.end_time IS NULL
+),
+s AS (
+	SELECT r.id,
+		COALESCE(SUM(m.passed_0), 0) AS passed_0,
+		COALESCE(SUM(m.passed_1), 0) AS passed_1,
+		COALESCE(SUM(m.passed_2), 0) AS passed_2,
+		COALESCE(SUM(m.passed_3), 0) AS passed_3,
+		COALESCE(SUM(m.passed_4), 0) AS passed_4,
+		COALESCE(SUM(m.passed_5), 0) AS passed_5,
+		COALESCE(SUM(m.failed_0), 0) AS failed_0,
+		COALESCE(SUM(m.failed_1), 0) AS failed_1,
+		COALESCE(SUM(m.failed_2), 0) AS failed_2,
+		COALESCE(SUM(m.failed_3), 0) AS failed_3,
+		COALESCE(SUM(m.failed_4), 0) AS failed_4,
+		COALESCE(SUM(m.failed_5), 0) AS failed_5
+	FROM live_runs AS r
+	LEFT JOIN pipelines_metrics AS m ON m.pipeline = r.pipeline
+	GROUP BY r.id
+)
+UPDATE pipelines_runs AS r
+SET function = '',
+	end_time = $2,
+	passed_0 = r.passed_0 + s.passed_0,
+	passed_1 = r.passed_1 + s.passed_1,
+	passed_2 = r.passed_2 + s.passed_2,
+	passed_3 = r.passed_3 + s.passed_3,
+	passed_4 = r.passed_4 + s.passed_4,
+	passed_5 = r.passed_5 + s.passed_5,
+	failed_0 = r.failed_0 + s.failed_0,
+	failed_1 = r.failed_1 + s.failed_1,
+	failed_2 = r.failed_2 + s.failed_2,
+	failed_3 = r.failed_3 + s.failed_3,
+	failed_4 = r.failed_4 + s.failed_4,
+	failed_5 = r.failed_5 + s.failed_5,
+	error = $3
+FROM s
+WHERE r.id = s.id AND r.end_time IS NULL
+`
 
 // TestWorkspaceCreation tests a workspace creation. It tests that a warehouse
 // with the provided platform and settings can be initialized.

--- a/core/organization.go
+++ b/core/organization.go
@@ -808,7 +808,7 @@ func (this *Organization) SetStatus(ctx context.Context, enabled bool) error {
 			if result.RowsAffected() > 0 {
 				// Update the pipelines for the terminated live runs.
 				const pipelinesQuery = "WITH ended_runs AS (\n" +
-					"SELECT r.pipeline, r.cursor\n" +
+					"SELECT r.pipeline\n" +
 					"FROM pipelines_runs AS r\n" +
 					"INNER JOIN pipelines AS p ON r.pipeline = p.id\n" +
 					"INNER JOIN connections AS c ON p.connection = c.id\n" +
@@ -816,7 +816,7 @@ func (this *Organization) SetStatus(ctx context.Context, enabled bool) error {
 					"WHERE w.organization = $1 AND r.end_time = $2 AND r.error = $3::text\n" +
 					")\n" +
 					"UPDATE pipelines AS p\n" +
-					"SET cursor = ended_runs.cursor, health = 'Healthy'::health\n" +
+					"SET health = 'Healthy'::health\n" +
 					"FROM ended_runs\n" +
 					"WHERE p.id = ended_runs.pipeline"
 				_, err = tx.Exec(ctx, pipelinesQuery, n.ID, endTime, errorMessage)

--- a/test/krenalistester/support_types.go
+++ b/test/krenalistester/support_types.go
@@ -72,6 +72,7 @@ type ConnectionToCreate struct {
 
 type DummySettings struct {
 	URLForDispatchingEvents string `json:"urlForDispatchingEvents"`
+	OperationDelay          string `json:"operationDelay,omitempty"`
 }
 
 type PipelineRun struct {

--- a/test/organization_disabled_test.go
+++ b/test/organization_disabled_test.go
@@ -102,8 +102,65 @@ func TestOrganizationDisabled(t *testing.T) {
 	// Create an API key while the organization is still enabled.
 	apiKey := k.CreateWorkspaceRestrictedAPIKey("Events ingestion key")
 
+	longRunningPipelineParams := func(name string) krenalistester.PipelineToSet {
+		return krenalistester.PipelineToSet{
+			Name:    name,
+			Enabled: true,
+			InSchema: types.Object([]types.Property{
+				{Name: "email", Type: types.String(), Nullable: true},
+				{Name: "firstName", Type: types.String(), Nullable: true},
+			}),
+			OutSchema: types.Object([]types.Property{
+				{Name: "email", Type: types.String().WithMaxLength(300), ReadOptional: true},
+				{Name: "first_name", Type: types.String().WithMaxLength(300), ReadOptional: true},
+			}),
+			Transformation: &krenalistester.Transformation{
+				Mapping: map[string]string{
+					"email":      "email",
+					"first_name": "firstName",
+				},
+			},
+		}
+	}
+	longRunningDummy1 := k.CreateDummyWithSettings("Long-running Dummy 1 (source)", krenalistester.Source, krenalistester.DummySettings{
+		OperationDelay: "2m",
+	})
+	longRunningPipeline1 := k.CreatePipeline(longRunningDummy1, "User", longRunningPipelineParams("Long-running import users from Dummy 1"))
+	longRunningDummy2 := k.CreateDummyWithSettings("Long-running Dummy 2 (source)", krenalistester.Source, krenalistester.DummySettings{
+		OperationDelay: "2m",
+	})
+	longRunningPipeline2 := k.CreatePipeline(longRunningDummy2, "User", longRunningPipelineParams("Long-running import users from Dummy 2"))
+	longRunningRuns := []string{
+		k.StartPipelineRun(longRunningPipeline1),
+		k.StartPipelineRun(longRunningPipeline2),
+	}
+
 	// Disable the organization.
 	k.SetOrganizationStatus(orgID, false)
+
+	t.Run("live runs are interrupted when disabled", func(t *testing.T) {
+		deadline := time.Now().Add(10 * time.Second)
+		for _, run := range longRunningRuns {
+			for {
+				var completed bool
+				k.QueryRowTestDatabase(t.Context(), &completed,
+					"SELECT end_time IS NOT NULL FROM pipelines_runs WHERE id = $1", run)
+				if completed {
+					var runError string
+					k.QueryRowTestDatabase(t.Context(), &runError,
+						"SELECT error FROM pipelines_runs WHERE id = $1", run)
+					if runError != "organization has been disabled" {
+						t.Fatalf("expected run error %q for run %s, got %q", "organization has been disabled", run, runError)
+					}
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("run %s was not interrupted after disabling the organization", run)
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	})
 
 	// The organization endpoint must still be reachable and must report the new
 	// status.


### PR DESCRIPTION
```
core: preserve pipeline cursor after failed import

Previously, Core.endLiveRun could copy a live run's cursor back to the
pipeline after a failed import, allowing a later import to resume from
an advanced cursor and skip records that had not actually been persisted
to the warehouse. The same could happen when an organization was
disabled and its live runs were terminated.

Only copy the run cursor back to the pipeline when the import completes
normally. Imports terminated with an error still update pipeline health,
but leave the previous pipeline cursor unchanged.

This is intentionally conservative rather than optimal. A later change
should save the cursor once all records covered by it have been
persisted to the warehouse, so failed imports can resume from the latest
safe point instead of restarting from the previous pipeline cursor.
```