### PR TITLE
admin: re-enable pipeline "Add" button only after fullscreen closing

### DIFF
--- a/admin/src/components/routes/PipelineWrapper/PipelineHeader.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineHeader.tsx
@@ -38,7 +38,7 @@ const PipelineHeader = () => {
 		}
 
 		const handleMouseEnter = () => {
-			if (button.disabled) {
+			if (button.classList.contains('pipeline__header-save--fullscreen-closing-disabled')) {
 				button.addEventListener('mouseleave', handleMouseLeave, { once: true });
 			}
 		};


### PR DESCRIPTION
This commit fixes a bug where the pipeline "Add/Save" button would become unexpectedly re-enabled after hovering over it while disabled.

The fix has been applied by restricting the re-enabling logic to only trigger when the button is disabled due to the fullscreen closing animation, preserving the disabled state in all the other cases.