### PR TITLE
all: add vendored .gitattributes files again to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# Ignore the '.gitattributes' files within the Go vendor, as they would be read
-# by Git and the files inside the vendor would be modified, which, instead,
-# should be left as they are.
-/vendor/**/.gitattributes
-
 # Ignore the binaries produced by `go build`.
 /krenalis
 /krenalis.exe

--- a/vendor/github.com/99designs/keyring/.gitattributes
+++ b/vendor/github.com/99designs/keyring/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/vendor/github.com/Microsoft/go-winio/.gitattributes
+++ b/vendor/github.com/Microsoft/go-winio/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/vendor/github.com/containerd/platforms/.gitattributes
+++ b/vendor/github.com/containerd/platforms/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/vendor/github.com/danieljoos/wincred/.gitattributes
+++ b/vendor/github.com/danieljoos/wincred/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/vendor/github.com/distribution/reference/.gitattributes
+++ b/vendor/github.com/distribution/reference/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/vendor/github.com/gabriel-vasile/mimetype/.gitattributes
+++ b/vendor/github.com/gabriel-vasile/mimetype/.gitattributes
@@ -1,0 +1,1 @@
+testdata/* linguist-vendored

--- a/vendor/github.com/getsentry/sentry-go/.gitattributes
+++ b/vendor/github.com/getsentry/sentry-go/.gitattributes
@@ -1,0 +1,5 @@
+# Tell Git to use LF for line endings on all platforms.
+# Required to have correct test data on Windows.
+# https://github.com/mvdan/github-actions-golang#caveats
+# https://github.com/actions/checkout/issues/135#issuecomment-613361104
+* text eol=lf

--- a/vendor/github.com/klauspost/compress/.gitattributes
+++ b/vendor/github.com/klauspost/compress/.gitattributes
@@ -1,0 +1,3 @@
+* -text
+*.bin -text -diff
+*.md text eol=lf

--- a/vendor/github.com/moby/go-archive/.gitattributes
+++ b/vendor/github.com/moby/go-archive/.gitattributes
@@ -1,0 +1,2 @@
+*.go -text diff=golang
+*.go text eol=lf

--- a/vendor/go.opentelemetry.io/otel/.gitattributes
+++ b/vendor/go.opentelemetry.io/otel/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
## Commit message

```
all: add vendored .gitattributes files again to the repository

Commit 38f8fa9bd7baa9b9a447c33db24bc2eb4802afb6 had excluded the
'.gitattributes' files present in Go's vendor directory from Git, with
the aim of ignoring them and preventing the directives they contain from
being applied.

In practice, however, the directives are applied regardless.

Moreover, one of the problems this can currently cause is that the
'.gitattributes' files, being unversioned, are no longer tied to the
repository or to the versions of the vendored modules, and may therefore
differ from one machine to another, leading to unexpected behavior.

A further problem is that, since these files are unversioned, switching
branches applies the directives from whatever '.gitattributes' files
happened to be present locally the last time 'go mod vendor' was run —
regardless of the current state of the repository or the branch you're
on — causing unexpected changes to versioned files.

For these reasons, this commit removes the ignore rule and re-adds the
'.gitattributes' files to the vendor directory.
```