### PR TITLE
cmd, core: fix not initialized database error handling

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -26,15 +26,15 @@ import (
 	"time"
 
 	"github.com/krenalis/krenalis/cmd/internal/mcp"
-	"github.com/krenalis/krenalis/core"
+	corePkg "github.com/krenalis/krenalis/core"
 	"github.com/krenalis/krenalis/tools/prometheus"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const telemetryLevelErrors = core.TelemetryLevelErrors
-const telemetryLevelAll = core.TelemetryLevelAll
+const telemetryLevelErrors = corePkg.TelemetryLevelErrors
+const telemetryLevelAll = corePkg.TelemetryLevelAll
 
 // Run runs the server.
 // Cancel ctx to terminate the execution. If ctx is canceled, Run does not
@@ -44,7 +44,7 @@ const telemetryLevelAll = core.TelemetryLevelAll
 // initDBIfEmpty, a member specific for Docker scenarios is initialized.
 func Run(ctx context.Context, config *Config, assetsFS fs.FS, initDBIfEmpty, initDockerMember bool) error {
 
-	conf := core.Config{
+	conf := corePkg.Config{
 		KMS:                           config.KMS,
 		OrganizationsAPIKey:           config.OrganizationsAPIKey,
 		DB:                            config.DB,
@@ -61,14 +61,17 @@ func Run(ctx context.Context, config *Config, assetsFS fs.FS, initDBIfEmpty, ini
 
 	// Choose the transformation function provider setting.
 	if config.Transformers.Lambda.NodeJS.Runtime != "" || config.Transformers.Lambda.Python.Runtime != "" {
-		conf.FunctionProvider = core.LambdaConfig(config.Transformers.Lambda)
+		conf.FunctionProvider = corePkg.LambdaConfig(config.Transformers.Lambda)
 	}
 	if config.Transformers.Local.NodeJSExecutable != "" || config.Transformers.Local.PythonExecutable != "" {
-		conf.FunctionProvider = core.LocalConfig(config.Transformers.Local)
+		conf.FunctionProvider = corePkg.LocalConfig(config.Transformers.Local)
 	}
 
-	core, err := core.New(ctx, &conf)
+	core, err := corePkg.New(ctx, &conf)
 	if err != nil {
+		if _, ok := errors.AsType[*corePkg.DBNotInitializedError](err); ok {
+			return fmt.Errorf("%s (Krenalis's internal PostgreSQL may not be initialized. Try starting Krenalis with the -init-db-if-empty flag)", err)
+		}
 		return err
 	}
 	defer core.Close(ctx)

--- a/core/core.go
+++ b/core/core.go
@@ -170,8 +170,20 @@ type ExpressionToBeExtracted struct {
 	Type  types.Type `json:"type"`
 }
 
+// DBNotInitializedError is returned by New in those circumstances where the
+// Krenalis database appears not to have been initialized.
+type DBNotInitializedError struct {
+	msg string
+}
+
+func (e *DBNotInitializedError) Error() string {
+	return e.msg
+}
+
 // New returns a *Core instance.
 // If another Core instance is active, it returns an error.
+// If a condition occurs where the Krenalis database appears not to have been
+// initialized, returns an error of type *DBNotInitializedError.
 func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 
 	if !coreActive.CompareAndSwap(false, true) {
@@ -271,9 +283,8 @@ func New(ctx context.Context, conf *Config) (_ *Core, err error) {
 	}
 	core.state, err = state.New(ctx, db, kms, connectorsOAuth, sendStats)
 	if err != nil {
-		// Return a clear error if the database has not been initialized.
-		if dbpkg.IsUndefinedTable(err) {
-			return nil, fmt.Errorf("%s (Krenalis's internal PostgreSQL may not be initialized. Try starting Krenalis with the -init-db-if-empty flag)", err)
+		if _, ok := errors.AsType[*state.DBNotInitializedError](err); ok {
+			return nil, &DBNotInitializedError{msg: err.Error()}
 		}
 		return nil, err
 	}

--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -18,7 +18,20 @@ import (
 	"github.com/krenalis/krenalis/warehouses"
 )
 
+// DBNotInitializedError is returned by New in those circumstances where the
+// Krenalis database appears not to have been initialized.
+type DBNotInitializedError struct {
+	msg string
+}
+
+func (e *DBNotInitializedError) Error() string {
+	return e.msg
+}
+
 // load loads the state.
+//
+// If a condition occurs where the Krenalis database appears not to have been
+// initialized, returns an error of type *DBNotInitializedError.
 func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuthCredentials) error {
 
 	// Read all connectors.
@@ -201,13 +214,21 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 		_ = tx.Rollback(ctx)
 	}()
 
-	// Read the installation ID, the KMS-encrypted cookie, OAuth, and notification keys, and the API key pepper.
+	// Read the installation ID, the KMS-encrypted cookie, OAuth, and
+	// notification keys, and the API key pepper.
+	//
+	// This is the first query run against the database, so the undefined-table
+	// check below detects (with a good probability) an uninitialized database.
+	// Move it if a query is added before this one.
 	var kmsEncryptedCookieKey, kmsEncryptedOAuthKey, kmsEncryptedNotificationKey, kmsEncryptedAPIKeyPepper []byte
 	err = tx.QueryRow(ctx, "SELECT installation_id, kms_encrypted_cookie_key, kms_encrypted_oauth_key,"+
 		" kms_encrypted_notification_key, kms_encrypted_api_key_pepper FROM metadata").Scan(
 		&state.metadata.installationID, &kmsEncryptedCookieKey, &kmsEncryptedOAuthKey,
 		&kmsEncryptedNotificationKey, &kmsEncryptedAPIKeyPepper)
 	if err != nil {
+		if db.IsUndefinedTable(err) {
+			return &DBNotInitializedError{msg: err.Error()}
+		}
 		if err == sql.ErrNoRows {
 			return errors.New("cannot load metadata: no rows found in table; expected exactly one row")
 		}

--- a/core/internal/state/state.go
+++ b/core/internal/state/state.go
@@ -92,9 +92,11 @@ type OAuthCredentials struct {
 }
 
 // New returns a state given the database, the key manager, the 64-byte master
-// key, and the OAuth
-// client credentials for connectors.
-// sendStats indicates whether the state should send statistics or not.
+// key, and the OAuth client credentials for connectors. sendStats indicates
+// whether the state should send statistics or not.
+//
+// If a condition occurs where the Krenalis database appears not to have been
+// initialized, returns an error of type *DBNotInitializedError.
 func New(ctx context.Context, db *db.DB, kms kms.Kms, credentials map[string]*OAuthCredentials, sendStats bool) (*State, error) {
 
 	id, err := uuid.NewUUID()
@@ -129,7 +131,7 @@ func New(ctx context.Context, db *db.DB, kms kms.Kms, credentials map[string]*OA
 	err = state.load(ctx, credentials)
 	if err != nil {
 		state.notifications.Close()
-		return nil, err
+		return nil, fmt.Errorf("cannot load Krenalis state: %w", err)
 	}
 
 	// Keep the state updated.


### PR DESCRIPTION
## Commit message

```
cmd, core: fix not initialized database error handling

Previously, when a Krenalis database hadn't been initialized, a specific
error was printed that explained how to resolve the issue.

This no longer works; the commit that broke this behavior is the
following: https://github.com/krenalis/krenalis/commit/c677d9408cf61ca02ea53b7704f0d81350c4daf3

The problem is that the captured error is now embedded into a string
instead:

https://github.com/krenalis/krenalis/blob/ecff13b29d938c8128dfe0cb51d22fd33c877c37/core/internal/state/load.go#L214

So, this commit restores the check by defining a dedicated error type
and wrapping it so that it can be caught further up the call stack.
```