### PR TITLE
core: preserve pipeline cursor after failed import

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1294,9 +1294,14 @@ func (core *Core) endLiveRun(ctx context.Context, run *state.PipelineRun, reason
 					return nil, err
 				}
 			}
-			// Update the pipeline's cursor.
-			res, err = tx.Exec(ctx, "UPDATE pipelines SET cursor = (SELECT cursor FROM pipelines_runs WHERE id = $1), health = $2 WHERE id = $3",
-				n.ID, n.Health, pipeline)
+			// Update the pipeline's cursor only when the run completed normally.
+			if reason == nil {
+				res, err = tx.Exec(ctx, "UPDATE pipelines SET cursor = (SELECT cursor FROM pipelines_runs WHERE id = $1), health = $2 WHERE id = $3",
+					n.ID, n.Health, pipeline)
+			} else {
+				res, err = tx.Exec(ctx, "UPDATE pipelines SET health = $1 WHERE id = $2",
+					n.Health, pipeline)
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/core/organization.go
+++ b/core/organization.go
@@ -814,8 +814,8 @@ func (this *Organization) SetStatus(ctx context.Context, enabled bool) error {
 }
 
 // endOrganizationLiveRunsQuery ends all live pipeline runs for an organization.
-// For each run it terminates, it records the final metrics, advances the related
-// pipeline cursor, marks the pipeline as healthy, and records the termination error.
+// For each run it terminates, it records the final metrics, marks the pipeline
+// as healthy, and records the termination error.
 const endOrganizationLiveRunsQuery = `
 WITH live_runs AS (
 	SELECT r.id, r.pipeline
@@ -862,12 +862,11 @@ ended_runs AS (
 		error = $3
 	FROM s
 	WHERE r.id = s.id AND r.end_time IS NULL
-	RETURNING r.pipeline, r.cursor
+	RETURNING r.pipeline
 ),
 updated_pipelines AS (
 	UPDATE pipelines AS p
-	SET cursor = ended_runs.cursor,
-		health = 'Healthy'::health
+	SET health = 'Healthy'::health
 	FROM ended_runs
 	WHERE p.id = ended_runs.pipeline
 	RETURNING p.id


### PR DESCRIPTION
```
core: preserve pipeline cursor after failed import

Previously, Core.endLiveRun could copy a live run's cursor back to the
pipeline after a failed import, allowing a later import to resume from
an advanced cursor and skip records that had not actually been persisted
to the warehouse. The same could happen when an organization was
disabled and its live runs were terminated.

Only copy the run cursor back to the pipeline when the import completes
normally. Imports terminated with an error still update pipeline health,
but leave the previous pipeline cursor unchanged.

This is intentionally conservative rather than optimal. A later change
should save the cursor once all records covered by it have been
persisted to the warehouse, so failed imports can resume from the latest
safe point instead of restarting from the previous pipeline cursor.
```