### PR TITLE
core/internal/state: file storage destination documentation

### DIFF
--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -162,8 +162,8 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 				// settings.
 				c.HasDestinationSettings = true
 				c.Documentation.Destination = asDest.Documentation
-				if c.Documentation.Source.Summary == "" {
-					c.Documentation.Source.Summary = "Exports users to a file on " + c.Label
+				if c.Documentation.Destination.Summary == "" {
+					c.Documentation.Destination.Summary = "Exports users to a file on " + c.Label
 				}
 			}
 		case connectors.MessageBrokerSpec:


### PR DESCRIPTION
```
core/internal/state: file storage destination documentation

Show the default documentation summary on file storage destinations when
no custom summary is configured.

Previously, the default destination summary was written to the source
documentation instead.
```