### PR TITLE
connectors, core/internal/state: use profiles in destination summaries

### DIFF
--- a/connectors/brevo/brevo.go
+++ b/connectors/brevo/brevo.go
@@ -55,7 +55,7 @@ func init() {
 			HasSettings: true,
 			SendingMode: connectors.Server,
 			Documentation: connectors.RoleDocumentation{
-				Summary:  "Export users as contacts and send events to Brevo",
+				Summary:  "Export profiles as contacts and send events to Brevo",
 				Overview: destinationOverview,
 			},
 		},

--- a/connectors/clickhouse/documentation/destination/overview.md
+++ b/connectors/clickhouse/documentation/destination/overview.md
@@ -3,11 +3,11 @@ ClickHouse is an open-source, column-oriented database optimized for real-time a
 
 ## What can you do with this?
 
-Using this connector you can write the unified users from your data warehouse into a ClickHouse table and keep it synchronized.
+Using this connector you can write the unified profiles from your data warehouse into a ClickHouse table and keep it synchronized.
 
 ## What does it require?
 
-* A ClickHouse database with a table in which to store the users.
+* A ClickHouse database with a table in which to store the profiles.
 
 > ClickHouse is a trademark of ClickHouse, Inc.
 > This connector is not affiliated with or endorsed by ClickHouse, Inc.

--- a/connectors/clickhouse/documentation/source/overview.md
+++ b/connectors/clickhouse/documentation/source/overview.md
@@ -4,7 +4,7 @@ ClickHouse is an open-source, column-oriented database optimized for real-time a
 
 ## What can you do with this?
 
-Using this connector you can read users from a ClickHouse database, store them in your data warehouse, and unify them as users within Krenalis.
+Using this connector you can read users from a ClickHouse database, store them in your data warehouse, and unify them as profiles within Krenalis.
 
 ## What does it require?
 

--- a/connectors/csv/documentation/destination/overview.md
+++ b/connectors/csv/documentation/destination/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you export unified users from your data warehouse (users consolidated through identity resolution) into a CSV file and save it to a storage location, such as S3 or SFTP.
+This connector lets you export unified profiles from your data warehouse (users consolidated through identity resolution) into a CSV file and save it to a storage location, such as S3 or SFTP.
 
 ## What does it require?
 

--- a/connectors/csv/documentation/source/overview.md
+++ b/connectors/csv/documentation/source/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you import users from a CSV file into your data warehouse and unify them as users within Krenalis. 
+This connector lets you import users from a CSV file into your data warehouse and unify them as profiles within Krenalis. 
 
 ## What does it require?
 

--- a/connectors/dummy/documentation/destination/overview.md
+++ b/connectors/dummy/documentation/destination/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector simulates an API to export users into and send events for testing purposes. It is also used in Krenalis's internal tests.
+This connector simulates an API to export profiles into and send events for testing purposes. It is also used in Krenalis's internal tests.
 
 ## What does it require?
 

--- a/connectors/dummy/dummy.go
+++ b/connectors/dummy/dummy.go
@@ -50,7 +50,7 @@ func init() {
 			SendingMode: connectors.Server,
 			HasSettings: true,
 			Documentation: connectors.RoleDocumentation{
-				Summary:  "Export users as customers and send events to Dummy",
+				Summary:  "Export profiles as customers and send events to Dummy",
 				Overview: destinationOverview,
 			},
 		},

--- a/connectors/excel/documentation/destination/overview.md
+++ b/connectors/excel/documentation/destination/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you export unified users from your data warehouse (users consolidated through identity resolution) into an Excel file and save it to a storage location, such as S3 or SFTP.
+This connector lets you export unified profiles from your data warehouse (users consolidated through identity resolution) into an Excel file and save it to a storage location, such as S3 or SFTP.
 
 ## What does it require?
 

--- a/connectors/excel/documentation/source/overview.md
+++ b/connectors/excel/documentation/source/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you import users from an Excel file into your data warehouse and unify them as users within Krenalis.
+This connector lets you import users from an Excel file into your data warehouse and unify them as profiles within Krenalis.
 
 ## What does it require?
 

--- a/connectors/http/documentation/destination/overview.md
+++ b/connectors/http/documentation/destination/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you send a POST request to an HTTP server with a file (e.g., CSV or Excel) containing the unified users from your data warehouse.
+This connector lets you send a POST request to an HTTP server with a file (e.g., CSV or Excel) containing the unified profiles from your data warehouse.
 
 ## What does it require?
 

--- a/connectors/http/documentation/source/overview.md
+++ b/connectors/http/documentation/source/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you read a file (e.g., CSV or Excel) with user data from an HTTP server, import them into your data warehouse, and unify them as users in Krenalis.
+This connector lets you read a file (e.g., CSV or Excel) with user data from an HTTP server, import them into your data warehouse, and unify them as profiles in Krenalis.
 
 ## What does it require?
 

--- a/connectors/hubspot/documentation/destination/overview.md
+++ b/connectors/hubspot/documentation/destination/overview.md
@@ -3,7 +3,7 @@ HubSpot is a cloud application that offers tools for customer relationship manag
 
 ## What can you do with this?
 
-Using this connector you can create and update unified Krenalis users from your data warehouse in HubSpot as contacts.
+Using this connector you can create and update unified Krenalis profiles from your data warehouse in HubSpot as contacts.
 
 ## What does it require?
 

--- a/connectors/hubspot/documentation/source/overview.md
+++ b/connectors/hubspot/documentation/source/overview.md
@@ -3,7 +3,7 @@ HubSpot is a cloud application that offers tools for customer relationship manag
 
 ## What can you do with this?
 
-Using this connector you can read contacts from HubSpot, import them into your data warehouse, and unify them as users in Krenalis.
+Using this connector you can read contacts from HubSpot, import them into your data warehouse, and unify them as profiles in Krenalis.
 
 ## What does it require?
 

--- a/connectors/hubspot/hubspot.go
+++ b/connectors/hubspot/hubspot.go
@@ -52,7 +52,7 @@ func init() {
 			Targets:     connectors.TargetUser,
 			HasSettings: true,
 			Documentation: connectors.RoleDocumentation{
-				Summary:  "Export users as contacts to HubSpot",
+				Summary:  "Export profiles as contacts to HubSpot",
 				Overview: destinationOverview,
 			},
 		},

--- a/connectors/json/documentation/destination/overview.md
+++ b/connectors/json/documentation/destination/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you export unified users from your data warehouse (users consolidated through identity resolution) into a JSON file and save it to a storage location, such as S3 or SFTP.
+This connector lets you export unified profiles from your data warehouse (users consolidated through identity resolution) into a JSON file and save it to a storage location, such as S3 or SFTP.
 
 ## What does it require?
 

--- a/connectors/json/documentation/source/overview.md
+++ b/connectors/json/documentation/source/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you import users from a JSON file into your data warehouse and unify them as users within Krenalis.
+This connector lets you import users from a JSON file into your data warehouse and unify them as profiles within Krenalis.
 
 ## What does it require?
 

--- a/connectors/klaviyo/documentation/destination/overview.md
+++ b/connectors/klaviyo/documentation/destination/overview.md
@@ -3,7 +3,7 @@ Klaviyo is an email marketing and automation platform that enables businesses to
 
 ## What can you do with this?
 
-Using this connector you can create and update unified Krenalis users from your data warehouse in Klaviyo as profiles.
+Using this connector you can create and update unified Krenalis profiles from your data warehouse in Klaviyo as profiles.
 
 ## What does it require?
 

--- a/connectors/klaviyo/documentation/source/overview.md
+++ b/connectors/klaviyo/documentation/source/overview.md
@@ -3,7 +3,7 @@ Klaviyo is an email marketing and automation platform that enables businesses to
 
 ## What can you do with this?
 
-Using this connector you can read profiles from Klaviyo, import them into your data warehouse, and unify them as users in Krenalis.
+Using this connector you can read profiles from Klaviyo, import them into your data warehouse, and unify them as profiles in Krenalis.
 
 ## What does it require?
 

--- a/connectors/klaviyo/klaviyo.go
+++ b/connectors/klaviyo/klaviyo.go
@@ -55,7 +55,7 @@ func init() {
 			HasSettings: true,
 			SendingMode: connectors.Server,
 			Documentation: connectors.RoleDocumentation{
-				Summary:  "Export users as profiles and send events to Klaviyo",
+				Summary:  "Export profiles and send events to Klaviyo",
 				Overview: destinationOverview,
 			},
 		},

--- a/connectors/mailchimp/documentation/destination/overview.md
+++ b/connectors/mailchimp/documentation/destination/overview.md
@@ -3,7 +3,7 @@ Mailchimp is an email marketing platform that helps businesses design and send m
 
 ## What can you do with this?
 
-Using this connector you can you create and update unified Krenalis users from your data warehouse in Mailchimp as contacts.
+Using this connector you can you create and update unified Krenalis profiles from your data warehouse in Mailchimp as contacts.
 
 ## What does it require?
 

--- a/connectors/mailchimp/documentation/source/overview.md
+++ b/connectors/mailchimp/documentation/source/overview.md
@@ -3,7 +3,7 @@ Mailchimp is an email marketing platform that helps businesses design and send m
 
 ## What can you do with this?
 
-Using this connector you can read contacts from Mailchimp, import them into your data warehouse, and unify them as users in Krenalis.
+Using this connector you can read contacts from Mailchimp, import them into your data warehouse, and unify them as profiles in Krenalis.
 
 ## What does it require?
 

--- a/connectors/mailchimp/mailchimp.go
+++ b/connectors/mailchimp/mailchimp.go
@@ -56,7 +56,7 @@ func init() {
 			Targets:     connectors.TargetUser,
 			HasSettings: true,
 			Documentation: connectors.RoleDocumentation{
-				Summary:  "Export users as contacts to Mailchimp",
+				Summary:  "Export profiles as contacts to Mailchimp",
 				Overview: destinationOverview,
 			},
 		},

--- a/connectors/mailerlite/mailerlite.go
+++ b/connectors/mailerlite/mailerlite.go
@@ -65,7 +65,7 @@ func init() {
 			Targets:     connectors.TargetUser,
 			HasSettings: true,
 			Documentation: connectors.RoleDocumentation{
-				Summary:  "Export users as subscribers to MailerLite",
+				Summary:  "Export profiles as subscribers to MailerLite",
 				Overview: destinationOverview,
 			},
 		},

--- a/connectors/mysql/documentation/destination/overview.md
+++ b/connectors/mysql/documentation/destination/overview.md
@@ -3,11 +3,11 @@ MySQL is an open-source relational database management system. It's popular for 
 
 ## What can you do with this?
 
-This connector lets you write the unified users from your data warehouse into a MySQL table and keep it synchronized.
+This connector lets you write the unified profiles from your data warehouse into a MySQL table and keep it synchronized.
 
 ## What does it require?
 
-* A MySQL database with a table in which to store the users.
+* A MySQL database with a table in which to store the profiles.
 
 > MySQL is a trademark of Oracle Corporation.
 > This connector is not affiliated with or endorsed by Oracle Corporation.

--- a/connectors/mysql/documentation/source/overview.md
+++ b/connectors/mysql/documentation/source/overview.md
@@ -3,7 +3,7 @@ MySQL is an open-source relational database management system. It's popular for 
 
 ## What can you do with this?
 
-This connector lets you read users from a MySQL database, store them in your data warehouse, and unify them as users within Krenalis.
+This connector lets you read users from a MySQL database, store them in your data warehouse, and unify them as profiles within Krenalis.
 
 ## What does it require?
 

--- a/connectors/parquet/documentation/destination/overview.md
+++ b/connectors/parquet/documentation/destination/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you export unified users from your data warehouse (users consolidated through identity resolution) into a Parquet file and save it to a storage location, such as S3 or SFTP.
+This connector lets you export unified profiles from your data warehouse (users consolidated through identity resolution) into a Parquet file and save it to a storage location, such as S3 or SFTP.
 
 ## What does it require?
 

--- a/connectors/parquet/documentation/source/overview.md
+++ b/connectors/parquet/documentation/source/overview.md
@@ -1,7 +1,7 @@
 
 ## What can you do with this?
 
-This connector lets you  import users from a Parquet file into your data warehouse and unify them as users within Krenalis.
+This connector lets you  import users from a Parquet file into your data warehouse and unify them as profiles within Krenalis.
 
 ## What does it require?
 

--- a/connectors/postgresql/documentation/destination/overview.md
+++ b/connectors/postgresql/documentation/destination/overview.md
@@ -3,8 +3,8 @@ PostgreSQL is an advanced open-source relational database system known for its r
 
 ## What can you do with this?
 
-This connector lets you write the unified users from your data warehouse into a PostgreSQL table and keep it synchronized.
+This connector lets you write the unified profiles from your data warehouse into a PostgreSQL table and keep it synchronized.
 
 ## What does it require?
 
-* A PostgreSQL database with a table in which to store the users.
+* A PostgreSQL database with a table in which to store the profiles.

--- a/connectors/postgresql/documentation/source/overview.md
+++ b/connectors/postgresql/documentation/source/overview.md
@@ -3,7 +3,7 @@ PostgreSQL is an advanced open-source relational database system known for its r
 
 ## What can you do with this?
 
-This connector lets you read users from a PostgreSQL database, store them in your data warehouse, and unify them as users within Krenalis.
+This connector lets you read users from a PostgreSQL database, store them in your data warehouse, and unify them as profiles within Krenalis.
 
 ## What does it require?
 

--- a/connectors/s3/documentation/destination/overview.md
+++ b/connectors/s3/documentation/destination/overview.md
@@ -3,7 +3,7 @@ S3 (Simple Storage Service) is a scalable object storage service provided by Ama
 
 ## What can you do with this?
 
-This connector exports unified users (i.e., users consolidated through identity resolution) from your data warehouse in various file formats, such as CSV or Excel, and sends them directly to S3 buckets
+This connector exports unified profiles (i.e., users consolidated through identity resolution) from your data warehouse in various file formats, such as CSV or Excel, and sends them directly to S3 buckets
 
 ## What does it require?
 

--- a/connectors/s3/documentation/source/overview.md
+++ b/connectors/s3/documentation/source/overview.md
@@ -3,7 +3,7 @@ S3 (Simple Storage Service) is a scalable object storage service provided by Ama
 
 ## What can you do with this?
 
-This connector lets you import user data from files stored in S3 buckets into your data warehouse. You can unify this data as users within Krenalis by importing files in various formats, such as CSV, Excel, or others.
+This connector lets you import user data from files stored in S3 buckets into your data warehouse. You can unify this data as profiles within Krenalis by importing files in various formats, such as CSV, Excel, or others.
 
 ## What does it require?
 

--- a/connectors/sftp/documentation/destination/overview.md
+++ b/connectors/sftp/documentation/destination/overview.md
@@ -3,7 +3,7 @@ SFTP (Secure File Transfer Protocol) is a secure network protocol used for trans
 
 ## What can you do with this?
 
-This connector lets you export unified users. These are users that have been consolidated through identity resolution. The exported data can be in formats like CSV or Excel, and it's securely sent to your SFTP server using the SFTP protocol.
+This connector lets you export unified profiles. These are users that have been consolidated through identity resolution. The exported data can be in formats like CSV or Excel, and it's securely sent to your SFTP server using the SFTP protocol.
 
 ## What does it require?
 

--- a/connectors/sftp/documentation/source/overview.md
+++ b/connectors/sftp/documentation/source/overview.md
@@ -3,7 +3,7 @@ SFTP (Secure File Transfer Protocol) is a secure network protocol used for trans
 
 ## What can you do with this?
 
-This connector lets you import user data from files stored in a SFTP server into your data warehouse. Once imported, this data can be unified as users within Krenalis. Supported file formats include CSV, Excel, and others.
+This connector lets you import user data from files stored in a SFTP server into your data warehouse. Once imported, this data can be unified as profiles within Krenalis. Supported file formats include CSV, Excel, and others.
 
 ## What does it require?
 

--- a/connectors/skills/create-application/references/application-spec.md
+++ b/connectors/skills/create-application/references/application-spec.md
@@ -53,7 +53,7 @@ func init() {
         //     HasSettings: true,
         //     SendingMode: connectors.Server, // Client / Server / ClientAndServer; must not be None if TargetEvent is set
         //     Documentation: connectors.RoleDocumentation{
-        //         Summary:  "Export users to <App> and/or send events",
+        //         Summary:  "Export profiles to <App> and/or send events",
         //         Overview: "<longer description>",
         //     },
         // },

--- a/connectors/snowflake/documentation/destination/overview.md
+++ b/connectors/snowflake/documentation/destination/overview.md
@@ -3,11 +3,11 @@ Snowflake is a cloud-based data warehousing platform for storing and analyzing l
 
 ## What can you do with this?
 
-This connector lets you write the unified users from your data warehouse into a Snowflake table and keep it synchronized.
+This connector lets you write the unified profiles from your data warehouse into a Snowflake table and keep it synchronized.
 
 ## What does it require?
 
-* A Snowflake database with a table in which to store the users.
+* A Snowflake database with a table in which to store the profiles.
 
 > Snowflake is a trademark of Snowflake Inc.
 > This connector is not affiliated with or endorsed by Snowflake Inc.

--- a/connectors/snowflake/documentation/source/overview.md
+++ b/connectors/snowflake/documentation/source/overview.md
@@ -3,7 +3,7 @@ Snowflake is a cloud-based data warehousing platform for storing and analyzing l
 
 ## What can you do with this?
 
-This connector lets you read users from a Snowflake database, store them in your data warehouse, and unify them as users within Krenalis.
+This connector lets you read users from a Snowflake database, store them in your data warehouse, and unify them as profiles within Krenalis.
 
 ## What does it require?
 

--- a/connectors/stripe/documentation/destination/overview.md
+++ b/connectors/stripe/documentation/destination/overview.md
@@ -3,7 +3,7 @@ Stripe is a payment processing platform that enables businesses to accept online
 
 ## What can you do with this?
 
-This connector lets you create and update unified Krenalis users from your data warehouse in Stripe as customers.
+This connector lets you create and update unified Krenalis profiles from your data warehouse in Stripe as customers.
 
 ## What does it require?
 

--- a/connectors/stripe/documentation/source/overview.md
+++ b/connectors/stripe/documentation/source/overview.md
@@ -3,7 +3,7 @@ Stripe is a payment processing platform that enables businesses to accept online
 
 ## What can you do with this?
 
-This connector lets you read customers from Stripe, import them into your data warehouse, and unify them as users in Krenalis.
+This connector lets you read customers from Stripe, import them into your data warehouse, and unify them as profiles in Krenalis.
 
 ## What does it require?
 

--- a/connectors/stripe/stripe.go
+++ b/connectors/stripe/stripe.go
@@ -52,7 +52,7 @@ func init() {
 			Targets:     connectors.TargetUser,
 			HasSettings: true,
 			Documentation: connectors.RoleDocumentation{
-				Summary:  "Export users as customers",
+				Summary:  "Export profiles as customers",
 				Overview: destinationOverview,
 			},
 		},

--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -114,7 +114,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 				c.Documentation.Source.Summary = "Import users from " + article(c.Label) + " " + c.Label + " database"
 			}
 			if summary := c.Documentation.Destination.Summary; summary == "" {
-				c.Documentation.Destination.Summary = "Exports users to " + article(c.Label) + " " + c.Label + " database"
+				c.Documentation.Destination.Summary = "Exports profiles to " + article(c.Label) + " " + c.Label + " database"
 			}
 		case connectors.FileSpec:
 			c.Code = connector.Code
@@ -134,7 +134,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 				c.HasDestinationSettings = connector.AsDestination.HasSettings
 				c.Documentation.Destination = asDest.Documentation
 				if c.Documentation.Destination.Summary == "" {
-					c.Documentation.Destination.Summary = "Export users to " + article(c.Label) + " " + c.Label + " file"
+					c.Documentation.Destination.Summary = "Export profiles to " + article(c.Label) + " " + c.Label + " file"
 				}
 			}
 			c.FileExtension = connector.Extension
@@ -163,7 +163,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 				c.HasDestinationSettings = true
 				c.Documentation.Destination = asDest.Documentation
 				if c.Documentation.Destination.Summary == "" {
-					c.Documentation.Destination.Summary = "Exports users to a file on " + c.Label
+					c.Documentation.Destination.Summary = "Exports profiles to a file on " + c.Label
 				}
 			}
 		case connectors.MessageBrokerSpec:


### PR DESCRIPTION
```
connectors, core/internal/state: use profiles in destination summaries

Destination connectors export profiles, not raw users, so update their
summaries to use the more accurate terminology.
```