### PR TITLE
core/internal/state: fix race when deleting workspace

### DIFF
--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -973,10 +973,12 @@ func (state *State) deleteWorkspace(n notification) string {
 	}
 	e.workspace = state.workspaces[e.ID]
 	organization := e.workspace.organization
-	state.mu.Lock()
 	// Delete the workspace.
-	delete(state.workspaces, e.ID)
+	organization.mu.Lock()
 	delete(organization.workspaces, e.ID)
+	organization.mu.Unlock()
+	state.mu.Lock()
+	delete(state.workspaces, e.ID)
 	// Delete access keys restricted to the workspace.
 	for hmac, key := range state.accessKeyByHMAC {
 		if key.Workspace == e.ID {


### PR DESCRIPTION
```
core/internal/state: fix race when deleting workspace

Protect the organization workspace map when removing a workspace.

Workspace deletion updates both the global state index and the
organization-local workspace index. The latter can be read concurrently
through organization accessors, so take the organization lock around the
map mutation.
```