### PR TITLE
core: fix password reset race

### DIFF
--- a/core/organization.go
+++ b/core/organization.go
@@ -742,24 +742,15 @@ func (this *Organization) SendMemberPasswordReset(ctx context.Context, email str
 		return err
 	}
 	now := time.Now().UTC()
-	err = this.core.state.Transaction(ctx, func(tx *db.Tx) (any, error) {
-		result, err := tx.Exec(ctx, `UPDATE members SET reset_password_token = $1, reset_password_token_created_at = $2`+
-			` WHERE organization = $3 AND email = $4 AND invitation_token = ''`, resetToken, now, this.organization.ID, email)
-		if err != nil {
-			return nil, err
-		}
-		if result.RowsAffected() == 0 {
-			return nil, errMemberNotFoundOrInvitationPending
-		}
-		return nil, nil
-	})
+	result, err := this.core.db.Exec(ctx, `UPDATE members SET reset_password_token = $1, reset_password_token_created_at = $2`+
+		` WHERE organization = $3 AND email = $4 AND invitation_token = ''`, resetToken, now, this.organization.ID, email)
 	if err != nil {
-		if err == errMemberNotFoundOrInvitationPending {
-			// Do not return an error, to avoid revealing whether the email
-			// belongs to an existing member or to a member with a pending invitation.
-			return nil
-		}
 		return err
+	}
+	if result.RowsAffected() == 0 {
+		// Do not return an error, to avoid revealing whether the email
+		// belongs to an existing member or to a member with a pending invitation.
+		return nil
 	}
 	t := strings.ReplaceAll(emailTemplate, "${token}", html.EscapeString(resetToken))
 	emailToSend := &emailToSend{

--- a/core/organization.go
+++ b/core/organization.go
@@ -743,16 +743,15 @@ func (this *Organization) SendMemberPasswordReset(ctx context.Context, email str
 	}
 	now := time.Now().UTC()
 	err = this.core.state.Transaction(ctx, func(tx *db.Tx) (any, error) {
-		exists, err := tx.QueryExists(ctx, "SELECT FROM members WHERE organization = $1 AND email = $2 AND invitation_token = ''", this.organization.ID, email)
+		result, err := tx.Exec(ctx, `UPDATE members SET reset_password_token = $1, reset_password_token_created_at = $2`+
+			` WHERE organization = $3 AND email = $4 AND invitation_token = ''`, resetToken, now, this.organization.ID, email)
 		if err != nil {
 			return nil, err
 		}
-		if !exists {
+		if result.RowsAffected() == 0 {
 			return nil, errMemberNotFoundOrInvitationPending
 		}
-		_, err = tx.Exec(ctx, `UPDATE members SET reset_password_token = $1, reset_password_token_created_at = $2 WHERE organization = $3 AND email = $4`,
-			resetToken, now, this.organization.ID, email)
-		return nil, err
+		return nil, nil
 	})
 	if err != nil {
 		if err == errMemberNotFoundOrInvitationPending {

--- a/core/organization.go
+++ b/core/organization.go
@@ -721,8 +721,6 @@ func (this *Organization) Members(ctx context.Context) ([]*Member, error) {
 	return members, nil
 }
 
-var errMemberNotFoundOrInvitationPending = errors.New("member not found or invitation pending")
-
 // SendMemberPasswordReset sends a reset password email to the given email
 // address using the given template.
 //


### PR DESCRIPTION
```
core: fix password reset race

Previously SendMemberPasswordReset first looked up an active member by
email, then updated the password reset token in a separate query. A
concurrent change could therefore make the method write a reset token to
a row that was no longer an active member.

Now the reset token is written only when the matching row is still an
active member. If no row matches, SendMemberPasswordReset preserves the
existing behavior and does not reveal whether the email belongs to a
member or to a pending invitation.
```