### PR TITLE
core: prevent pending invited members from authenticating

### DIFF
--- a/core/organization.go
+++ b/core/organization.go
@@ -301,7 +301,8 @@ func (this *Organization) AuthenticateMember(ctx context.Context, email, passwor
 
 	var id string
 	var hashedPassword []byte
-	err := this.core.db.QueryRow(ctx, "SELECT id, password FROM members WHERE organization = $1 AND email = $2", this.organization.ID, email).Scan(&id, &hashedPassword)
+	err := this.core.db.QueryRow(ctx, "SELECT id, password FROM members WHERE organization = $1 AND email = $2 AND invitation_token = ''",
+		this.organization.ID, email).Scan(&id, &hashedPassword)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return "", errors.Unprocessable(AuthenticationFailed, "authentication has failed")


### PR DESCRIPTION
```
core: prevent pending invited members from authenticating

Members with pending invitations do not have a password yet. Previously,
if an invited member tried to log in, the authentication flow still
reached the password check and failed there.

Return the login failure earlier, before checking the password.
```