### PR TITLE
core: avoid state-change notifications for invited members

### DIFF
--- a/core/organization.go
+++ b/core/organization.go
@@ -555,12 +555,16 @@ func (this *Organization) DeleteMember(ctx context.Context, id string) error {
 		Organization: this.organization.ID,
 	}
 	err := this.core.state.Transaction(ctx, func(tx *db.Tx) (any, error) {
-		result, err := tx.Exec(ctx, "DELETE FROM members WHERE id = $1 AND organization = $2", id, this.organization.ID)
+		var invited bool
+		err := tx.QueryRow(ctx, "DELETE FROM members WHERE id = $1 AND organization = $2 RETURNING invitation_token <> ''", id, this.organization.ID).Scan(&invited)
 		if err != nil {
+			if err == sql.ErrNoRows {
+				return nil, errors.NotFound("member %s does not exist", id)
+			}
 			return nil, err
 		}
-		if result.RowsAffected() == 0 {
-			return nil, errors.NotFound("member %s does not exist", id)
+		if invited {
+			return nil, nil
 		}
 		return n, nil
 	})


### PR DESCRIPTION
```
core: avoid state-change notifications for invited members

Removing an invited member that has not completed registration should
not trigger a state-change notification, because invited members are not
stored in the state.

This currently has no practical impact because the notification handler
ignores this case, but the behavior is still incorrect and should be
fixed.
```