### PR TITLE
core/internal/state: clarify why some state reads do not require locking

### DIFF
--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -60,6 +60,8 @@ func (state *State) keep() {
 		}
 		var org string
 		state.changing.Lock()
+		// While state.changing is locked, only the current goroutine may modify the state.
+		// Other goroutines may only read it, so handlers do not need to acquire the lock for read-only access.
 		switch n.Name {
 		case "AcceptInvitation":
 			org = state.acceptInvitation(n)

--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -60,8 +60,9 @@ func (state *State) keep() {
 		}
 		var org string
 		state.changing.Lock()
-		// While state.changing is locked, only the current goroutine may modify the state.
-		// Other goroutines may only read it, so handlers do not need to acquire the lock for read-only access.
+		// Multiple goroutines may read different parts of the state concurrently, but
+		// only this goroutine can write to it. Therefore, this goroutine can read the
+		// state without acquiring the corresponding locks.
 		switch n.Name {
 		case "AcceptInvitation":
 			org = state.acceptInvitation(n)


### PR DESCRIPTION
```
core/internal/state: clarify why some state reads do not require locking

Only the goroutine running keep can write to the state, so reads
performed by that goroutine are safe without acquiring the corresponding
locks for the affected state parts.
```