### PR TITLE
cmd: extract request body normalization from validation

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -28,11 +28,11 @@ type api struct {
 //
 // It returns an errors.UnprocessableError with code WorkOSEnabled when WorkOS
 // authentication is configured.
-func (api api) AcceptInvitation(w http.ResponseWriter, r *http.Request) (any, error) {
+func (api api) AcceptInvitation(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if api.workos != nil {
 		return nil, errors.Unprocessable(core.BuiltInAuthenticationDisabled, "invitations cannot be accepted because WorkOS authentication is enabled")
 	}
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -68,11 +68,11 @@ func (api api) AcceptInvitation(w http.ResponseWriter, r *http.Request) (any, er
 //
 // It returns an errors.UnprocessableError with code WorkOSEnabled when WorkOS
 // authentication is configured.
-func (api api) ChangeMemberPasswordByToken(w http.ResponseWriter, r *http.Request) (any, error) {
+func (api api) ChangeMemberPasswordByToken(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if api.workos != nil {
 		return nil, errors.Unprocessable(core.BuiltInAuthenticationDisabled, "passwords cannot be changed because WorkOS authentication is enabled")
 	}
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -127,11 +127,11 @@ func (api api) Connectors(_ http.ResponseWriter, r *http.Request) (any, error) {
 // CreateOrganization creates a new organization.
 //
 // Authentication is performed using the organizations API key.
-func (api api) CreateOrganization(w http.ResponseWriter, r *http.Request) (any, error) {
+func (api api) CreateOrganization(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if err := api.authenticateOrganizationsRequest(r); err != nil {
 		return nil, err
 	}
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -169,8 +169,8 @@ func (api api) EventsSettings(w http.ResponseWriter, r *http.Request) (any, erro
 
 // ExpressionsProperties returns all the unique properties contained inside a
 // list of expressions.
-func (api api) ExpressionsProperties(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (api api) ExpressionsProperties(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	if _, _, _, err := api.authenticateAdminRequest(r); err != nil {
@@ -348,11 +348,11 @@ func (api api) PublicMetadata(_ http.ResponseWriter, r *http.Request) (any, erro
 //
 // It returns an errors.UnprocessableError with code WorkOSEnabled when WorkOS
 // authentication is configured.
-func (api api) SendMemberPasswordReset(w http.ResponseWriter, r *http.Request) (any, error) {
+func (api api) SendMemberPasswordReset(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if api.workos != nil {
 		return nil, errors.Unprocessable(core.BuiltInAuthenticationDisabled, "password reset emails cannot be sent because WorkOS authentication is enabled")
 	}
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -408,8 +408,8 @@ func (api api) ValidateMemberPasswordResetToken(_ http.ResponseWriter, r *http.R
 
 // TransformData transforms data using a mapping or a function transformation
 // and returns the transformed data.
-func (api api) TransformData(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (api api) TransformData(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	if _, _, _, err := api.authenticateAdminRequest(r); err != nil {
@@ -443,8 +443,8 @@ func (api api) TransformationLanguages(_ http.ResponseWriter, r *http.Request) (
 }
 
 // ValidateExpression validates an expression.
-func (api api) ValidateExpression(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (api api) ValidateExpression(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	if _, _, _, err := api.authenticateAdminRequest(r); err != nil {

--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -185,7 +185,8 @@ func (s *apisServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-
+		// Wrap the request body to enforce the size limit and normalize it before decoding.
+		r.Body = maxBytesNormalizedReader(w, r.Body, maxRequestSize)
 	}
 
 	r.URL.Path = r.URL.Path[len("/v1"):]
@@ -400,7 +401,7 @@ func (s *apisServer) forwardSentryError(w http.ResponseWriter, r *http.Request) 
 // If workOS is not configured, it uses Krenalis native email and password
 // login.
 func (s *apisServer) login(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 
@@ -852,6 +853,19 @@ func (s *apisServer) secureCookie(ctx context.Context) (*securecookie.SecureCook
 	return s.cookies.SecureCookie, nil
 }
 
+// maxBytesNormalizedReader returns a reader that enforces a maximum size and
+// normalizes the stream to NFC.
+func maxBytesNormalizedReader(w http.ResponseWriter, r io.ReadCloser, n int64) io.ReadCloser {
+	b := http.MaxBytesReader(w, r, n)
+	return struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: norm.NFC.Reader(b),
+		Closer: b,
+	}
+}
+
 // validateForbiddenBody rejects requests that contain a request body.
 func validateForbiddenBody(r *http.Request) error {
 	if r.ContentLength == 0 {
@@ -876,10 +890,10 @@ func validateForbiddenBody(r *http.Request) error {
 	return nil
 }
 
-// validateRequiredBody validates that the request body is present and is JSON,
-// then applies size limiting and NFC normalization.
-// If allowPlainText is true, it also allows "text/plain" as a content type.
-func validateRequiredBody(w http.ResponseWriter, r *http.Request, allowPlainText bool) error {
+// validateRequiredBody validates that the request body is present and has an
+// allowed content type with an optional UTF-8 charset. If allowPlainText is
+// true, "text/plain" is allowed in addition to "application/json".
+func validateRequiredBody(r *http.Request, allowPlainText bool) error {
 	if r.ContentLength == 0 {
 		return errors.BadRequest("request's body is missing")
 	}
@@ -894,14 +908,6 @@ func validateRequiredBody(w http.ResponseWriter, r *http.Request, allowPlainText
 	}
 	if charset, ok := params["charset"]; ok && strings.ToLower(charset) != "utf-8" {
 		return errors.BadRequest("request's content type charset must be 'utf-8'")
-	}
-	b := http.MaxBytesReader(w, r.Body, maxRequestSize)
-	r.Body = struct {
-		io.Reader
-		io.Closer
-	}{
-		Reader: norm.NFC.Reader(b),
-		Closer: b,
 	}
 	return nil
 }

--- a/cmd/apis_server_test.go
+++ b/cmd/apis_server_test.go
@@ -238,9 +238,8 @@ func TestValidateRequiredBody(t *testing.T) {
 
 	t.Run("fails when body is missing", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
-		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(w, req, false)
+		err := validateRequiredBody(req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -251,9 +250,8 @@ func TestValidateRequiredBody(t *testing.T) {
 
 	t.Run("fails when content type is missing", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
-		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(w, req, false)
+		err := validateRequiredBody(req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -265,9 +263,8 @@ func TestValidateRequiredBody(t *testing.T) {
 	t.Run("fails when content type is not json", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
 		req.Header.Set("Content-Type", "text/plain")
-		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(w, req, false)
+		err := validateRequiredBody(req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -279,9 +276,8 @@ func TestValidateRequiredBody(t *testing.T) {
 	t.Run("fails when content type is not json or plain/text", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
 		req.Header.Set("Content-Type", "application/xml")
-		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(w, req, true)
+		err := validateRequiredBody(req, true)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -293,9 +289,8 @@ func TestValidateRequiredBody(t *testing.T) {
 	t.Run("fails when content type has unsupported parameters", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
 		req.Header.Set("Content-Type", "application/json; charset=utf-8; version=1")
-		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(w, req, false)
+		err := validateRequiredBody(req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -307,9 +302,8 @@ func TestValidateRequiredBody(t *testing.T) {
 	t.Run("fails when charset is not utf8", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
 		req.Header.Set("Content-Type", "application/json; charset=iso-8859-1")
-		w := httptest.NewRecorder()
 
-		err := validateRequiredBody(w, req, false)
+		err := validateRequiredBody(req, false)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -322,9 +316,8 @@ func TestValidateRequiredBody(t *testing.T) {
 		const payload = `{"ok":true}`
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload))
 		req.Header.Set("Content-Type", "Application/Json; Charset=UTF-8")
-		w := httptest.NewRecorder()
 
-		if err := validateRequiredBody(w, req, false); err != nil {
+		if err := validateRequiredBody(req, false); err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 		body, err := io.ReadAll(req.Body)
@@ -336,15 +329,17 @@ func TestValidateRequiredBody(t *testing.T) {
 		}
 	})
 
+}
+
+// TestMaxBytesNormalizedReader tests the maxBytesNormalizedReader function.
+func TestMaxBytesNormalizedReader(t *testing.T) {
+
 	t.Run("normalizes body", func(t *testing.T) {
 		const payload = "{\"text\":\"Cafe\u0301\"}"
 		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload))
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 		w := httptest.NewRecorder()
-
-		if err := validateRequiredBody(w, req, false); err != nil {
-			t.Fatalf("expected nil error, got %v", err)
-		}
+		req.Body = maxBytesNormalizedReader(w, req.Body, maxRequestSize)
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			t.Fatalf("expected to read body, got %v", err)
@@ -359,10 +354,7 @@ func TestValidateRequiredBody(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(oversized))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
-
-		if err := validateRequiredBody(w, req, false); err != nil {
-			t.Fatalf("expected nil error, got %v", err)
-		}
+		req.Body = maxBytesNormalizedReader(w, req.Body, maxRequestSize)
 		body, err := io.ReadAll(req.Body)
 		if err == nil {
 			t.Fatalf("expected error, got nil")

--- a/cmd/connection.go
+++ b/cmd/connection.go
@@ -69,8 +69,8 @@ func (connection connection) AbsolutePath(_ http.ResponseWriter, r *http.Request
 }
 
 // CreatePipeline creates a pipeline.
-func (connection connection) CreatePipeline(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (connection connection) CreatePipeline(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace{connection.apisServer}.workspace(r)
@@ -147,8 +147,8 @@ func (connection connection) DeleteEventWriteKey(_ http.ResponseWriter, r *http.
 }
 
 // ExecQuery executes a query on a database connection.
-func (connection connection) ExecQuery(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (connection connection) ExecQuery(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	c, err := connection.id(r)
@@ -310,8 +310,8 @@ func (connection connection) PipelineTypes(_ http.ResponseWriter, r *http.Reques
 }
 
 // PreviewSendEvent previews sending an event.
-func (connection connection) PreviewSendEvent(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (connection connection) PreviewSendEvent(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	c, err := connection.id(r)
@@ -336,9 +336,9 @@ func (connection connection) PreviewSendEvent(w http.ResponseWriter, r *http.Req
 }
 
 // ServeUI serves the user interface for a connection.
-func (connection connection) ServeUI(w http.ResponseWriter, r *http.Request) (any, error) {
+func (connection connection) ServeUI(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if r.Method != http.MethodGet {
-		if err := validateRequiredBody(w, r, false); err != nil {
+		if err := validateRequiredBody(r, false); err != nil {
 			return nil, err
 		}
 	}
@@ -439,8 +439,8 @@ func (connection connection) UnlinkConnection(_ http.ResponseWriter, r *http.Req
 }
 
 // Update updates a connection.
-func (connection connection) Update(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (connection connection) Update(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	c, err := connection.id(r)

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -27,11 +27,11 @@ type organization struct {
 // If the ability to add new members without requiring email invitation has not
 // been enabled, it returns an errors.UnprocessableError error with code
 // EmailInvitationRequired.
-func (organization organization) AddMember(w http.ResponseWriter, r *http.Request) (any, error) {
+func (organization organization) AddMember(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if organization.workos != nil {
 		return nil, errors.Unprocessable(core.BuiltInAuthenticationDisabled, "members cannot be added because WorkOS authentication is enabled")
 	}
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	org, _, _, err := organization.authenticateAdminRequest(r)
@@ -91,8 +91,8 @@ func (organization organization) AccessKeys(_ http.ResponseWriter, r *http.Reque
 }
 
 // CreateAccessKey creates a new access key for an organization.
-func (organization organization) CreateAccessKey(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (organization organization) CreateAccessKey(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	org, _, _, err := organization.authenticateAdminRequest(r)
@@ -132,8 +132,8 @@ func (organization organization) CreateAccessKey(w http.ResponseWriter, r *http.
 }
 
 // CreateWorkspace creates a workspace for the organization.
-func (organization organization) CreateWorkspace(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (organization organization) CreateWorkspace(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	org, ws, err := organization.authenticateRequest(r)
@@ -217,11 +217,11 @@ func (organization organization) DeleteMember(_ http.ResponseWriter, r *http.Req
 //
 // It returns an errors.UnprocessableError with code WorkOSEnabled when WorkOS
 // authentication is configured.
-func (organization organization) InviteMember(w http.ResponseWriter, r *http.Request) (any, error) {
+func (organization organization) InviteMember(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if organization.workos != nil {
 		return nil, errors.Unprocessable(core.BuiltInAuthenticationDisabled, "members cannot be invited because WorkOS authentication is enabled")
 	}
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	org, _, memberID, err := organization.authenticateAdminRequest(r)
@@ -266,11 +266,11 @@ func (organization organization) Members(_ http.ResponseWriter, r *http.Request)
 // SetStatus sets the status of an organization.
 //
 // Authentication is performed using the organizations API key.
-func (organization organization) SetStatus(w http.ResponseWriter, r *http.Request) (any, error) {
+func (organization organization) SetStatus(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if err := organization.authenticateOrganizationsRequest(r); err != nil {
 		return nil, err
 	}
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	var body struct {
@@ -289,8 +289,8 @@ func (organization organization) SetStatus(w http.ResponseWriter, r *http.Reques
 }
 
 // TestWorkspaceCreation tests a workspace creation.
-func (organization organization) TestWorkspaceCreation(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (organization organization) TestWorkspaceCreation(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	org, ws, err := organization.authenticateRequest(r)
@@ -315,8 +315,8 @@ func (organization organization) TestWorkspaceCreation(w http.ResponseWriter, r 
 }
 
 // UpdateAccessKey updates the name of an access key for an organization.
-func (organization organization) UpdateAccessKey(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (organization organization) UpdateAccessKey(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	org, _, _, err := organization.authenticateAdminRequest(r)
@@ -338,11 +338,11 @@ func (organization organization) UpdateAccessKey(w http.ResponseWriter, r *http.
 //
 // It returns an errors.UnprocessableError with code WorkOSEnabled when WorkOS
 // authentication is configured.
-func (organization organization) UpdateMember(w http.ResponseWriter, r *http.Request) (any, error) {
+func (organization organization) UpdateMember(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if organization.workos != nil {
 		return nil, errors.Unprocessable(core.BuiltInAuthenticationDisabled, "members cannot be updated because WorkOS authentication is enabled")
 	}
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	org, _, memberID, err := organization.authenticateAdminRequest(r)
@@ -384,11 +384,11 @@ func (organization organization) UpdateMember(w http.ResponseWriter, r *http.Req
 // Update updates the name of the organization with the given identifier.
 //
 // Authentication is performed using the organizations API key.
-func (organization organization) Update(w http.ResponseWriter, r *http.Request) (any, error) {
+func (organization organization) Update(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if err := organization.authenticateOrganizationsRequest(r); err != nil {
 		return nil, err
 	}
-	if err := validateRequiredBody(w, r, false); err != nil {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	var body struct {

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -30,8 +30,8 @@ func (pipeline pipeline) Delete(_ http.ResponseWriter, r *http.Request) (any, er
 }
 
 // Run runs a pipeline.
-func (pipeline pipeline) Run(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (pipeline pipeline) Run(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	p, err := pipeline.id(r)
@@ -53,8 +53,8 @@ func (pipeline pipeline) Run(w http.ResponseWriter, r *http.Request) (any, error
 }
 
 // ServeUI serves the UI of a pipeline.
-func (pipeline pipeline) ServeUI(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (pipeline pipeline) ServeUI(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	_, ws, _, err := pipeline.authenticateAdminRequest(r)
@@ -84,8 +84,8 @@ func (pipeline pipeline) ServeUI(w http.ResponseWriter, r *http.Request) (any, e
 }
 
 // SetSchedulePeriod sets the schedule period of a pipeline.
-func (pipeline pipeline) SetSchedulePeriod(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (pipeline pipeline) SetSchedulePeriod(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	p, err := pipeline.id(r)
@@ -104,8 +104,8 @@ func (pipeline pipeline) SetSchedulePeriod(w http.ResponseWriter, r *http.Reques
 }
 
 // SetStatus sets the status of a pipeline.
-func (pipeline pipeline) SetStatus(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (pipeline pipeline) SetStatus(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	p, err := pipeline.id(r)
@@ -124,8 +124,8 @@ func (pipeline pipeline) SetStatus(w http.ResponseWriter, r *http.Request) (any,
 }
 
 // Update updates a pipeline.
-func (pipeline pipeline) Update(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (pipeline pipeline) Update(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	p, err := pipeline.id(r)

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -23,8 +23,8 @@ type workspace struct {
 }
 
 // AlterProfileSchema alters the profile schema of a workspace.
-func (workspace workspace) AlterProfileSchema(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) AlterProfileSchema(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -86,8 +86,8 @@ func (workspace workspace) Connections(_ http.ResponseWriter, r *http.Request) (
 }
 
 // CreateConnection creates a connection for a workspace.
-func (workspace workspace) CreateConnection(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) CreateConnection(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -114,8 +114,8 @@ func (workspace workspace) CreateConnection(w http.ResponseWriter, r *http.Reque
 
 // CreateEventListener creates an event listener for a workspace that listens to
 // events.
-func (workspace workspace) CreateEventListener(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) CreateEventListener(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -280,7 +280,7 @@ func (workspace workspace) ProfilePropertiesSuitableAsIdentifiers(_ http.Respons
 // IngestEvents ingests a batch of events.
 func (workspace workspace) IngestEvents(w http.ResponseWriter, r *http.Request) (any, error) {
 	// Unlike other endpoints, it allows "text/plain" as a content type.
-	if err := validateRequiredBody(w, r, true); err != nil {
+	if err := validateRequiredBody(r, true); err != nil {
 		return nil, err
 	}
 	// Removes the headers that were set earlier, as ServeEvents handles the response fully.
@@ -656,8 +656,8 @@ func (workspace workspace) PipelineRuns(_ http.ResponseWriter, r *http.Request) 
 // PreviewAlterProfileSchema provides a preview of an alter profile schema
 // operation by returning the queries that would be executed on the warehouse to
 // perform a given alter schema.
-func (workspace workspace) PreviewAlterProfileSchema(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) PreviewAlterProfileSchema(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -694,8 +694,8 @@ func (workspace workspace) RepairWarehouse(_ http.ResponseWriter, r *http.Reques
 }
 
 // ServeUI serves the user interface for a connector.
-func (workspace workspace) ServeUI(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) ServeUI(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	_, ws, _, err := workspace.authenticateAdminRequest(r)
@@ -747,8 +747,8 @@ func (workspace workspace) StartIdentityResolution(_ http.ResponseWriter, r *htt
 }
 
 // TestWarehouseUpdate tests a warehouse update.
-func (workspace workspace) TestWarehouseUpdate(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) TestWarehouseUpdate(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -785,8 +785,8 @@ func (workspace workspace) Attributes(_ http.ResponseWriter, r *http.Request) (a
 }
 
 // Update updates the name and the displayed properties of a workspace.
-func (workspace workspace) Update(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) Update(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -807,8 +807,8 @@ func (workspace workspace) Update(w http.ResponseWriter, r *http.Request) (any, 
 
 // UpdateIdentityResolutionSettings updates the identity resolution settings of
 // the workspace.
-func (workspace workspace) UpdateIdentityResolutionSettings(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) UpdateIdentityResolutionSettings(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -828,8 +828,8 @@ func (workspace workspace) UpdateIdentityResolutionSettings(w http.ResponseWrite
 }
 
 // UpdateWarehouse updates the warehouse of a workspace.
-func (workspace workspace) UpdateWarehouse(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) UpdateWarehouse(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)
@@ -854,8 +854,8 @@ func (workspace workspace) UpdateWarehouse(w http.ResponseWriter, r *http.Reques
 }
 
 // UpdateWarehouseMode updates the mode of the data warehouse for a workspace.
-func (workspace workspace) UpdateWarehouseMode(w http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateRequiredBody(w, r, false); err != nil {
+func (workspace workspace) UpdateWarehouseMode(_ http.ResponseWriter, r *http.Request) (any, error) {
+	if err := validateRequiredBody(r, false); err != nil {
 		return nil, err
 	}
 	ws, err := workspace.workspace(r)


### PR DESCRIPTION
```
cmd: extract request body normalization from validation

Move request body size limiting and NFC normalization out of
validateRequiredBody and into a dedicated helper.

This keeps validateRequiredBody focused on validating that the body is
present and has an allowed content type, while body wrapping is handled
separately before decoding.
```