### PR TITLE
core/internal/state: fix loading pending invited members

### DIFF
--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -290,7 +290,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 		return fmt.Errorf("cannot load organizations: %s", err)
 	}
 
-	// Read all members.
+	// Read all members who have accepted their invitation.
 	err = tx.QueryScan(ctx, "SELECT id, organization FROM members WHERE invitation_token = '' ORDER BY organization", func(rows *db.Rows) error {
 		var org *Organization
 		for rows.Next() {

--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -291,7 +291,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 	}
 
 	// Read all members.
-	err = tx.QueryScan(ctx, "SELECT id, organization FROM members ORDER BY organization", func(rows *db.Rows) error {
+	err = tx.QueryScan(ctx, "SELECT id, organization FROM members WHERE invitation_token = '' ORDER BY organization", func(rows *db.Rows) error {
 		var org *Organization
 		for rows.Next() {
 			var id, organization string


### PR DESCRIPTION
```
core/internal/state: fix loading pending invited members

Exclude pending invitations when loading members.

State must contain only members that can log in. Invited members cannot
log in until they accept the invitation, so they should not be included
in the state.
```