### PR TITLE
core: reject out-of-range integer values

### DIFF
--- a/core/internal/state/notifier.go
+++ b/core/internal/state/notifier.go
@@ -331,8 +331,8 @@ func parsePayload(s string) (id int64, name, payload string, err error) {
 	if s[0] != '@' {
 		return 0, "", "", errors.New("invalid identifier")
 	}
-	id, _ = strconv.ParseInt(s[1:], 10, 64)
-	if id < 1 {
+	id, err = strconv.ParseInt(s[1:], 10, 64)
+	if err != nil || id < 1 {
 		return 0, "", "", errors.New("invalid identifier")
 	}
 	return

--- a/core/internal/transformers/local/local.go
+++ b/core/internal/transformers/local/local.go
@@ -74,7 +74,7 @@ func (fn *function) Call(ctx context.Context, id, version string, inSchema, outS
 		return errors.New("language is not supported")
 	}
 
-	if v, _ := strconv.Atoi(version); v <= 0 || version[0] == '+' {
+	if v, err := strconv.Atoi(version); err != nil || v <= 0 || version[0] == '+' {
 		return fmt.Errorf("invalid version %q", version)
 	}
 	filename := fn.filename(name, version, language)


### PR DESCRIPTION
```
core: reject out-of-range integer values

Check for parsing errors when validating notification IDs and local
function versions.

When strconv fails because a number is too large for the target integer
type, it still returns the maximum representable value. Checking only
the parsed value could therefore accept invalid numeric strings.
```