### PR TITLE
krenalis: document how to dump dbs in `compose.dev.yaml` from CLI

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -15,6 +15,7 @@
 #     Password:             no password set (auth method = trust)
 #     Database:             krenalis
 #     Connecting from CLI:  psql -h 127.0.0.1 -p 15432 -U krenalis krenalis
+#     Dump from CLI:        pg_dump -h 127.0.0.1 -p 15432 -U krenalis krenalis
 #
 # =============================================================================
 # Krenalis PostgreSQL warehouse
@@ -26,6 +27,7 @@
 #     Password:             no password set (auth method = trust)
 #     Database:             warehouse
 #     Connecting from CLI:  psql -h 127.0.0.1 -p 15433 -U warehouse warehouse
+#     Dump from CLI:        pg_dump -h 127.0.0.1 -p 15433 -U warehouse warehouse
 #
 # =============================================================================
 # Krenalis PostgreSQL warehouse (MCP user)


### PR DESCRIPTION
```
krenalis: document how to dump dbs in `compose.dev.yaml` from CLI

Dumping the Krenalis database and warehouse using 'pg_dump' is
convenient because it allows you, for example, to dump a new Krenalis
database and one updated using the updater, so you can check for any
discrepancies.

Document the command directly in the 'compose.dev.yaml' file, which is
already configured for the database or warehouse started with Docker
Compose.
```