### PR TITLE
core: keep invited members in organization state for clarity

### DIFF
--- a/cmd/apis_server.go
+++ b/cmd/apis_server.go
@@ -231,8 +231,8 @@ func (s *apisServer) authenticateAdminRequest(r *http.Request) (org *core.Organi
 		}
 		return nil, nil, "", err
 	}
-	// Verify that the member still exists.
-	if exists, err := org.HasMember(session.Member); err != nil || !exists {
+	// Verify that the member can still log in.
+	if canLogin, err := org.CanMemberLogin(session.Member); err != nil || !canLogin {
 		return nil, nil, "", errInvalidSessionCookie
 	}
 	// Verify that the organization is enabled.

--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -327,7 +327,7 @@ func (state *State) acceptInvitation(n notification) string {
 	}
 	org := state.organizations[e.Organization]
 	org.mu.Lock()
-	org.members[e.Member] = struct{}{}
+	org.members[e.Member] = true
 	org.mu.Unlock()
 	return org.ID
 }
@@ -346,7 +346,7 @@ func (state *State) addMember(n notification) string {
 	}
 	org := state.organizations[e.Organization]
 	org.mu.Lock()
-	org.members[e.ID] = struct{}{}
+	org.members[e.ID] = true
 	org.usage.addMember()
 	org.mu.Unlock()
 	return org.ID
@@ -502,7 +502,7 @@ func (state *State) createOrganization(n notification) string {
 	org := &Organization{
 		mu:         &sync.Mutex{},
 		workspaces: map[string]*Workspace{},
-		members:    map[string]struct{}{},
+		members:    map[string]bool{},
 		usage:      newOrganizationUsage(e.Limits),
 		ID:         e.ID,
 		Name:       e.Name,
@@ -875,7 +875,7 @@ func (state *State) deleteMember(n notification) string {
 	}
 	org := state.organizations[e.Organization]
 	org.mu.Lock()
-	delete(org.members, e.ID) // This is a no-op for invited members, which are not in org.members.
+	delete(org.members, e.ID)
 	org.usage.removeMember()
 	org.mu.Unlock()
 	return e.Organization
@@ -1178,6 +1178,7 @@ func (state *State) inviteMember(n notification) string {
 	}
 	org := state.organizations[e.Organization]
 	org.mu.Lock()
+	org.members[e.Member] = false
 	org.usage.addMember()
 	org.mu.Unlock()
 	return org.ID

--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -285,7 +285,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 			}
 			org.usage = newOrganizationUsage(limits)
 			org.workspaces = map[string]*Workspace{}
-			org.members = map[string]struct{}{}
+			org.members = map[string]bool{}
 			state.organizations[org.ID] = org
 		}
 		return nil
@@ -295,21 +295,19 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 	}
 
 	// Read all members.
-	err = tx.QueryScan(ctx, "SELECT id, organization, invitation_token <> '' FROM members ORDER BY organization", func(rows *db.Rows) error {
+	err = tx.QueryScan(ctx, "SELECT id, organization, invitation_token = '' FROM members ORDER BY organization", func(rows *db.Rows) error {
 		var org *Organization
 		for rows.Next() {
 			var id, organization string
-			var hasPendingInvitation bool
-			if err := rows.Scan(&id, &organization, &hasPendingInvitation); err != nil {
+			var canLogin bool
+			if err := rows.Scan(&id, &organization, &canLogin); err != nil {
 				return fmt.Errorf("loading member %s: %s", id, err)
 			}
 			if org == nil || org.ID != organization {
 				org = state.organizations[organization]
 			}
 			org.usage.addMember()
-			if !hasPendingInvitation {
-				org.members[id] = struct{}{}
-			}
+			org.members[id] = canLogin
 		}
 		return nil
 	})

--- a/core/internal/state/state.go
+++ b/core/internal/state/state.go
@@ -537,7 +537,7 @@ type AccessKey struct {
 type Organization struct {
 	mu         *sync.Mutex
 	workspaces map[string]*Workspace
-	members    map[string]struct{}
+	members    map[string]bool // true when the member can log in.
 	usage      organizationUsage
 	ID         string
 	Name       string
@@ -564,20 +564,21 @@ type OrganizationLimits struct {
 	Pipelines   int
 }
 
+// CanMemberLogin reports whether the member with the given ID can log in and
+// whether the member exists.
+func (organization *Organization) CanMemberLogin(id string) (bool, bool) {
+	organization.mu.Lock()
+	canLogin, ok := organization.members[id]
+	organization.mu.Unlock()
+	return canLogin, ok
+}
+
 // Counts returns the organization's counts.
 func (organization *Organization) Counts() OrganizationCounts {
 	organization.mu.Lock()
 	counts := organization.usage.currentCounts()
 	organization.mu.Unlock()
 	return counts
-}
-
-// HasMember reports whether the organization has a member with the given ID.
-func (organization *Organization) HasMember(id string) bool {
-	organization.mu.Lock()
-	_, ok := organization.members[id]
-	organization.mu.Unlock()
-	return ok
 }
 
 // IsAccessKeyLimitReached returns whether the organization has reached its

--- a/core/organization.go
+++ b/core/organization.go
@@ -234,9 +234,7 @@ func (this *Organization) AddMember(ctx context.Context, member MemberToSet) (st
 		Organization: this.organization.ID,
 	}
 	for {
-		n.ID = generateID(func(id string) (any, bool) {
-			return nil, this.organization.HasMember(id)
-		})
+		n.ID = generateID(this.organization.CanMemberLogin)
 		now := time.Now().UTC()
 		err = this.core.state.Transaction(ctx, func(tx *db.Tx) (any, error) {
 			// Ensure the organization can accept another member.
@@ -354,6 +352,22 @@ func (this *Organization) AuthenticateMember(ctx context.Context, email, passwor
 	}
 
 	return id, nil
+}
+
+// CanMemberLogin reports whether the member with the given ID can log in to the
+// organization.
+//
+// If the member does not exist, it returns an errors.NotFound error.
+func (this *Organization) CanMemberLogin(id string) (bool, error) {
+	this.core.mustBeOpen()
+	if !IsValidID(id) {
+		return false, errors.BadRequest("identifier %q is not a valid member identifier", id)
+	}
+	canLogin, ok := this.organization.CanMemberLogin(id)
+	if !ok {
+		return false, errors.NotFound("member %s does not exist", id)
+	}
+	return canLogin, nil
 }
 
 // CreateAccessKey creates a new access key for the organization with the
@@ -638,15 +652,6 @@ func (this *Organization) DeleteMember(ctx context.Context, id string) error {
 	return err
 }
 
-// HasMember reports whether the organization has a member with the given ID.
-func (this *Organization) HasMember(id string) (bool, error) {
-	this.core.mustBeOpen()
-	if !IsValidID(id) {
-		return false, errors.BadRequest("identifier %q is not a valid member identifier", id)
-	}
-	return this.organization.HasMember(id), nil
-}
-
 // InviteMember sends an invitation email to the given email address using the
 // given template. It then creates a new invited member, or updates an existing
 // pending invitation.
@@ -669,9 +674,7 @@ func (this *Organization) InviteMember(ctx context.Context, email string, emailT
 	}
 	var invitationToken string
 	for {
-		n.Member = generateID(func(id string) (any, bool) {
-			return nil, this.organization.HasMember(id)
-		})
+		n.Member = generateID(this.organization.CanMemberLogin)
 		invitationToken, err = generateMemberToken()
 		if err != nil {
 			return err


### PR DESCRIPTION
```
core: keep invited members in organization state for clarity

Store all organization members in state, including pending invitations.
Track login access explicitly so the member state is easier to
understand and reason about.
```