### PR TITLE
core/internal/collector: return 415 for invalid gzip request bodies

### DIFF
--- a/core/internal/collector/collector.go
+++ b/core/internal/collector/collector.go
@@ -183,8 +183,7 @@ func (c *Collector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Content-Encoding") == "gzip" {
 			reader, err := gzip.NewReader(r.Body)
 			if err != nil {
-				slog.Error("core/events/collector: an error occurred creating gzip reader", "error", err)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				http.Error(w, "Unsupported Media Type", http.StatusUnsupportedMediaType)
 				return
 			}
 			defer reader.Close()


### PR DESCRIPTION
```
core/internal/collector: return 415 for invalid gzip request bodies

Return a 415 Unsupported Media Type response without logging an error
when a request declares "Content-Encoding: gzip" but its body is not
valid gzip data or is corrupted.
```