### PR TITLE
core/internal/collector: fix API key scoping for event ingestion

### DIFF
--- a/core/internal/collector/collector.go
+++ b/core/internal/collector/collector.go
@@ -707,7 +707,7 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 			}
 			if ws == nil {
 				connection, ok = c.state.Connection(id)
-				if ok && connection.Organization() != org {
+				if ok && connection.Organization().ID != org.ID {
 					connection = nil
 				}
 			} else {

--- a/core/internal/collector/collector.go
+++ b/core/internal/collector/collector.go
@@ -665,6 +665,14 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 			if key.Type != state.AccessKeyTypeAPI {
 				return errors.Unauthorized("API key in the Authorization header is invalid")
 			}
+			org, ok := c.state.Organization(key.Organization)
+			if !ok {
+				return errors.Unauthorized("API key in the Authorization header is invalid")
+			}
+			if !org.Enabled {
+				return errors.Unprocessable("OrganizationDisabled", "organization %s is disabled", org.ID)
+			}
+			var ws *state.Workspace
 			if header, ok := r.Header["Krenalis-Workspace"]; ok {
 				if len(header) > 1 {
 					return errors.BadRequest(`request contains multiple "Krenalis-Workspace" headers`)
@@ -676,10 +684,13 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 				if !isValidWorkspaceID(id) {
 					return errors.BadRequest(`"Krenalis-Workspace" header is invalid; use "Krenalis-Workspace: <WORKSPACE_ID>"`)
 				}
-				if _, ok = c.state.Workspace(id); !ok {
+				if ws, ok = org.Workspace(id); !ok {
 					return errors.NotFound("workspace %s does not exist", id)
 				}
-				key.Workspace = id
+			} else if key.Workspace != "" {
+				if ws, ok = org.Workspace(key.Workspace); !ok {
+					return errors.Unauthorized("API key in the Authorization header is invalid")
+				}
 			}
 			// Decode the request.
 			dec, err = newDecoder(r)
@@ -694,20 +705,16 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 			if !ok {
 				return errors.BadRequest("parameter 'connectionId' is required when using API key authentication")
 			}
-			if key.Workspace == "" {
-				connection, _ = c.state.Connection(id)
-			} else {
-				workspace, ok := c.state.Workspace(key.Workspace)
-				if !ok {
-					return errors.Unauthorized("API key in the Authorization header is invalid")
+			if ws == nil {
+				connection, ok = c.state.Connection(id)
+				if ok && connection.Organization() != org {
+					connection = nil
 				}
-				connection, _ = workspace.Connection(id)
+			} else {
+				connection, _ = ws.Connection(id)
 			}
 			if connection == nil {
 				return errors.Unprocessable("ConnectionNotExist", "connection %s does not exist", id)
-			}
-			if org := connection.Organization(); !org.Enabled {
-				return errors.Unprocessable("OrganizationDisabled", "organization %s is disabled", org.ID)
 			}
 		} else {
 			// Authenticate with the event write key in the header.


### PR DESCRIPTION
```
core/internal/collector: fix API key scoping for event ingestion

Fixes four issues affecting event ingestion when using an API key that
is not restricted to a specific workspace:

a) The collector overwrites the AccessKey.Workspace field from the state
   package, even though state fields must never be modified.
   This introduces a data race and can cause an API key that was
   originally not restricted to a workspace to become unexpectedly bound
   to the workspace specified in the request through the
   Krenalis-Workspace header.

b) The collector does not verify that the workspace specified in the
   Krenalis-Workspace header belongs to the organization associated with
   the API key. As a result, anyone who knows a workspace ID can use an
   API key from one organization to ingest events into a workspace owned
   by another organization.

c) The collector does not verify that the connection specified in the
   request body belongs to the organization associated with the API key.
   As a result, anyone who knows a connection ID can use an API key from
   one organization to ingest events into a connection owned by another
   organization.

d) When an organization is disabled, no information about its resources
   should be disclosed. However, the collector reveals whether the
   workspace specified in the Krenalis-Workspace header exists.
   Combined with the issue described in point b), this information is
   also disclosed when the workspace belongs to a different
   organization.
```