### PR TITLE
core/internal/metrics: fix daily aggregation interval

### DIFF
--- a/core/internal/metrics/metrics.go
+++ b/core/internal/metrics/metrics.go
@@ -255,16 +255,16 @@ func (c *Collector) WaitStore() {
 // 48 hours, or 30 days, respectively. timeslot represents the current timeslot.
 func (c *Collector) aggregate(timeslot int32, unit time.Duration) {
 
-	var interval int32
-	var threshold int32
+	var interval int32  // Bucket width in minutes.
+	var threshold int32 // Rows before this timeslot are aggregated.
 
 	switch unit {
 	case Hour:
 		interval = 60
 		threshold = timeslot + 1 - interval
 	case Day:
-		interval = 48 * 60
-		threshold = timeslot + (60 - (timeslot % 60)) - interval
+		interval = 24 * 60
+		threshold = timeslot + (60 - (timeslot % 60)) - 48*60
 	case Month:
 		interval = 30 * 24 * 60
 		threshold = timeslot + (24*60 - (timeslot % (24 * 60))) - interval


### PR DESCRIPTION
```
core/internal/metrics: fix daily aggregation interval

Metrics older than 48 hours should be progressively aggregated by day.
Therefore, metrics older than 48 hours are grouped daily rather than
hourly.

However, the current implementation aggregates metrics from two
consecutive days instead of grouping metrics from the same day.

Fix the `interval` variable by setting it to 24 * 60 (one day) instead
of 48 * 60 (two days). The value assigned to the threshold variable is
correct at two days and remains unchanged.
```