### PR TITLE
cmd: avoid duplicate validation of `DELETE` request bodies

### DIFF
--- a/cmd/connection.go
+++ b/cmd/connection.go
@@ -122,9 +122,6 @@ func (connection connection) CreateEventWriteKey(_ http.ResponseWriter, r *http.
 
 // Delete deletes a connection.
 func (connection connection) Delete(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateForbiddenBody(r); err != nil {
-		return nil, err
-	}
 	c, err := connection.id(r)
 	if err != nil {
 		return nil, err
@@ -135,9 +132,6 @@ func (connection connection) Delete(_ http.ResponseWriter, r *http.Request) (any
 
 // DeleteEventWriteKey deletes an event write key of a connection.
 func (connection connection) DeleteEventWriteKey(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateForbiddenBody(r); err != nil {
-		return nil, err
-	}
 	c, err := connection.id(r)
 	if err != nil {
 		return nil, err
@@ -427,9 +421,6 @@ func (connection connection) TableSchema(_ http.ResponseWriter, r *http.Request)
 
 // UnlinkConnection unlink a connection from another connection and vice versa.
 func (connection connection) UnlinkConnection(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateForbiddenBody(r); err != nil {
-		return nil, err
-	}
 	src, err := connection.src(r)
 	if err != nil {
 		return nil, err

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -170,9 +170,6 @@ func (organization organization) Delete(_ http.ResponseWriter, r *http.Request) 
 	if err := organization.authenticateOrganizationsRequest(r); err != nil {
 		return nil, err
 	}
-	if err := validateForbiddenBody(r); err != nil {
-		return nil, err
-	}
 	org, err := organization.core.Organization(r.PathValue("id"))
 	if err != nil {
 		return nil, err
@@ -183,9 +180,6 @@ func (organization organization) Delete(_ http.ResponseWriter, r *http.Request) 
 
 // DeleteAccessKey deletes an access key of an organization.
 func (organization organization) DeleteAccessKey(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateForbiddenBody(r); err != nil {
-		return nil, err
-	}
 	org, _, _, err := organization.authenticateAdminRequest(r)
 	if err != nil {
 		return nil, err
@@ -201,9 +195,6 @@ func (organization organization) DeleteAccessKey(_ http.ResponseWriter, r *http.
 func (organization organization) DeleteMember(_ http.ResponseWriter, r *http.Request) (any, error) {
 	if organization.workos != nil {
 		return nil, errors.Unprocessable(core.BuiltInAuthenticationDisabled, "members cannot be deleted because WorkOS authentication is enabled")
-	}
-	if err := validateForbiddenBody(r); err != nil {
-		return nil, err
 	}
 	org, _, _, err := organization.authenticateAdminRequest(r)
 	if err != nil {

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -18,9 +18,6 @@ type pipeline struct {
 
 // Delete deletes a pipeline.
 func (pipeline pipeline) Delete(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateForbiddenBody(r); err != nil {
-		return nil, err
-	}
 	p, err := pipeline.id(r)
 	if err != nil {
 		return nil, err

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -148,9 +148,6 @@ func (workspace workspace) CreateEventListener(_ http.ResponseWriter, r *http.Re
 
 // Delete deletes the current workspace with all its connections.
 func (workspace workspace) Delete(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateForbiddenBody(r); err != nil {
-		return nil, err
-	}
 	ws, err := workspace.workspace(r)
 	if err != nil {
 		return nil, err
@@ -161,9 +158,6 @@ func (workspace workspace) Delete(_ http.ResponseWriter, r *http.Request) (any, 
 
 // DeleteEventListener deletes an event listener of a workspace.
 func (workspace workspace) DeleteEventListener(_ http.ResponseWriter, r *http.Request) (any, error) {
-	if err := validateForbiddenBody(r); err != nil {
-		return nil, err
-	}
 	ws, err := workspace.workspace(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```
cmd: avoid duplicate validation of `DELETE` request bodies

apisServer.ServeHTTP already rejects DELETE requests with a body, so
individual DELETE handlers do not need to validate this again.
```