### PR TITLE
core/internal/collector: defer metrics until batch publishing succeeds

### DIFF
--- a/core/internal/collector/collector.go
+++ b/core/internal/collector/collector.go
@@ -778,6 +778,9 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 	var destinations []string
 
 	var observedEvents []events.Event
+	var pendingReceivePassed []string
+	var pendingFilterPassed []string
+	var pendingFilterFailed []string
 
 	// Decode the events.
 	for event, err := range dec.Events(connection.ID, connector.FallbackToRequestIP) {
@@ -804,12 +807,12 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 			if !p.Enabled || p.Target != state.TargetEvent {
 				continue
 			}
-			c.metrics.ReceivePassed(p.ID, 1)
+			pendingReceivePassed = append(pendingReceivePassed, p.ID)
 			if !filters.Applies(p.Filter, event) {
-				c.metrics.FilterFailed(p.ID, 1)
+				pendingFilterFailed = append(pendingFilterFailed, p.ID)
 				continue
 			}
-			c.metrics.FilterPassed(p.ID, 1)
+			pendingFilterPassed = append(pendingFilterPassed, p.ID)
 			if _, ok := c.eventWriters.Load(ws.ID); ok {
 				topics = append(topics, "pipeline-"+p.ID)
 			}
@@ -820,12 +823,12 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 			if !p.Enabled || p.Target != state.TargetUser {
 				continue
 			}
-			c.metrics.ReceivePassed(p.ID, 1)
+			pendingReceivePassed = append(pendingReceivePassed, p.ID)
 			if !filters.Applies(p.Filter, event) {
-				c.metrics.FilterFailed(p.ID, 1)
+				pendingFilterFailed = append(pendingFilterFailed, p.ID)
 				continue
 			}
-			c.metrics.FilterPassed(p.ID, 1)
+			pendingFilterPassed = append(pendingFilterPassed, p.ID)
 			if _, ok := c.identityWriters.Load(p.ID); ok {
 				topics = append(topics, "pipeline-"+p.ID)
 			}
@@ -841,12 +844,12 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 				if !p.Enabled || p.Target != state.TargetEvent {
 					continue
 				}
-				c.metrics.ReceivePassed(p.ID, 1)
+				pendingReceivePassed = append(pendingReceivePassed, p.ID)
 				if !filters.Applies(p.Filter, event) {
-					c.metrics.FilterFailed(p.ID, 1)
+					pendingFilterFailed = append(pendingFilterFailed, p.ID)
 					continue
 				}
-				c.metrics.FilterPassed(p.ID, 1)
+				pendingFilterPassed = append(pendingFilterPassed, p.ID)
 				destinations = append(destinations, p.ID)
 			}
 			if len(destinations) > 0 {
@@ -871,6 +874,15 @@ func (c *Collector) serveEvents(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
+	for _, pipeline := range pendingReceivePassed {
+		c.metrics.ReceivePassed(pipeline, 1)
+	}
+	for _, pipeline := range pendingFilterPassed {
+		c.metrics.FilterPassed(pipeline, 1)
+	}
+	for _, pipeline := range pendingFilterFailed {
+		c.metrics.FilterFailed(pipeline, 1)
+	}
 	for _, event := range observedEvents {
 		observer.addEvent(event)
 	}


### PR DESCRIPTION
```
core/internal/collector: defer metrics until batch publishing succeeds

To avoid recording metrics for unsuccessful pipeline processing, keep
pipeline metric updates pending while preparing the event batch.

Apply receive and filter metrics only after BatchPublisher.Done returns
successfully, so failed Publish or Done calls do not affect the metrics.
```