### PR TITLE
core/internal/collector/sender: fix a race in the sender test

### DIFF
--- a/core/internal/collector/sender/sender_test.go
+++ b/core/internal/collector/sender/sender_test.go
@@ -795,7 +795,7 @@ type application struct {
 	seed uint64
 
 	mu        sync.Mutex
-	iteration uint64
+	iteration uint64   // protected by mu
 	n         int      // protected by mu
 	consumed  []string // ids of the consumed events; protected by mu
 	sends     []send   // protected by mu

--- a/core/internal/collector/sender/sender_test.go
+++ b/core/internal/collector/sender/sender_test.go
@@ -844,13 +844,13 @@ func (app *application) SendEvents(ctx context.Context, events connectors.Events
 	// Get the current iteration number.
 	var iteration uint64
 	app.mu.Lock()
+	if app.iteration == math.MaxUint64 {
+		app.mu.Unlock()
+		panic("iteration is out of range")
+	}
 	iteration = app.iteration
 	app.iteration++
 	app.mu.Unlock()
-
-	if app.iteration == math.MaxUint64 {
-		panic("iteration is out of range")
-	}
 
 	seed := app.seed + iteration
 	src := rand.NewPCG(seed, ^seed)


### PR DESCRIPTION
```
core/internal/collector/sender: fix a race in the sender test (#2386)

The test read app.iteration without holding the mutex that protects it,
causing a data race. It also checked the counter after incrementing it,
allowing concurrent calls to wrap it to zero before the check and
leaving the overflow undetected.
```