### PR TITLE
core/internal/collector/sender: preserve event order after discard

### DIFF
--- a/core/internal/collector/sender/sender.go
+++ b/core/internal/collector/sender/sender.go
@@ -359,6 +359,7 @@ func (s *Sender) discard(err error) {
 	s.iterator.numConsumed--
 	if s.iterator.numConsumed == 0 {
 		s.iterator.sameUser.user = nil
+		s.iterator.index = i + 1
 	}
 	trace("Sender.discard: iterator %p; discard index %d, current %d; pipeline %s, message ID %q\n",
 		s.iterator, i, s.iterator.index, e.pipeline, e.Received.MessageID())

--- a/core/internal/collector/sender/sender_test.go
+++ b/core/internal/collector/sender/sender_test.go
@@ -226,6 +226,91 @@ func Test_Sender_DiscardedOutOfOrderEvent(t *testing.T) {
 	})
 }
 
+// Test_Sender_SameUserRebindPreservesOrder verifies that, after Peek skips an
+// event from another user, discarding the iterator's only consumed event allows
+// it to bind to the skipped event's user without consuming events out of order.
+func Test_Sender_SameUserRebindPreservesOrder(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+
+		var delivered []string
+		var peeked string
+		var peekedOK bool
+		var unexpected []string
+		done := make(chan struct{})
+		discardErr := errors.New("event is invalid")
+
+		app := newTestApplication()
+		app.SendEventsFunc = func(_ context.Context, events connectors.Events) error {
+			for event := range events.SameUser() {
+				switch id := event.Received.MessageID(); id {
+				case "w-0":
+					// Peek the next event of the same user, reading past the
+					// event of the other user that precedes it.
+					peekedEvent, ok := events.Peek()
+					peekedOK = ok
+					if ok {
+						peeked = peekedEvent.Received.MessageID()
+					}
+					events.Discard(discardErr)
+				case "w-1":
+					events.Discard(discardErr)
+				case "u-0", "u-1":
+					delivered = append(delivered, id)
+					if len(delivered) == 2 {
+						close(done)
+					}
+				default:
+					unexpected = append(unexpected, id)
+				}
+			}
+			return nil
+		}
+		s := New(app, nil)
+		defer s.Close(t.Context())
+
+		newEvent := func(anonymousID, messageID string) *Event {
+			return s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
+				Attributes: map[string]any{
+					"anonymousId": anonymousID,
+					"messageId":   messageID,
+				},
+				Ack: nopAck,
+			})
+		}
+
+		// Discarding w-0 releases user-w, so the iteration binds to user-u
+		// after Peek has already read past u-0 to find w-1.
+		s.SendEvent(newEvent("user-w", "w-0"))
+		s.SendEvent(newEvent("user-u", "u-0"))
+		s.SendEvent(newEvent("user-w", "w-1"))
+		s.SendEvent(newEvent("user-u", "u-1"))
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for events")
+		}
+
+		s.Close(t.Context())
+
+		if !peekedOK {
+			t.Fatal("expected Peek to return an event")
+		}
+		if peeked != "w-1" {
+			t.Fatalf("expected Peek to return event %q, got %q", "w-1", peeked)
+		}
+		if len(unexpected) != 0 {
+			t.Fatalf("unexpected delivered events: %v", unexpected)
+		}
+
+		want := []string{"u-0", "u-1"}
+		if !slices.Equal(delivered, want) {
+			t.Fatalf("expected the events delivered in order %v, got %v", want, delivered)
+		}
+
+	})
+}
+
 // Test_Sender_SequenceOverflowRescale verifies that per-user ordering holds
 // across sequence overflow.
 func Test_Sender_SequenceOverflowRescale(t *testing.T) {


### PR DESCRIPTION
```
core/internal/collector/sender: preserve event order after discard (#2387)

While iterating over connectors.Events.SameUser, Peek can advance the
read index past queued events belonging to other users while searching
for the next event from the selected user.

If the current event is then discarded and no previously consumed events
remain, Discard clears the SameUser selection. The next read can then
select a different user, but it starts from the index advanced by Peek
and skips the events in between.

As a result, a newer event from that user can be consumed before an
older one. When Discard clears the SameUser selection, reset the read
index to the position immediately after the discarded event so that the
skipped events are considered again.

Fixes #2222
```