### PR TITLE
core/internal/collector/sender: use selected event when reading

### DIFF
--- a/core/internal/collector/sender/sender.go
+++ b/core/internal/collector/sender/sender.go
@@ -564,7 +564,7 @@ func (s *Sender) read(consume bool) (*Event, bool) {
 	}
 	s.iterator.index = i
 	if event != nil && consume {
-		s.queue.events[i].iterator = s.iterator
+		event.iterator = s.iterator
 		s.iterator.index++
 		if event.user.consumed == 0 {
 			event.user.iterator = s.iterator


### PR DESCRIPTION
```
core/internal/collector/sender: use selected event when reading (#2388)

Set the iterator directly on the event selected while scanning the
queue, instead of looking it up again by its queue index. This makes the
code clearer and avoids accessing the queue a second time.
```