### PR TITLE
core/internal/collector: use Base58 for event listener IDs

### DIFF
--- a/core/internal/collector/observer.go
+++ b/core/internal/collector/observer.go
@@ -16,11 +16,10 @@ import (
 	"github.com/krenalis/krenalis/core/internal/filters"
 	"github.com/krenalis/krenalis/core/internal/schemas"
 	"github.com/krenalis/krenalis/core/internal/state"
+	"github.com/krenalis/krenalis/tools/base58"
 	"github.com/krenalis/krenalis/tools/errors"
 	"github.com/krenalis/krenalis/tools/json"
 	"github.com/krenalis/krenalis/tools/types"
-
-	"github.com/google/uuid"
 )
 
 const MaxEventListeners = 100 // maximum number of event listeners.
@@ -93,7 +92,7 @@ func newObserver() *Observer {
 // It returns the ErrTooManyListeners error if there are already too many
 // listeners.
 func (observer *Observer) CreateListener(connections []string, size int, filter *state.Where) (string, error) {
-	id := uuid.New().String()
+	id := base58.Generate(12)
 	listener := listener{
 		id:          id,
 		connections: connections,


### PR DESCRIPTION
```
core/internal/collector: use Base58 for event listener IDs (#2393)
```