### PR TITLE
core/internal/streams: introduce event acknowledgment interface

### DIFF
--- a/core/internal/collector/destination_pipeline.go
+++ b/core/internal/collector/destination_pipeline.go
@@ -184,7 +184,7 @@ func (dp *destinationPipeline) transform() {
 	if err != nil {
 		for i := range n {
 			dp.queue.sender.DiscardEvent(events[i].senderEvent)
-			events[i].streamEvent.Ack()
+			events[i].streamEvent.Ack.Acknowledge()
 		}
 		var msg string
 		if _, ok := err.(transformers.FunctionExecError); ok {
@@ -202,7 +202,7 @@ func (dp *destinationPipeline) transform() {
 	for i, record := range records {
 		if err := record.Err; err != nil {
 			dp.queue.sender.DiscardEvent(events[i].senderEvent)
-			events[i].streamEvent.Ack()
+			events[i].streamEvent.Ack.Acknowledge()
 			switch err.(type) {
 			case transformers.RecordTransformationError:
 				dp.queue.metrics.TransformationFailed(dp.id, 1, err.Error())

--- a/core/internal/collector/identitywriter.go
+++ b/core/internal/collector/identitywriter.go
@@ -132,7 +132,7 @@ func (iw *identityWriter) transformAndWrite(events []streams.Event) {
 	err := transformer.Transform(ctx, records)
 	if err != nil {
 		for _, event := range events {
-			event.Ack()
+			event.Ack.Acknowledge()
 		}
 		if err2, ok := err.(transformers.FunctionExecError); ok {
 			iw.metrics.TransformationFailed(iw.pipeline, len(records), err2.Error())
@@ -151,7 +151,7 @@ func (iw *identityWriter) transformAndWrite(events []streams.Event) {
 				iw.metrics.TransformationPassed(iw.pipeline, 1)
 				iw.metrics.OutputValidationFailed(iw.pipeline, 1, err.Error())
 			}
-			events[i].Ack()
+			events[i].Ack.Acknowledge()
 			continue
 		}
 		iw.metrics.TransformationPassed(iw.pipeline, 1)

--- a/core/internal/collector/sender/sender.go
+++ b/core/internal/collector/sender/sender.go
@@ -747,7 +747,7 @@ func (s *Sender) send(ctx context.Context, iter *iterator, rateLimiterPattern st
 	}
 
 	for _, ack := range acks {
-		ack()
+		ack.Acknowledge()
 	}
 
 	for key, count := range metricsCounts {

--- a/core/internal/collector/sender/sender_randomized_test.go
+++ b/core/internal/collector/sender/sender_randomized_test.go
@@ -106,7 +106,7 @@ func testSenderRandomScenario(t *testing.T, test senderRandomTest) senderRandomC
 				"anonymousId": anonymousID,
 				"messageId":   messageID,
 			},
-			Ack: nopAck,
+			Ack: nopAck{},
 		})
 		expectedEvents[messageID] = senderRandomExpectedEvent{
 			anonymousID: anonymousID,

--- a/core/internal/collector/sender/sender_test.go
+++ b/core/internal/collector/sender/sender_test.go
@@ -169,7 +169,10 @@ func Test_iterator_invalidUsage(t *testing.T) {
 }
 
 // nopAck is a no-op streams.Ack implementation.
-func nopAck() {}
+type nopAck struct{}
+
+// Acknowledge implements streams.Ack.
+func (nopAck) Acknowledge() {}
 
 // Test_Sender_DiscardedOutOfOrderEvent verifies that discarding an out-of-order
 // event does not prevent delivering the next event exactly once.
@@ -195,14 +198,14 @@ func Test_Sender_DiscardedOutOfOrderEvent(t *testing.T) {
 				"anonymousId": "user",
 				"messageId":   "msg-0",
 			},
-			Ack: nopAck,
+			Ack: nopAck{},
 		})
 		event1 := s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
 			Attributes: map[string]any{
 				"anonymousId": "user",
 				"messageId":   "msg-1",
 			},
-			Ack: nopAck,
+			Ack: nopAck{},
 		})
 
 		s.DiscardEvent(event1)
@@ -265,7 +268,7 @@ func Test_Sender_SameUserRebindPreservesOrder(t *testing.T) {
 					"anonymousId": anonymousID,
 					"messageId":   messageID,
 				},
-				Ack: nopAck,
+				Ack: nopAck{},
 			})
 		}
 
@@ -335,7 +338,7 @@ func Test_Sender_SequenceOverflowRescale(t *testing.T) {
 					"anonymousId": userID,
 					"messageId":   messageID,
 				},
-				Ack: nopAck,
+				Ack: nopAck{},
 			})
 		}
 
@@ -388,7 +391,7 @@ func Test_Sender_RetryAfterSendEventsErrorWithoutIteration(t *testing.T) {
 				"anonymousId": "user",
 				"messageId":   "msg-0",
 			},
-			Ack: nopAck,
+			Ack: nopAck{},
 		})
 		s.SendEvent(event)
 
@@ -592,7 +595,7 @@ func Test_Sender_UserRemoval(t *testing.T) {
 				"anonymousId": "user-1",
 				"messageId":   "msg-1",
 			},
-			Ack: nopAck,
+			Ack: nopAck{},
 		})
 
 		s.DiscardEvent(event)
@@ -629,7 +632,7 @@ func Test_Sender_UserRemoval(t *testing.T) {
 				"anonymousId": "user-2",
 				"messageId":   "msg-2",
 			},
-			Ack: nopAck,
+			Ack: nopAck{},
 		})
 		s.SendEvent(event)
 
@@ -667,7 +670,7 @@ func Test_Sender_UserRemoval(t *testing.T) {
 				"anonymousId": "user-3",
 				"messageId":   "msg-3",
 			},
-			Ack: nopAck,
+			Ack: nopAck{},
 		})
 		s.SendEvent(event)
 
@@ -693,6 +696,6 @@ func createTestEvent(s *Sender, i int) *Event {
 			"anonymousId": "user123",
 			"messageId":   fmt.Sprintf("msg-%d", i),
 		},
-		Ack: nopAck,
+		Ack: nopAck{},
 	})
 }

--- a/core/internal/datastore/flusher.go
+++ b/core/internal/datastore/flusher.go
@@ -23,7 +23,7 @@ type flusherRow[T any] struct {
 	pipeline string      // pipeline identifier; if empty, no metrics are recorded
 	key      any         // deduplication key; if nil, deduplication is disabled
 	row      T           // row to be flushed
-	ack      streams.Ack // ack callback; if nil, it is not invoked
+	ack      streams.Ack // event acknowledgment; if nil, it is not performed
 }
 
 type flusher[T any] struct {
@@ -199,7 +199,7 @@ func (f *flusher[T]) loop(opts flusherOptions, startOperation startOperationFunc
 			return
 		}
 		for _, ack := range acks {
-			ack()
+			ack.Acknowledge()
 		}
 		for pipeline, count := range metrics {
 			opts.MetricsFinalizer(pipeline, count)

--- a/core/internal/datastore/flusher_test.go
+++ b/core/internal/datastore/flusher_test.go
@@ -19,6 +19,16 @@ type testRow struct {
 	id int
 }
 
+// testAck is a streams.Ack implementation for tests.
+type testAck struct {
+	acknowledge func()
+}
+
+// Acknowledge implements streams.Ack.
+func (a testAck) Acknowledge() {
+	a.acknowledge()
+}
+
 const (
 	testPipeline1 = "8QaT3mN7KxP5"
 	testPipeline2 = "5zBpR9Y2QnM3"
@@ -322,7 +332,7 @@ func TestFlusherAckAfterRetry(t *testing.T) {
 		}
 		f := newTestFlusher(opts, flushFn)
 		f.Ch() <- flusherRow[testRow]{row: testRow{id: 1}, ack: nil}
-		f.Ch() <- flusherRow[testRow]{row: testRow{id: 2}, ack: ack}
+		f.Ch() <- flusherRow[testRow]{row: testRow{id: 2}, ack: testAck{acknowledge: ack}}
 
 		<-thirdStart
 		if got := ackCount.Load(); got != 0 {
@@ -366,7 +376,7 @@ func TestFlusherStartOperationRetry(t *testing.T) {
 		}
 		acked := make(chan struct{}, 1)
 		f := newFlusher[testRow](opts, startOp, flushFn)
-		f.Ch() <- flusherRow[testRow]{row: testRow{id: 1}, ack: func() { acked <- struct{}{} }}
+		f.Ch() <- flusherRow[testRow]{row: testRow{id: 1}, ack: testAck{acknowledge: func() { acked <- struct{}{} }}}
 
 		receiveWithin(t, flushCh, 30*time.Second, "flush")
 		receiveWithin(t, acked, 30*time.Second, "ack")
@@ -406,7 +416,7 @@ func TestFlusherStartOperationCanceled(t *testing.T) {
 		}
 		acked := make(chan struct{}, 1)
 		f := newFlusher[testRow](opts, startOp, flushFn)
-		f.Ch() <- flusherRow[testRow]{row: testRow{id: 1}, ack: func() { acked <- struct{}{} }}
+		f.Ch() <- flusherRow[testRow]{row: testRow{id: 1}, ack: testAck{acknowledge: func() { acked <- struct{}{} }}}
 
 		<-started
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -532,7 +542,7 @@ func TestFlusherRetryLogErrorDedup(t *testing.T) {
 			return nil
 		}
 		f := newTestFlusher(opts, flushFn)
-		f.Ch() <- flusherRow[testRow]{row: testRow{id: 1}, pipeline: testPipeline1, ack: ack}
+		f.Ch() <- flusherRow[testRow]{row: testRow{id: 1}, pipeline: testPipeline1, ack: testAck{acknowledge: ack}}
 
 		receiveWithin(t, ackCh, 30*time.Second, "ack")
 		receiveWithin(t, finalizeCh, 30*time.Second, "metrics finalize")

--- a/core/internal/streams/nats/nats.go
+++ b/core/internal/streams/nats/nats.go
@@ -522,11 +522,7 @@ func (s *stream) Consume(topic string, size int) streams.Consumer {
 							event.Destinations = destinations
 						}
 					}
-					event.Ack = func() {
-						if err := msg.Ack(); err != nil {
-							slog.Warn(fmt.Sprintf("collector: cannot ack event: %s", err))
-						}
-					}
+					event.Ack = &ack{msg: msg}
 					select {
 					case consumer.events <- event:
 					case <-done:
@@ -553,6 +549,18 @@ func (s *stream) Consume(topic string, size int) streams.Consumer {
 		<-done
 	}()
 	return consumer
+}
+
+// ack acknowledges a NATS event.
+type ack struct {
+	msg jetstream.Msg
+}
+
+// Acknowledge acknowledges the event.
+func (a *ack) Acknowledge() {
+	if err := a.msg.Ack(); err != nil {
+		slog.Warn(fmt.Sprintf("collector: cannot ack event: %s", err))
+	}
 }
 
 // consumer implements the streams.Consumer interface.

--- a/core/internal/streams/stream.go
+++ b/core/internal/streams/stream.go
@@ -71,8 +71,11 @@ type BatchPublisher interface {
 	Done(ctx context.Context) error
 }
 
-// Ack acknowledges an event.
-type Ack func()
+// Ack acknowledges an event read from a stream.
+type Ack interface {
+	// Acknowledge acknowledges the event.
+	Acknowledge()
+}
 
 // Event represents an event read from the stream.
 type Event struct {


### PR DESCRIPTION
```
core/internal/streams: introduce event acknowledgment interface (#2394)

Replace the function-based event acknowledgment callback with an Ack
interface and propagate it through the collector, sender, and datastore.

This is the first commit in a series.

Keep the current acknowledgment behavior unchanged while preparing the
abstraction for subsequent commits in this series, which will add
support for long-running event processing.

```