### PR TITLE
core/internal/streams/nats: prevent prefetched event redelivery

### DIFF
--- a/core/internal/streams/nats/nats.go
+++ b/core/internal/streams/nats/nats.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"iter"
 	"log/slog"
 	"slices"
 	"strconv"
@@ -447,138 +448,56 @@ func (s *stream) Batch(ctx context.Context) (streams.BatchPublisher, error) {
 // the specified topic. Events belonging to the same shard are sent on the
 // channel in order, ensuring per-user ordering is preserved.
 func (s *stream) Consume(topic string, size int) streams.Consumer {
-	ctx, cancel := context.WithCancel(context.Background())
-	consumer := &consumer{
-		stream: s,
-		events: make(chan streams.Event, size),
-		cancel: cancel,
-		acks:   newAckManager(s.ackWait),
-	}
-	done := ctx.Done()
-	go func() {
-		ccs := make([]jetstream.ConsumeContext, 0, numShards)
-		var wg sync.WaitGroup
-		var mu sync.Mutex
-		closing := false
-		defer func() {
-			mu.Lock()
-			closing = true
-			mu.Unlock()
-			// Stop the consumers.
-			for _, cc := range ccs {
-				cc.Stop()
-			}
-			wg.Wait()
-			consumer.acks.Close()
-			// The channel is closed only after no callback can send to it.
-			close(consumer.events)
-		}()
-		err := s.waitStream(ctx)
-		if err != nil {
-			return
-		}
-		for shard := range numShards {
-			consumerName := "EVENTS_" + topic + "_" + strconv.Itoa(shard)
-			filterSubject := "events.v1." + topic + "." + strconv.Itoa(shard)
-			var cc jetstream.ConsumeContext
-			bo := backoff.New(10)
-			for bo.Next(ctx) {
-				jsConsumer, err := s.js.jetStream.CreateOrUpdateConsumer(ctx, "EVENTS", jetstream.ConsumerConfig{
-					Name:          consumerName,
-					Durable:       consumerName,
-					FilterSubject: filterSubject,
-					AckPolicy:     jetstream.AckExplicitPolicy,
-					AckWait:       s.ackWait,
-					MaxDeliver:    -1,
-					MaxAckPending: -1,
-				})
-				if err != nil {
-					if ctx.Err() != nil {
-						return
-					}
-					slog.Warn("cannot create or update a NATS consumer", "name", consumerName)
-					continue
-				}
-				cc, err = jsConsumer.Consume(func(msg jetstream.Msg) {
-					mu.Lock()
-					if closing {
-						mu.Unlock()
-						_ = msg.Nak()
-						return
-					}
-					wg.Add(1)
-					mu.Unlock()
-					defer wg.Done()
-					eventAck := consumer.acks.Track(msg)
-					var event streams.Event
-					var err error
-					defer func() {
-						if err != nil {
-							eventAck.Stop()
-							termErr := msg.TermWithReason(err.Error())
-							if termErr != nil {
-								slog.Warn("collector: cannot terminate invalid event", "error", termErr)
-							}
-						}
-					}()
-					event.Attributes, err = types.Decode[map[string]any](bytes.NewReader(msg.Data()), schemas.Event)
-					if err != nil {
-						err = fmt.Errorf("invalid event data: %s", err)
-						return
-					}
-					var destinations []string
-					if header := msg.Headers(); header != nil {
-						if ids, ok := header["destinations"]; ok {
-							for _, id := range ids {
-								if !isValidDestination(id) {
-									err = fmt.Errorf("invalid event destination: %q", id)
-									return
-								}
-							}
-							destinations = ids
-						}
-					}
-					event.Destinations = destinationsForMessage(eventAck, destinations)
-					select {
-					case consumer.events <- event:
-					case <-done:
-						eventAck.Stop()
-						if err := msg.Nak(); err != nil {
-							slog.Warn("cannot send nack for a NATS message", "error", err)
-						}
-						return
-					}
-				})
-				if err != nil && ctx.Err() == nil {
-					if errors.Is(err, jetstream.ErrConsumerDoesNotExist) {
-						continue
-					}
-					slog.Warn("cannot consume messages from a NATS consumer", "consumer", consumerName)
-					continue
-				}
-				break
-			}
-			if ctx.Err() != nil {
-				return
-			}
-			ccs = append(ccs, cc)
-		}
-		<-done
-	}()
-	return consumer
+	return newConsumer(s, topic, size)
 }
 
 // consumer implements the streams.Consumer interface.
 type consumer struct {
 	stream *stream
+	topic  string
 	events chan streams.Event
-	cancel context.CancelFunc
 	acks   *ackManager
+	close  struct {
+		cancel context.CancelFunc // stops shard consumption
+		closed atomic.Bool        // indicates whether Close has been called
+		sync.WaitGroup
+	}
 }
 
-// Close closes the consumer and eventually closes the events channel.
+// newConsumer creates a consumer and starts consuming events from topic.
+func newConsumer(s *stream, topic string, size int) *consumer {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &consumer{
+		stream: s,
+		topic:  topic,
+		events: make(chan streams.Event, size),
+		acks:   newAckManager(s.ackWait),
+	}
+	c.close.cancel = cancel
+	for shard := range numShards {
+		c.close.Go(func() {
+			sc := newShardConsumer(c, shard)
+			for message := range sc.Messages(ctx) {
+				c.processMessage(ctx, message.msg, message.ack)
+			}
+		})
+	}
+	return c
+}
+
+// Close closes the consumer and its events channel. When Close is called, no
+// calls to other consumer methods should be in progress, and no other methods
+// should be called afterward.
+//
+// Close is idempotent; subsequent calls have no effect.
 func (c *consumer) Close() {
-	c.cancel()
+	if c.close.closed.Swap(true) {
+		return
+	}
+	c.close.cancel()
+	c.close.Wait()
+	c.acks.Close()
+	close(c.events)
 }
 
 // Events returns the events channel.
@@ -591,6 +510,186 @@ func (c *consumer) Events(ctx context.Context) (<-chan streams.Event, error) {
 		return nil, err
 	}
 	return c.events, nil
+}
+
+// processMessage decodes and validates a NATS message, then delivers the
+// resulting event to the consumer. If ctx is canceled, it stops acknowledgment
+// tracking and negatively acknowledges the message.
+func (c *consumer) processMessage(ctx context.Context, msg jetstream.Msg, eventAck *ack) {
+	select {
+	case <-ctx.Done():
+		eventAck.Stop()
+		if err := msg.Nak(); err != nil {
+			slog.Warn("cannot send nack for a NATS message", "error", err)
+		}
+		return
+	default:
+	}
+
+	var event streams.Event
+	var err error
+	defer func() {
+		if err != nil {
+			eventAck.Stop()
+			termErr := msg.TermWithReason(err.Error())
+			if termErr != nil {
+				slog.Warn("collector: cannot terminate invalid event", "error", termErr)
+			}
+		}
+	}()
+	event.Attributes, err = types.Decode[map[string]any](bytes.NewReader(msg.Data()), schemas.Event)
+	if err != nil {
+		err = fmt.Errorf("invalid event data: %s", err)
+		return
+	}
+	var destinations []string
+	if header := msg.Headers(); header != nil {
+		if ids, ok := header["destinations"]; ok {
+			for _, id := range ids {
+				if !isValidDestination(id) {
+					err = fmt.Errorf("invalid event destination: %q", id)
+					return
+				}
+			}
+			destinations = ids
+		}
+	}
+	event.Destinations = destinationsForMessage(eventAck, destinations)
+	select {
+	case c.events <- event:
+	case <-ctx.Done():
+		eventAck.Stop()
+		if err := msg.Nak(); err != nil {
+			slog.Warn("cannot send nack for a NATS message", "error", err)
+		}
+	}
+}
+
+// maxMessagesPerFetch preserves the NATS client's default pull size while
+// bounding the number of messages waiting to be processed for each shard.
+const maxMessagesPerFetch = jetstream.DefaultMaxMessages
+
+// fetchedMsg represents a message fetched from a stream for one shard.
+type fetchedMsg struct {
+	msg jetstream.Msg
+	ack *ack
+}
+
+// shardConsumer fetches and buffers messages for one shard.
+type shardConsumer struct {
+	consumer *consumer
+	shard    int
+}
+
+// newShardConsumer returns a consumer for one shard.
+func newShardConsumer(consumer *consumer, shard int) *shardConsumer {
+	return &shardConsumer{consumer: consumer, shard: shard}
+}
+
+// Messages returns an iterator over messages fetched from the shard.
+func (sc *shardConsumer) Messages(ctx context.Context) iter.Seq[fetchedMsg] {
+	return func(yield func(fetchedMsg) bool) {
+		if err := sc.consumer.stream.waitStream(ctx); err != nil {
+			return
+		}
+
+		fetchCtx, cancel := context.WithCancel(ctx)
+		pending := make(chan fetchedMsg, maxMessagesPerFetch)
+		// spaceAvailable wakes the fetch loop when processing frees a full queue.
+		spaceAvailable := make(chan struct{}, 1)
+		go sc.fetch(fetchCtx, pending, spaceAvailable)
+		defer func() {
+			cancel()
+			for message := range pending {
+				message.ack.Stop()
+				if err := message.msg.Nak(); err != nil {
+					slog.Warn("cannot send nack for a NATS message", "error", err)
+				}
+			}
+		}()
+
+		for message := range pending {
+			if !yield(message) {
+				return
+			}
+			select {
+			case spaceAvailable <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// fetch keeps pending filled with tracked messages until fetching stops.
+func (sc *shardConsumer) fetch(ctx context.Context, pending chan<- fetchedMsg, spaceAvailable <-chan struct{}) {
+	defer close(pending)
+
+	c := sc.consumer
+	consumerName := "EVENTS_" + c.topic + "_" + strconv.Itoa(sc.shard)
+	filterSubject := "events.v1." + c.topic + "." + strconv.Itoa(sc.shard)
+	bo := backoff.New(10)
+
+	for bo.Next(ctx) {
+		jsConsumer, err := c.stream.js.jetStream.CreateOrUpdateConsumer(ctx, "EVENTS", jetstream.ConsumerConfig{
+			Name:          consumerName,
+			Durable:       consumerName,
+			FilterSubject: filterSubject,
+			AckPolicy:     jetstream.AckExplicitPolicy,
+			AckWait:       c.stream.ackWait,
+			MaxDeliver:    -1,
+			MaxAckPending: -1,
+		})
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			slog.Warn("cannot create or update a NATS consumer", "name", consumerName)
+			continue
+		}
+
+		for ctx.Err() == nil {
+			// Do not fetch until every returned message is guaranteed to fit in
+			// pending without waiting for the preceding message to be processed.
+			for len(pending) == cap(pending) {
+				select {
+				case <-spaceAvailable:
+				case <-ctx.Done():
+					return
+				}
+			}
+
+			batchSize := cap(pending) - len(pending)
+			batch, err := jsConsumer.Fetch(batchSize, jetstream.FetchContext(ctx))
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				if !errors.Is(err, jetstream.ErrConsumerDoesNotExist) {
+					slog.Warn("failed to fetch messages from NATS consumer", "consumer", consumerName, "error", err)
+				}
+				break
+			}
+
+			for msg := range batch.Messages() {
+				// batchSize reserves enough queue capacity for the whole batch.
+				pending <- fetchedMsg{msg: msg, ack: c.acks.Track(msg)}
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			if err := batch.Error(); err != nil {
+				if !errors.Is(err, jetstream.ErrConsumerDoesNotExist) {
+					slog.Warn("failed to fetch messages from NATS consumer", "consumer", consumerName, "error", err)
+				}
+				break
+			}
+
+			// A completed fetch marks the end of a sequence of transient errors.
+			// TODO(marco): add a Reset method to backoff.Backoff and replace the
+			// following assignment with bo.Reset().
+			bo = backoff.New(10)
+		}
+	}
 }
 
 // batch implements the streams.Batch interface.

--- a/core/internal/streams/nats/nats.go
+++ b/core/internal/streams/nats/nats.go
@@ -478,18 +478,18 @@ func newConsumer(s *stream, topic string, size int) *consumer {
 		c.close.Go(func() {
 			sc := newShardConsumer(c, shard)
 			for message := range sc.Messages(ctx) {
-				c.processMessage(ctx, message.msg, message.ack)
+				c.processMessage(ctx, message)
 			}
 		})
 	}
 	return c
 }
 
-// Close closes the consumer and its events channel. When Close is called, no
-// calls to other consumer methods should be in progress, and no other methods
-// should be called afterward.
+// Close closes the consumer and its events channel.
 //
-// Close is idempotent; subsequent calls have no effect.
+// No call to Events may be in progress when Close is called, and Events must not
+// be called afterward. Close may be called more than once, but calls must not
+// overlap. Calls made after the first one has completed have no effect.
 func (c *consumer) Close() {
 	if c.close.closed.Swap(true) {
 		return
@@ -515,13 +515,12 @@ func (c *consumer) Events(ctx context.Context) (<-chan streams.Event, error) {
 // processMessage decodes and validates a NATS message, then delivers the
 // resulting event to the consumer. If ctx is canceled, it stops acknowledgment
 // tracking and negatively acknowledges the message.
-func (c *consumer) processMessage(ctx context.Context, msg jetstream.Msg, eventAck *ack) {
+func (c *consumer) processMessage(ctx context.Context, message fetchedMsg) {
+	msg := message.msg
+	eventAck := message.ack
 	select {
 	case <-ctx.Done():
-		eventAck.Stop()
-		if err := msg.Nak(); err != nil {
-			slog.Warn("cannot send nack for a NATS message", "error", err)
-		}
+		message.nack()
 		return
 	default:
 	}
@@ -558,10 +557,7 @@ func (c *consumer) processMessage(ctx context.Context, msg jetstream.Msg, eventA
 	select {
 	case c.events <- event:
 	case <-ctx.Done():
-		eventAck.Stop()
-		if err := msg.Nak(); err != nil {
-			slog.Warn("cannot send nack for a NATS message", "error", err)
-		}
+		message.nack()
 	}
 }
 
@@ -577,6 +573,15 @@ const minFetchBatchSize = maxMessagesPerFetch / 2
 type fetchedMsg struct {
 	msg jetstream.Msg
 	ack *ack
+}
+
+// nack stops acknowledgment tracking and negatively acknowledges the message.
+func (message fetchedMsg) nack() {
+	message.ack.Stop()
+	err := message.msg.Nak()
+	if err != nil {
+		slog.Warn("cannot send nack for a NATS message", "error", err)
+	}
 }
 
 // shardConsumer fetches and buffers messages for one shard.
@@ -605,10 +610,7 @@ func (sc *shardConsumer) Messages(ctx context.Context) iter.Seq[fetchedMsg] {
 		defer func() {
 			cancel()
 			for message := range pending {
-				message.ack.Stop()
-				if err := message.msg.Nak(); err != nil {
-					slog.Warn("cannot send nack for a NATS message", "error", err)
-				}
+				message.nack()
 			}
 		}()
 
@@ -669,7 +671,7 @@ func (sc *shardConsumer) fetch(ctx context.Context, pending chan<- fetchedMsg, s
 					return
 				}
 				if !errors.Is(err, jetstream.ErrConsumerDoesNotExist) {
-					slog.Warn("failed to fetch messages from NATS consumer", "consumer", consumerName, "error", err)
+					slog.Warn("cannot fetch messages from a NATS consumer", "consumer", consumerName, "error", err)
 				}
 				break
 			}
@@ -683,7 +685,7 @@ func (sc *shardConsumer) fetch(ctx context.Context, pending chan<- fetchedMsg, s
 			}
 			if err := batch.Error(); err != nil {
 				if !errors.Is(err, jetstream.ErrConsumerDoesNotExist) {
-					slog.Warn("failed to fetch messages from NATS consumer", "consumer", consumerName, "error", err)
+					slog.Warn("cannot fetch messages from a NATS consumer", "consumer", consumerName, "error", err)
 				}
 				break
 			}

--- a/core/internal/streams/nats/nats.go
+++ b/core/internal/streams/nats/nats.go
@@ -569,6 +569,10 @@ func (c *consumer) processMessage(ctx context.Context, msg jetstream.Msg, eventA
 // bounding the number of messages waiting to be processed for each shard.
 const maxMessagesPerFetch = jetstream.DefaultMaxMessages
 
+// minFetchBatchSize prevents slow message processing from reducing fetches to
+// individual messages.
+const minFetchBatchSize = maxMessagesPerFetch / 2
+
 // fetchedMsg represents a message fetched from a stream for one shard.
 type fetchedMsg struct {
 	msg jetstream.Msg
@@ -595,7 +599,7 @@ func (sc *shardConsumer) Messages(ctx context.Context) iter.Seq[fetchedMsg] {
 
 		fetchCtx, cancel := context.WithCancel(ctx)
 		pending := make(chan fetchedMsg, maxMessagesPerFetch)
-		// spaceAvailable wakes the fetch loop when processing frees a full queue.
+		// spaceAvailable wakes the fetch loop as processing frees pending slots.
 		spaceAvailable := make(chan struct{}, 1)
 		go sc.fetch(fetchCtx, pending, spaceAvailable)
 		defer func() {
@@ -648,9 +652,9 @@ func (sc *shardConsumer) fetch(ctx context.Context, pending chan<- fetchedMsg, s
 		}
 
 		for ctx.Err() == nil {
-			// Do not fetch until every returned message is guaranteed to fit in
-			// pending without waiting for the preceding message to be processed.
-			for len(pending) == cap(pending) {
+			// Wait for enough room to keep fetches batched. The resulting batch size
+			// also guarantees that every returned message fits in pending.
+			for cap(pending)-len(pending) < minFetchBatchSize {
 				select {
 				case <-spaceAvailable:
 				case <-ctx.Done():

--- a/core/internal/streams/nats/nats_test.go
+++ b/core/internal/streams/nats/nats_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/krenalis/krenalis/core/internal/streams"
 	"github.com/krenalis/krenalis/core/natsopts"
 
+	gonats "github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -141,6 +142,91 @@ func TestAckStopPreventsDestinationAcknowledgment(t *testing.T) {
 	})
 }
 
+// TestConsumerTracksFetchedMessagesWhileDecodingIsBlocked verifies that
+// acknowledgment heartbeats are sent for every fetched message while the first
+// message is waiting to be decoded. It also verifies that fetching resumes as
+// processing makes space in the pending queue.
+func TestConsumerTracksFetchedMessagesWhileDecodingIsBlocked(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		messages := make([]*testJetStreamMsg, maxMessagesPerFetch+100)
+		for i := range messages {
+			messages[i] = &testJetStreamMsg{data: fmt.Appendf(nil, `{
+				"connectionId":"connection","anonymousId":"anonymous","messageId":"message-%d",
+				"receivedAt":"2026-01-01T00:00:00Z","sentAt":"2026-01-01T00:00:00Z",
+				"originalTimestamp":"2026-01-01T00:00:00Z","timestamp":"2026-01-01T00:00:00Z",
+				"traits":{},"type":"identify"}`, i)}
+		}
+		decodeReady := make(chan struct{})
+		var decodeReadyOnce sync.Once
+		releaseDecode := func() {
+			decodeReadyOnce.Do(func() {
+				close(decodeReady)
+			})
+		}
+		messages[0].dataReady = decodeReady
+
+		pullConsumer := newTestPullConsumer(messages)
+		wait := make(chan struct{})
+		close(wait)
+		s := &stream{ackWait: 3 * time.Second}
+		s.js.jetStream = &testJetStream{consumer: pullConsumer}
+		s.js.wait = wait
+		consumer := s.Consume("test", 1)
+		events, err := consumer.Events(context.Background())
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		defer func() {
+			releaseDecode()
+			pullConsumer.Close()
+			consumer.Close()
+			for range events {
+			}
+		}()
+
+		synctest.Wait()
+		fetched := pullConsumer.fetchedCount()
+		if fetched < maxMessagesPerFetch {
+			t.Fatalf("expected at least %d fetched messages, got %d", maxMessagesPerFetch, fetched)
+		}
+		if fetched >= len(messages) {
+			t.Fatalf("expected backpressure before %d messages, got %d", len(messages), fetched)
+		}
+
+		time.Sleep(1500 * time.Millisecond)
+		synctest.Wait()
+		for i, msg := range messages {
+			want := 0
+			if i < fetched {
+				want = 1
+			}
+			if got := msg.inProgressCount(); got != want {
+				t.Fatalf("message %d: expected %d in-progress acknowledgments, got %d", i, want, got)
+			}
+		}
+
+		releaseDecode()
+		for i := range messages {
+			select {
+			case event, ok := <-events:
+				if !ok {
+					t.Fatalf("expected message %d, got a closed event channel", i)
+				}
+				want := fmt.Sprintf("message-%d", i)
+				if got := event.Attributes["messageId"]; got != want {
+					t.Fatalf("expected message ID %q, got %q", want, got)
+				}
+				event.Destinations[0].Ack.Acknowledge()
+			case <-time.After(time.Second):
+				t.Fatalf("expected message %d, got none", i)
+			}
+		}
+		if got := pullConsumer.fetchCount(); got < 2 {
+			t.Fatalf("expected at least 2 fetches, got %d", got)
+		}
+	})
+}
+
 // TestDestinationsForMessageCreatesAnonymousDestination verifies that a message
 // without explicit destinations receives one anonymous destination.
 func TestDestinationsForMessageCreatesAnonymousDestination(t *testing.T) {
@@ -223,15 +309,156 @@ func testDestinationsForMessage(t *testing.T, msg jetstream.Msg, ids []string) [
 	return destinationsForMessage(manager.Track(msg), ids)
 }
 
+// TestShardConsumerNacksBufferedMessagesWhenIterationStops verifies that
+// messages fetched but not yielded are negatively acknowledged when iteration
+// stops.
+func TestShardConsumerNacksBufferedMessagesWhenIterationStops(t *testing.T) {
+	messages := []*testJetStreamMsg{{}, {}, {}}
+	pullConsumer := newTestPullConsumer(messages)
+	wait := make(chan struct{})
+	close(wait)
+	s := &stream{ackWait: 3 * time.Second}
+	s.js.jetStream = &testJetStream{consumer: pullConsumer}
+	s.js.wait = wait
+	c := &consumer{stream: s, topic: "test", acks: newAckManager(s.ackWait)}
+	defer c.acks.Close()
+
+	sc := newShardConsumer(c, 0)
+	for message := range sc.Messages(context.Background()) {
+		message.ack.Stop()
+		if err := message.msg.Nak(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// The test pull consumer cannot inspect FetchContext, so release any
+		// pending fetch before stopping iteration.
+		pullConsumer.Close()
+		break
+	}
+
+	if got := pullConsumer.fetchedCount(); got != len(messages) {
+		t.Fatalf("expected %d fetched messages, got %d", len(messages), got)
+	}
+	for i, message := range messages {
+		if got := message.nakCount(); got != 1 {
+			t.Fatalf("message %d: expected 1 negative acknowledgment, got %d", i, got)
+		}
+	}
+}
+
+// testJetStream provides the pull consumer used by consumer tests.
+type testJetStream struct {
+	jetstream.JetStream
+	consumer jetstream.Consumer
+}
+
+// CreateOrUpdateConsumer returns the configured test pull consumer.
+func (js *testJetStream) CreateOrUpdateConsumer(context.Context, string, jetstream.ConsumerConfig) (jetstream.Consumer, error) {
+	return js.consumer, nil
+}
+
+// testPullConsumer returns messages in explicitly sized fetch batches.
+type testPullConsumer struct {
+	jetstream.Consumer
+	mu       sync.Mutex // protects next and fetches
+	messages []*testJetStreamMsg
+	next     int
+	fetches  int
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// newTestPullConsumer returns a test pull consumer containing messages.
+func newTestPullConsumer(messages []*testJetStreamMsg) *testPullConsumer {
+	return &testPullConsumer{messages: messages, stop: make(chan struct{})}
+}
+
+// Fetch returns at most batch messages. After exhausting the configured
+// messages, it waits for Close to simulate a pending fetch.
+func (c *testPullConsumer) Fetch(batch int, _ ...jetstream.FetchOpt) (jetstream.MessageBatch, error) {
+	c.mu.Lock()
+	c.fetches++
+	start := c.next
+	end := min(start+batch, len(c.messages))
+	c.next = end
+	c.mu.Unlock()
+
+	messages := make(chan jetstream.Msg, end-start)
+	for _, msg := range c.messages[start:end] {
+		messages <- msg
+	}
+	if start < end {
+		close(messages)
+	} else {
+		go func() {
+			<-c.stop
+			close(messages)
+		}()
+	}
+	return &testMessageBatch{messages: messages}, nil
+}
+
+// Close releases a fetch waiting for more test messages.
+func (c *testPullConsumer) Close() {
+	c.stopOnce.Do(func() {
+		close(c.stop)
+	})
+}
+
+// fetchedCount returns the number of messages returned by Fetch.
+func (c *testPullConsumer) fetchedCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.next
+}
+
+// fetchCount returns the number of calls to Fetch.
+func (c *testPullConsumer) fetchCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.fetches
+}
+
+// testMessageBatch contains the messages returned by a test fetch operation.
+type testMessageBatch struct {
+	messages <-chan jetstream.Msg
+}
+
+// Messages returns the messages in the test batch.
+func (b *testMessageBatch) Messages() <-chan jetstream.Msg {
+	return b.messages
+}
+
+// Error reports that the test batch completed successfully.
+func (b *testMessageBatch) Error() error {
+	return nil
+}
+
 // testJetStreamMsg embeds jetstream.Msg so tests only need to implement the
-// acknowledgment methods exercised by ackManager.
+// methods exercised by consumer and acknowledgment tests.
 type testJetStreamMsg struct {
 	jetstream.Msg
-	mu         sync.Mutex
+	mu         sync.Mutex // protects acks, naks, and inProgress
+	data       []byte
+	dataReady  <-chan struct{}
 	acks       int
+	naks       int
 	inProgress int
 }
 
+// Data waits until the test message is ready and returns its body.
+func (m *testJetStreamMsg) Data() []byte {
+	if m.dataReady != nil {
+		<-m.dataReady
+	}
+	return m.data
+}
+
+// Headers returns no headers for the test message.
+func (m *testJetStreamMsg) Headers() gonats.Header {
+	return nil
+}
+
+// Ack records a final acknowledgment.
 func (m *testJetStreamMsg) Ack() error {
 	m.mu.Lock()
 	m.acks++
@@ -239,6 +466,15 @@ func (m *testJetStreamMsg) Ack() error {
 	return nil
 }
 
+// Nak records a negative acknowledgment.
+func (m *testJetStreamMsg) Nak() error {
+	m.mu.Lock()
+	m.naks++
+	m.mu.Unlock()
+	return nil
+}
+
+// InProgress records an acknowledgment heartbeat.
 func (m *testJetStreamMsg) InProgress() error {
 	m.mu.Lock()
 	m.inProgress++
@@ -250,6 +486,13 @@ func (m *testJetStreamMsg) ackCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.acks
+}
+
+// nakCount returns the number of negative acknowledgments.
+func (m *testJetStreamMsg) nakCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.naks
 }
 
 func (m *testJetStreamMsg) inProgressCount() int {

--- a/core/internal/streams/nats/nats_test.go
+++ b/core/internal/streams/nats/nats_test.go
@@ -224,6 +224,11 @@ func TestConsumerTracksFetchedMessagesWhileDecodingIsBlocked(t *testing.T) {
 		if got := pullConsumer.fetchCount(); got < 2 {
 			t.Fatalf("expected at least 2 fetches, got %d", got)
 		}
+		for i, batchSize := range pullConsumer.fetchBatchSizes() {
+			if batchSize < minFetchBatchSize {
+				t.Fatalf("fetch %d: expected a batch of at least %d messages, got %d", i, minFetchBatchSize, batchSize)
+			}
+		}
 	})
 }
 
@@ -345,36 +350,49 @@ func TestShardConsumerNacksBufferedMessagesWhenIterationStops(t *testing.T) {
 	}
 }
 
-// TestShardConsumerRecreatesConsumerAfterFetchError verifies that a transient
-// fetch error causes the NATS consumer to be recreated before fetching resumes.
-func TestShardConsumerRecreatesConsumerAfterFetchError(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		message := new(testJetStreamMsg)
-		pullConsumer := newTestPullConsumer([]*testJetStreamMsg{message})
-		pullConsumer.fetchError = jetstream.ErrConsumerDoesNotExist
-		wait := make(chan struct{})
-		close(wait)
-		js := &testJetStream{consumer: pullConsumer}
-		s := &stream{ackWait: 3 * time.Second}
-		s.js.jetStream = js
-		s.js.wait = wait
-		c := &consumer{stream: s, topic: "test", acks: newAckManager(s.ackWait)}
-		defer c.acks.Close()
-
-		sc := newShardConsumer(c, 0)
-		for fetched := range sc.Messages(context.Background()) {
-			fetched.ack.Stop()
-			if err := fetched.msg.Nak(); err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-			pullConsumer.Close()
-			break
+// TestShardConsumerRecreatesConsumerAfterFetchErrors verifies that the NATS
+// consumer is recreated and fetching resumes when Fetch or MessageBatch reports
+// that the consumer no longer exists.
+func TestShardConsumerRecreatesConsumerAfterFetchErrors(t *testing.T) {
+	for _, fromBatch := range []bool{false, true} {
+		name := "Fetch"
+		if fromBatch {
+			name = "MessageBatch"
 		}
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				message := new(testJetStreamMsg)
+				pullConsumer := newTestPullConsumer([]*testJetStreamMsg{message})
+				if fromBatch {
+					pullConsumer.batchError = jetstream.ErrConsumerDoesNotExist
+				} else {
+					pullConsumer.fetchError = jetstream.ErrConsumerDoesNotExist
+				}
+				wait := make(chan struct{})
+				close(wait)
+				js := &testJetStream{consumer: pullConsumer}
+				s := &stream{ackWait: 3 * time.Second}
+				s.js.jetStream = js
+				s.js.wait = wait
+				c := &consumer{stream: s, topic: "test", acks: newAckManager(s.ackWait)}
+				defer c.acks.Close()
 
-		if got := js.createCount(); got != 2 {
-			t.Fatalf("expected 2 consumer creations, got %d", got)
-		}
-	})
+				sc := newShardConsumer(c, 0)
+				for fetched := range sc.Messages(context.Background()) {
+					fetched.ack.Stop()
+					if err := fetched.msg.Nak(); err != nil {
+						t.Fatalf("expected no error, got %v", err)
+					}
+					pullConsumer.Close()
+					break
+				}
+
+				if got := js.createCount(); got != 2 {
+					t.Fatalf("expected 2 consumer creations, got %d", got)
+				}
+			})
+		})
+	}
 }
 
 // testJetStream provides the pull consumer used by consumer tests.
@@ -403,9 +421,11 @@ func (js *testJetStream) createCount() int {
 // testPullConsumer returns messages in explicitly sized fetch batches.
 type testPullConsumer struct {
 	jetstream.Consumer
-	mu         sync.Mutex // protects next, fetches, and fetchError
+	mu         sync.Mutex // protects the fields below
 	messages   []*testJetStreamMsg
 	next       int
+	batchSizes []int
+	batchError error
 	fetches    int
 	fetchError error
 	stop       chan struct{}
@@ -422,11 +442,20 @@ func newTestPullConsumer(messages []*testJetStreamMsg) *testPullConsumer {
 func (c *testPullConsumer) Fetch(batch int, _ ...jetstream.FetchOpt) (jetstream.MessageBatch, error) {
 	c.mu.Lock()
 	c.fetches++
+	c.batchSizes = append(c.batchSizes, batch)
 	if c.fetchError != nil {
 		err := c.fetchError
 		c.fetchError = nil
 		c.mu.Unlock()
 		return nil, err
+	}
+	if c.batchError != nil {
+		err := c.batchError
+		c.batchError = nil
+		c.mu.Unlock()
+		messages := make(chan jetstream.Msg)
+		close(messages)
+		return &testMessageBatch{messages: messages, err: err}, nil
 	}
 	start := c.next
 	end := min(start+batch, len(c.messages))
@@ -469,9 +498,17 @@ func (c *testPullConsumer) fetchCount() int {
 	return c.fetches
 }
 
+// fetchBatchSizes returns the message limit requested by each call to Fetch.
+func (c *testPullConsumer) fetchBatchSizes() []int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int(nil), c.batchSizes...)
+}
+
 // testMessageBatch contains the messages returned by a test fetch operation.
 type testMessageBatch struct {
 	messages <-chan jetstream.Msg
+	err      error
 }
 
 // Messages returns the messages in the test batch.
@@ -479,9 +516,9 @@ func (b *testMessageBatch) Messages() <-chan jetstream.Msg {
 	return b.messages
 }
 
-// Error reports that the test batch completed successfully.
+// Error returns the error reported after consuming the test batch.
 func (b *testMessageBatch) Error() error {
-	return nil
+	return b.err
 }
 
 // testJetStreamMsg embeds jetstream.Msg so tests only need to implement the

--- a/core/internal/streams/nats/nats_test.go
+++ b/core/internal/streams/nats/nats_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/krenalis/krenalis/core/internal/streams"
 	"github.com/krenalis/krenalis/core/natsopts"
 
-	gonats "github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -330,10 +330,7 @@ func TestShardConsumerNacksBufferedMessagesWhenIterationStops(t *testing.T) {
 
 	sc := newShardConsumer(c, 0)
 	for message := range sc.Messages(context.Background()) {
-		message.ack.Stop()
-		if err := message.msg.Nak(); err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+		message.nack()
 		// The test pull consumer cannot inspect FetchContext, so release any
 		// pending fetch before stopping iteration.
 		pullConsumer.Close()
@@ -379,10 +376,7 @@ func TestShardConsumerRecreatesConsumerAfterFetchErrors(t *testing.T) {
 
 				sc := newShardConsumer(c, 0)
 				for fetched := range sc.Messages(context.Background()) {
-					fetched.ack.Stop()
-					if err := fetched.msg.Nak(); err != nil {
-						t.Fatalf("expected no error, got %v", err)
-					}
+					fetched.nack()
 					pullConsumer.Close()
 					break
 				}
@@ -542,7 +536,7 @@ func (m *testJetStreamMsg) Data() []byte {
 }
 
 // Headers returns no headers for the test message.
-func (m *testJetStreamMsg) Headers() gonats.Header {
+func (m *testJetStreamMsg) Headers() nats.Header {
 	return nil
 }
 

--- a/core/internal/streams/nats/nats_test.go
+++ b/core/internal/streams/nats/nats_test.go
@@ -186,11 +186,11 @@ func TestConsumerTracksFetchedMessagesWhileDecodingIsBlocked(t *testing.T) {
 
 		synctest.Wait()
 		fetched := pullConsumer.fetchedCount()
-		if fetched < maxMessagesPerFetch {
-			t.Fatalf("expected at least %d fetched messages, got %d", maxMessagesPerFetch, fetched)
+		if fetched != maxMessagesPerFetch {
+			t.Fatalf("expected %d fetched messages while decoding is blocked, got %d", maxMessagesPerFetch, fetched)
 		}
-		if fetched >= len(messages) {
-			t.Fatalf("expected backpressure before %d messages, got %d", len(messages), fetched)
+		if got := pullConsumer.fetchCount(); got != 1 {
+			t.Fatalf("expected 1 fetch while decoding is blocked, got %d", got)
 		}
 
 		time.Sleep(1500 * time.Millisecond)
@@ -345,26 +345,71 @@ func TestShardConsumerNacksBufferedMessagesWhenIterationStops(t *testing.T) {
 	}
 }
 
+// TestShardConsumerRecreatesConsumerAfterFetchError verifies that a transient
+// fetch error causes the NATS consumer to be recreated before fetching resumes.
+func TestShardConsumerRecreatesConsumerAfterFetchError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		message := new(testJetStreamMsg)
+		pullConsumer := newTestPullConsumer([]*testJetStreamMsg{message})
+		pullConsumer.fetchError = jetstream.ErrConsumerDoesNotExist
+		wait := make(chan struct{})
+		close(wait)
+		js := &testJetStream{consumer: pullConsumer}
+		s := &stream{ackWait: 3 * time.Second}
+		s.js.jetStream = js
+		s.js.wait = wait
+		c := &consumer{stream: s, topic: "test", acks: newAckManager(s.ackWait)}
+		defer c.acks.Close()
+
+		sc := newShardConsumer(c, 0)
+		for fetched := range sc.Messages(context.Background()) {
+			fetched.ack.Stop()
+			if err := fetched.msg.Nak(); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			pullConsumer.Close()
+			break
+		}
+
+		if got := js.createCount(); got != 2 {
+			t.Fatalf("expected 2 consumer creations, got %d", got)
+		}
+	})
+}
+
 // testJetStream provides the pull consumer used by consumer tests.
 type testJetStream struct {
 	jetstream.JetStream
+	mu       sync.Mutex
 	consumer jetstream.Consumer
+	creates  int
 }
 
 // CreateOrUpdateConsumer returns the configured test pull consumer.
 func (js *testJetStream) CreateOrUpdateConsumer(context.Context, string, jetstream.ConsumerConfig) (jetstream.Consumer, error) {
+	js.mu.Lock()
+	js.creates++
+	js.mu.Unlock()
 	return js.consumer, nil
+}
+
+// createCount returns the number of consumer creations.
+func (js *testJetStream) createCount() int {
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	return js.creates
 }
 
 // testPullConsumer returns messages in explicitly sized fetch batches.
 type testPullConsumer struct {
 	jetstream.Consumer
-	mu       sync.Mutex // protects next and fetches
-	messages []*testJetStreamMsg
-	next     int
-	fetches  int
-	stop     chan struct{}
-	stopOnce sync.Once
+	mu         sync.Mutex // protects next, fetches, and fetchError
+	messages   []*testJetStreamMsg
+	next       int
+	fetches    int
+	fetchError error
+	stop       chan struct{}
+	stopOnce   sync.Once
 }
 
 // newTestPullConsumer returns a test pull consumer containing messages.
@@ -377,6 +422,12 @@ func newTestPullConsumer(messages []*testJetStreamMsg) *testPullConsumer {
 func (c *testPullConsumer) Fetch(batch int, _ ...jetstream.FetchOpt) (jetstream.MessageBatch, error) {
 	c.mu.Lock()
 	c.fetches++
+	if c.fetchError != nil {
+		err := c.fetchError
+		c.fetchError = nil
+		c.mu.Unlock()
+		return nil, err
+	}
 	start := c.next
 	end := min(start+batch, len(c.messages))
 	c.next = end

--- a/core/internal/streams/stream.go
+++ b/core/internal/streams/stream.go
@@ -47,6 +47,10 @@ type Consumer interface {
 	Events(ctx context.Context) (<-chan Event, error)
 
 	// Close closes the consumer and its events channel.
+	//
+	// When Close is called, no calls to other Consumer methods should be in
+	// progress, and no other methods should be called afterward. Close is
+	// idempotent; subsequent calls have no effect.
 	Close()
 }
 

--- a/core/internal/streams/stream.go
+++ b/core/internal/streams/stream.go
@@ -48,9 +48,9 @@ type Consumer interface {
 
 	// Close closes the consumer and its events channel.
 	//
-	// When Close is called, no calls to other Consumer methods should be in
-	// progress, and no other methods should be called afterward. Close is
-	// idempotent; subsequent calls have no effect.
+	// No call to Events may be in progress when Close is called, and Events must not
+	// be called afterward. Close may be called more than once, but calls must not
+	// overlap. Calls made after the first one has completed have no effect.
 	Close()
 }
 


### PR DESCRIPTION
```
core/internal/streams/nats: prevent prefetched event redelivery (#2396)

JetStream starts the acknowledgment timer when a message is fetched. The
client may fetch a batch while Krenalis is still processing an earlier event,
so messages waiting behind it can use much of their acknowledgment time before
processing begins. If they wait long enough, JetStream redelivers them.

Fetch messages in bounded batches and start acknowledgment tracking before
each message enters the processing queue. Fetch another batch only when the
queue has enough room for every message that may be returned. This applies
backpressure without reducing the normal batch size and preserves per-shard
processing order.

Stop tracking and negatively acknowledge messages that remain buffered when
the consumer closes. Add regression tests proving that fetched messages receive
progress heartbeats while decoding is blocked and that fetching resumes as
processing frees capacity.
```