### PR TITLE
connectors, core: add delivery endpoints to event types

### DIFF
--- a/admin/src/lib/api/types/connection.ts
+++ b/admin/src/lib/api/types/connection.ts
@@ -12,6 +12,7 @@ interface EventType {
 	name: string;
 	description: string;
 	orderingGroup: string;
+	deliveryEndpoint: string;
 	defaultFilter: string;
 }
 

--- a/admin/src/lib/api/types/pipeline.ts
+++ b/admin/src/lib/api/types/pipeline.ts
@@ -100,6 +100,7 @@ interface Pipeline {
 	enabled: boolean;
 	eventType: string | null;
 	orderingGroup: string | null;
+	deliveryEndpoint: string | null;
 	running: boolean;
 	scheduleStart: number | null;
 	schedulePeriod: SchedulePeriod | null;
@@ -131,6 +132,7 @@ interface PipelineType {
 	target: PipelineTarget;
 	eventType: string;
 	orderingGroup: string | null;
+	deliveryEndpoint: string | null;
 }
 
 interface PipelineToSet {

--- a/connectors/applications.go
+++ b/connectors/applications.go
@@ -231,8 +231,8 @@ func (r FailureReason) String() string {
 	panic(fmt.Errorf("unexpected FailureReason %d", r))
 }
 
-// MaxEventTypeIdentifierLen is the maximum length of event type and ordering
-// group identifiers.
+// MaxEventTypeIdentifierLen is the maximum length of event type, ordering
+// group, and delivery endpoint identifiers.
 const MaxEventTypeIdentifierLen = 25
 
 // EventType represents a type of event that can be sent to an application.
@@ -255,6 +255,13 @@ type EventType struct {
 	// the syntax of a property name and cannot be longer than
 	// MaxEventTypeIdentifierLen characters.
 	OrderingGroup string
+
+	// DeliveryEndpoint identifies the destination endpoint used for events of
+	// this type. Event types in the same ordering group must use the same endpoint.
+	// An empty value selects the connector's default endpoint. If set, the value
+	// must follow the syntax of a property name and be no longer than
+	// MaxEventTypeIdentifierLen characters.
+	DeliveryEndpoint string
 
 	// DefaultFilter is the default filter to use for pipelines.
 	DefaultFilter string

--- a/connectors/skills/create-application/references/events.md
+++ b/connectors/skills/create-application/references/events.md
@@ -19,7 +19,12 @@ Use it to choose the right iteration method and payload-building pattern.
 - Set `OrderingGroup` to the same value on event types whose events must remain
   ordered for each user. Ordering groups follow the same syntax and length
   limit as IDs. If `OrderingGroup` is empty, the event type ID is used.
-- Do not change an ID or ordering group after the connector has been released.
+- Set `DeliveryEndpoint` when event types use separate destination endpoints.
+  Event types in the same ordering group must use the same delivery endpoint.
+  An empty value identifies the connector's default endpoint. Explicit endpoint
+  identifiers follow the same syntax and length limit as event type IDs.
+- Do not change an ID, ordering group, or delivery endpoint after the connector
+  has been released.
 - Return only event types the connector actually supports.
 
 ## EventTypeSchema

--- a/core/connection.go
+++ b/core/connection.go
@@ -65,11 +65,12 @@ type Connection struct {
 
 // EventType represents an event type of a destination application connection.
 type EventType struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	Description   string `json:"description"`
-	OrderingGroup string `json:"orderingGroup"`
-	DefaultFilter string `json:"defaultFilter"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	Description      string `json:"description"`
+	OrderingGroup    string `json:"orderingGroup"`
+	DeliveryEndpoint string `json:"deliveryEndpoint"`
+	DefaultFilter    string `json:"defaultFilter"`
 }
 
 type PipelineInfo struct {
@@ -104,11 +105,12 @@ var dummyGroupsSchema = types.Object([]types.Property{
 
 // PipelineType represents a pipeline type.
 type PipelineType struct {
-	Name          string  `json:"name"`
-	Description   string  `json:"description"`
-	Target        Target  `json:"target"`
-	EventType     *string `json:"eventType"`
-	OrderingGroup *string `json:"orderingGroup"`
+	Name             string  `json:"name"`
+	Description      string  `json:"description"`
+	Target           Target  `json:"target"`
+	EventType        *string `json:"eventType"`
+	OrderingGroup    *string `json:"orderingGroup"`
+	DeliveryEndpoint *string `json:"deliveryEndpoint"`
 }
 
 // AbsolutePath returns the absolute representation of the given path, based
@@ -399,7 +401,7 @@ func (this *Connection) CreatePipeline(ctx context.Context, target Target, event
 
 	// Only for destination event pipeline checks that the out schema is aligned with the event type's schema.
 	// See issue https://github.com/krenalis/krenalis/issues/2086.
-	var orderingGroup string
+	var orderingGroup, deliveryEndpoint string
 	if eventType != "" {
 		app := this.application()
 		et, err := app.EventType(ctx, eventType)
@@ -410,6 +412,7 @@ func (this *Connection) CreatePipeline(ctx context.Context, target Target, event
 			return "", err
 		}
 		orderingGroup = connectors.OrderingGroup(et)
+		deliveryEndpoint = et.DeliveryEndpoint
 		eventTypeSchema, err := app.Schema(ctx, state.TargetEvent, eventType)
 		if err != nil {
 			return "", err
@@ -436,6 +439,7 @@ func (this *Connection) CreatePipeline(ctx context.Context, target Target, event
 		Enabled:            pipeline.Enabled,
 		EventType:          eventType,
 		OrderingGroup:      orderingGroup,
+		DeliveryEndpoint:   deliveryEndpoint,
 		InSchema:           inSchema,
 		OutSchema:          pipeline.OutSchema,
 		RequiredConsents:   toStateRequiredConsents(pipeline.RequiredConsents),
@@ -560,17 +564,17 @@ func (this *Connection) CreatePipeline(ctx context.Context, target Target, event
 					return nil, err
 				}
 			}
-			query := "INSERT INTO pipelines (id, connection, target, event_type, ordering_group, name, enabled,\n" +
-				"schedule_start, schedule_period, in_schema, out_schema, filter, required_consents,\n" +
+			query := "INSERT INTO pipelines (id, connection, target, event_type, ordering_group, delivery_endpoint,\n" +
+				"name, enabled, schedule_start, schedule_period, in_schema, out_schema, filter, required_consents,\n" +
 				"required_consents_operator, transformation_mapping, transformation_id, transformation_version,\n" +
 				"transformation_language, transformation_source, transformation_preserve_json, transformation_in_paths,\n" +
 				"transformation_out_paths, query, format, path, sheet, compression, order_by, format_settings,\n" +
 				"export_mode, matching_in, matching_out, update_on_duplicates, table_name, table_key,\n" +
 				"user_id_column, updated_at_column, updated_at_format, incremental)\n" +
 				"VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21,\n" +
-				"$22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39)"
+				"$22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40)"
 			_, err := tx.Exec(ctx, query, n.ID, n.Connection, n.Target, n.EventType,
-				n.OrderingGroup, n.Name, n.Enabled, n.ScheduleStart, n.SchedulePeriod, rawInSchema, rawOutSchema,
+				n.OrderingGroup, n.DeliveryEndpoint, n.Name, n.Enabled, n.ScheduleStart, n.SchedulePeriod, rawInSchema, rawOutSchema,
 				n.Filter, n.RequiredConsents.Purposes, n.RequiredConsents.Operator, mapping, function.ID, function.Version,
 				function.Language, function.Source, function.PreserveJSON, n.Transformation.InPaths, n.Transformation.OutPaths,
 				n.Query, formatCode, n.Path, n.Sheet, n.Compression, n.OrderBy, n.FormatSettings, n.ExportMode, n.Matching.In,
@@ -1461,11 +1465,12 @@ func (this *Connection) PipelineTypes(ctx context.Context) ([]PipelineType, erro
 				for _, et := range eventTypes {
 					orderingGroup := connectors.OrderingGroup(et)
 					pipelineTypes = append(pipelineTypes, PipelineType{
-						Name:          et.Name,
-						Description:   et.Description,
-						Target:        TargetEvent,
-						EventType:     new(et.ID),
-						OrderingGroup: new(orderingGroup),
+						Name:             et.Name,
+						Description:      et.Description,
+						Target:           TargetEvent,
+						EventType:        new(et.ID),
+						OrderingGroup:    new(orderingGroup),
+						DeliveryEndpoint: new(et.DeliveryEndpoint),
 					})
 				}
 			}

--- a/core/internal/connections/application.go
+++ b/core/internal/connections/application.go
@@ -121,16 +121,22 @@ func (app *Application) EventTypes(ctx context.Context) ([]*EventType, error) {
 	if err != nil {
 		return nil, connectorError(err)
 	}
-	for i, eventType := range eventTypes {
+	for _, eventType := range eventTypes {
 		if eventType == nil {
 			return nil, fmt.Errorf("connector %s returned a nil event type", app.connector)
 		}
 		if err := validateEventType(app.connector, eventType); err != nil {
 			return nil, err
 		}
+	}
+	for i, et := range eventTypes {
+		orderingGroup := connectors.OrderingGroup(et)
 		for _, next := range eventTypes[i+1:] {
-			if next != nil && next.ID == eventType.ID {
-				return nil, fmt.Errorf("connector %s returned multiple event types with the same ID (%s)", app.connector, eventType.ID)
+			if next.ID == et.ID {
+				return nil, fmt.Errorf("connector %s returned multiple event types with the same ID (%s)", app.connector, et.ID)
+			}
+			if connectors.OrderingGroup(next) == orderingGroup && next.DeliveryEndpoint != et.DeliveryEndpoint {
+				return nil, fmt.Errorf("connector %s returned different delivery endpoints for ordering group %q", app.connector, orderingGroup)
 			}
 		}
 	}
@@ -146,25 +152,19 @@ func (app *Application) EventType(ctx context.Context, id string) (*EventType, e
 	if app.err != nil {
 		return nil, app.err
 	}
-	eventTypes, err := app.inner.(connectors.EventSender).EventTypes(ctx)
+	eventTypes, err := app.EventTypes(ctx)
 	if err != nil {
-		return nil, connectorError(err)
+		return nil, err
 	}
 	var et *EventType
 	for _, candidate := range eventTypes {
-		if candidate == nil || candidate.ID != id {
-			continue
+		if candidate.ID == id {
+			et = candidate
+			break
 		}
-		if et != nil {
-			return nil, fmt.Errorf("event type ID %q is repeated", id)
-		}
-		et = candidate
 	}
 	if et == nil {
 		return nil, connectors.ErrEventTypeNotExist
-	}
-	if err := validateEventType(app.connector, et); err != nil {
-		return nil, err
 	}
 	return et, nil
 }
@@ -423,6 +423,11 @@ func validateEventType(connector string, eventType *EventType) error {
 	if eventType.OrderingGroup != "" {
 		if !types.IsValidPropertyName(eventType.OrderingGroup) || len(eventType.OrderingGroup) > connectors.MaxEventTypeIdentifierLen {
 			return fmt.Errorf("connector %s returned an invalid ordering group (%q)", connector, eventType.OrderingGroup)
+		}
+	}
+	if eventType.DeliveryEndpoint != "" {
+		if !types.IsValidPropertyName(eventType.DeliveryEndpoint) || len(eventType.DeliveryEndpoint) > connectors.MaxEventTypeIdentifierLen {
+			return fmt.Errorf("connector %s returned an invalid delivery endpoint (%q)", connector, eventType.DeliveryEndpoint)
 		}
 	}
 	return nil

--- a/core/internal/connections/application_test.go
+++ b/core/internal/connections/application_test.go
@@ -14,18 +14,22 @@ import (
 	"github.com/krenalis/krenalis/tools/types"
 )
 
-// TestValidateEventType verifies event type ID and ordering group validation.
+// TestValidateEventType verifies validation of event type IDs, ordering groups,
+// and delivery endpoints.
 func TestValidateEventType(t *testing.T) {
 	tests := []struct {
 		name      string
 		eventType *EventType
 		err       string
 	}{
-		{name: "valid", eventType: &EventType{ID: "createContact", OrderingGroup: "contacts"}},
+		{name: "default delivery endpoint", eventType: &EventType{ID: "createContact", OrderingGroup: "contacts"}},
+		{name: "explicit delivery endpoint", eventType: &EventType{ID: "createContact", OrderingGroup: "contacts", DeliveryEndpoint: "contacts"}},
 		{name: "invalid ID", eventType: &EventType{ID: "create-contact"}, err: `connector test returned an invalid event type ID ("create-contact")`},
 		{name: "long ID", eventType: &EventType{ID: strings.Repeat("a", 26)}, err: `connector test returned an invalid event type ID ("aaaaaaaaaaaaaaaaaaaaaaaaaa")`},
 		{name: "invalid ordering group", eventType: &EventType{ID: "contact", OrderingGroup: "contact-events"}, err: `connector test returned an invalid ordering group ("contact-events")`},
 		{name: "long ordering group", eventType: &EventType{ID: "contact", OrderingGroup: strings.Repeat("a", 26)}, err: `connector test returned an invalid ordering group ("aaaaaaaaaaaaaaaaaaaaaaaaaa")`},
+		{name: "invalid delivery endpoint", eventType: &EventType{ID: "contact", DeliveryEndpoint: "contact-events"}, err: `connector test returned an invalid delivery endpoint ("contact-events")`},
+		{name: "long delivery endpoint", eventType: &EventType{ID: "contact", DeliveryEndpoint: strings.Repeat("a", 26)}, err: `connector test returned an invalid delivery endpoint ("aaaaaaaaaaaaaaaaaaaaaaaaaa")`},
 	}
 
 	for _, test := range tests {
@@ -47,15 +51,14 @@ func TestValidateEventType(t *testing.T) {
 	}
 }
 
-// TestApplicationEventType verifies that EventType validates only matching
-// event types while detecting missing and repeated IDs.
+// TestApplicationEventType verifies that EventType validates event types before
+// returning the one with the requested ID.
 func TestApplicationEventType(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		expected := &EventType{ID: "createContact", OrderingGroup: "contacts"}
 		app := &Application{inner: &testEventSender{eventTypes: []*EventType{
-			nil,
-			{ID: "invalid-id"},
 			expected,
+			{ID: "updateContact", OrderingGroup: "contacts"},
 		}}}
 
 		got, err := app.EventType(context.Background(), expected.ID)
@@ -67,12 +70,13 @@ func TestApplicationEventType(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid", func(t *testing.T) {
+	t.Run("invalid event type", func(t *testing.T) {
 		app := &Application{connector: "test", inner: &testEventSender{eventTypes: []*EventType{
+			{ID: "createContact"},
 			{ID: "invalid-id"},
 		}}}
 
-		_, err := app.EventType(context.Background(), "invalid-id")
+		_, err := app.EventType(context.Background(), "createContact")
 		expected := `connector test returned an invalid event type ID ("invalid-id")`
 		if err == nil {
 			t.Fatalf("expected %q, got nil", expected)
@@ -92,13 +96,13 @@ func TestApplicationEventType(t *testing.T) {
 	})
 
 	t.Run("repeated", func(t *testing.T) {
-		app := &Application{inner: &testEventSender{eventTypes: []*EventType{
+		app := &Application{connector: "test", inner: &testEventSender{eventTypes: []*EventType{
 			{ID: "createContact"},
 			{ID: "createContact"},
 		}}}
 
 		_, err := app.EventType(context.Background(), "createContact")
-		expected := `event type ID "createContact" is repeated`
+		expected := "connector test returned multiple event types with the same ID (createContact)"
 		if err == nil {
 			t.Fatalf("expected %q, got nil", expected)
 		}
@@ -106,6 +110,41 @@ func TestApplicationEventType(t *testing.T) {
 			t.Fatalf("expected %q, got %q", expected, err.Error())
 		}
 	})
+
+	t.Run("different delivery endpoints", func(t *testing.T) {
+		app := &Application{connector: "test", inner: &testEventSender{eventTypes: []*EventType{
+			{ID: "createContact", OrderingGroup: "contacts"},
+			{ID: "updateContact", OrderingGroup: "contacts", DeliveryEndpoint: "contacts"},
+		}}}
+
+		_, err := app.EventType(context.Background(), "createContact")
+		expected := `connector test returned different delivery endpoints for ordering group "contacts"`
+		if err == nil {
+			t.Fatalf("expected %q, got nil", expected)
+		}
+		if err.Error() != expected {
+			t.Fatalf("expected %q, got %q", expected, err.Error())
+		}
+	})
+}
+
+// TestApplicationEventTypesRejectsDifferentDeliveryEndpoints verifies that
+// event types in the same ordering group must resolve to the same delivery
+// endpoint.
+func TestApplicationEventTypesRejectsDifferentDeliveryEndpoints(t *testing.T) {
+	app := &Application{connector: "test", inner: &testEventSender{eventTypes: []*EventType{
+		{ID: "createContact", OrderingGroup: "contacts"},
+		{ID: "updateContact", OrderingGroup: "contacts", DeliveryEndpoint: "contacts"},
+	}}}
+
+	_, err := app.EventTypes(context.Background())
+	expected := `connector test returned different delivery endpoints for ordering group "contacts"`
+	if err == nil {
+		t.Fatalf("expected %q, got nil", expected)
+	}
+	if err.Error() != expected {
+		t.Fatalf("expected %q, got %q", expected, err.Error())
+	}
 }
 
 // testEventSender provides event types to Application tests.

--- a/core/internal/initdb/schema.sql
+++ b/core/internal/initdb/schema.sql
@@ -193,6 +193,9 @@ CREATE TABLE pipelines (
     ordering_group varchar(25) NOT NULL CONSTRAINT pipelines_ordering_group_check
         CHECK ((event_type = '' AND ordering_group = '') OR
             (event_type <> '' AND ordering_group ~ '^[A-Za-z_][A-Za-z0-9_]*$')),
+    delivery_endpoint varchar(25) NOT NULL CONSTRAINT pipelines_delivery_endpoint_check
+        CHECK (delivery_endpoint = '' OR
+            (event_type <> '' AND delivery_endpoint ~ '^[A-Za-z_][A-Za-z0-9_]*$')),
     name varchar(60) NOT NULL DEFAULT '',
     enabled boolean NOT NULL DEFAULT FALSE,
     schedule_start smallint NOT NULL DEFAULT 0 CHECK (schedule_start >= 0 AND schedule_start < 1440),

--- a/core/internal/initdb/upgrade.go
+++ b/core/internal/initdb/upgrade.go
@@ -144,6 +144,34 @@ const pipelineEventTypeUpgrade = `
 		END IF;
 	END $$`
 
+// pipelineDeliveryEndpointUpgrade adds persisted delivery endpoints and their
+// identifier constraint.
+const pipelineDeliveryEndpointUpgrade = `
+	ALTER TABLE pipelines
+		ADD COLUMN IF NOT EXISTS delivery_endpoint varchar(25);
+
+	UPDATE pipelines
+	SET delivery_endpoint = ''
+	WHERE delivery_endpoint IS NULL;
+
+	ALTER TABLE pipelines
+		ALTER COLUMN delivery_endpoint TYPE varchar(25),
+		ALTER COLUMN delivery_endpoint SET NOT NULL;
+
+	DO $$
+	BEGIN
+		IF NOT EXISTS (
+			SELECT FROM pg_constraint
+			WHERE conrelid = 'pipelines'::regclass
+				AND conname = 'pipelines_delivery_endpoint_check'
+		) THEN
+			ALTER TABLE pipelines
+				ADD CONSTRAINT pipelines_delivery_endpoint_check
+				CHECK (delivery_endpoint = '' OR
+					(event_type <> '' AND delivery_endpoint ~ '^[A-Za-z_][A-Za-z0-9_]*$'));
+		END IF;
+	END $$`
+
 // Upgrade applies idempotent updates to an existing Krenalis PostgreSQL
 // database.
 func Upgrade(ctx context.Context, database *db.DB) error {
@@ -363,6 +391,7 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 			organizationConnectorReferencesView,
 			nodeIDUpgrade,
 			pipelineEventTypeUpgrade,
+			pipelineDeliveryEndpointUpgrade,
 			`ALTER TYPE notification_name ADD VALUE IF NOT EXISTS 'InviteMember' AFTER 'EndPipelineRun'`,
 			consentPurposesTable,
 			`ALTER TYPE notification_name ADD VALUE IF NOT EXISTS 'AddConsentPurpose'`,

--- a/core/internal/initdb/upgrade_test.go
+++ b/core/internal/initdb/upgrade_test.go
@@ -128,7 +128,7 @@ func TestUpgrade(t *testing.T) {
 	assertIndexExists(t, database, pipelinesMetricsTimeslotIndex)
 	assertOrganizationConnectorReferences(t, database)
 	assertNodeIDsUpgraded(t, database)
-	assertPipelineEventTypesUpgraded(t, database)
+	assertPipelineEventMetadataUpgraded(t, database)
 	assertPipelineMetricsUpgrade(t, database)
 	assertPipelineMetricsColumnOrder(t, database)
 	assertPipelineMetricsSurvivePipelineDelete(t, database)
@@ -299,12 +299,12 @@ func assertRateLimitLeaseFunction(t *testing.T, database *db.DB) {
 	}
 }
 
-// assertPipelineEventTypesUpgraded verifies event type identifier limits and
-// persisted ordering groups.
-func assertPipelineEventTypesUpgraded(t *testing.T, database *db.DB) {
+// assertPipelineEventMetadataUpgraded verifies event type identifier limits
+// and persisted ordering and delivery metadata.
+func assertPipelineEventMetadataUpgraded(t *testing.T, database *db.DB) {
 	t.Helper()
 
-	for _, column := range []string{"event_type", "ordering_group"} {
+	for _, column := range []string{"event_type", "ordering_group", "delivery_endpoint"} {
 		var length int
 		err := database.QueryRow(t.Context(), `
 			SELECT character_maximum_length
@@ -320,31 +320,57 @@ func assertPipelineEventTypesUpgraded(t *testing.T, database *db.DB) {
 		}
 	}
 
-	var eventType, orderingGroup string
+	var eventType, orderingGroup, deliveryEndpoint string
 	err := database.QueryRow(t.Context(), `
-		SELECT event_type, ordering_group
+		SELECT event_type, ordering_group, delivery_endpoint
 		FROM pipelines
-		WHERE id = '777777777777'`).Scan(&eventType, &orderingGroup)
+		WHERE id = '777777777777'`).Scan(&eventType, &orderingGroup, &deliveryEndpoint)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if eventType != "send_event_with_no_schema" || orderingGroup != "events" {
 		t.Fatalf("expected event type %q and ordering group %q, got %q and %q", "send_event_with_no_schema", "events", eventType, orderingGroup)
 	}
+	if deliveryEndpoint != "" {
+		t.Fatalf("expected empty delivery endpoint, got %q", deliveryEndpoint)
+	}
 
 	err = database.QueryRow(t.Context(), `
-		SELECT event_type, ordering_group
+		SELECT event_type, ordering_group, delivery_endpoint
 		FROM pipelines
-		WHERE id = '444444444444'`).Scan(&eventType, &orderingGroup)
+		WHERE id = '444444444444'`).Scan(&eventType, &orderingGroup, &deliveryEndpoint)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if eventType != "" || orderingGroup != "" {
 		t.Fatalf("expected empty event type and ordering group, got %q and %q", eventType, orderingGroup)
 	}
+	if deliveryEndpoint != "" {
+		t.Fatalf("expected empty delivery endpoint, got %q", deliveryEndpoint)
+	}
 
 	assertConstraintExists(t, database, "pipelines", "pipelines_event_type_check")
 	assertConstraintExists(t, database, "pipelines", "pipelines_ordering_group_check")
+	assertConstraintExists(t, database, "pipelines", "pipelines_delivery_endpoint_check")
+
+	if _, err := database.Exec(t.Context(), `
+		UPDATE pipelines
+		SET delivery_endpoint = 'contacts'
+		WHERE id = '777777777777'`); err != nil {
+		t.Fatalf("expected explicit delivery endpoint to be accepted, got %v", err)
+	}
+	if _, err := database.Exec(t.Context(), `
+		UPDATE pipelines
+		SET delivery_endpoint = 'contact-events'
+		WHERE id = '777777777777'`); err == nil {
+		t.Fatal("expected invalid delivery endpoint to be rejected, got no error")
+	}
+	if _, err := database.Exec(t.Context(), `
+		UPDATE pipelines
+		SET delivery_endpoint = 'contacts'
+		WHERE id = '444444444444'`); err == nil {
+		t.Fatal("expected delivery endpoint on a non-event pipeline to be rejected, got no error")
+	}
 }
 
 func assertStateRequestSyncSchemaUpgraded(t *testing.T, database *db.DB) {

--- a/core/internal/state/keep.go
+++ b/core/internal/state/keep.go
@@ -559,6 +559,7 @@ type CreatePipeline struct {
 	Target             Target
 	EventType          string
 	OrderingGroup      string
+	DeliveryEndpoint   string
 	Name               string
 	Enabled            bool
 	ScheduleStart      int16
@@ -614,6 +615,7 @@ func (state *State) createPipeline(n notification) string {
 		Enabled:            e.Enabled,
 		EventType:          e.EventType,
 		OrderingGroup:      e.OrderingGroup,
+		DeliveryEndpoint:   e.DeliveryEndpoint,
 		ScheduleStart:      e.ScheduleStart,
 		SchedulePeriod:     e.SchedulePeriod,
 		InSchema:           e.InSchema,

--- a/core/internal/state/load.go
+++ b/core/internal/state/load.go
@@ -528,13 +528,13 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 	}
 
 	// Read all pipelines.
-	err = tx.QueryScan(ctx, "SELECT id, connection, target, event_type, ordering_group, name, enabled, schedule_start,\n"+
-		"schedule_period, in_schema, out_schema, filter, required_consents, required_consents_operator,\n"+
-		"transformation_mapping, transformation_id, transformation_version, transformation_language,\n"+
-		"transformation_source, transformation_preserve_json, transformation_in_paths, transformation_out_paths,\n"+
-		"query, format, path, sheet, compression::TEXT, order_by, format_settings, export_mode, matching_in,\n"+
-		"matching_out, update_on_duplicates, table_name, table_key, user_id_column, updated_at_column,\n"+
-		"updated_at_format, health, properties_to_unset\n"+
+	err = tx.QueryScan(ctx, "SELECT id, connection, target, event_type, ordering_group, delivery_endpoint,\n"+
+		"name, enabled, schedule_start, schedule_period, in_schema, out_schema, filter, required_consents,\n"+
+		"required_consents_operator, transformation_mapping, transformation_id, transformation_version,\n"+
+		"transformation_language, transformation_source, transformation_preserve_json, transformation_in_paths,\n"+
+		"transformation_out_paths, query, format, path, sheet, compression::TEXT, order_by, format_settings,\n"+
+		"export_mode, matching_in, matching_out, update_on_duplicates, table_name, table_key, user_id_column,\n"+
+		"updated_at_column, updated_at_format, health, properties_to_unset\n"+
 		"FROM pipelines",
 		func(rows *db.Rows) error {
 			for rows.Next() {
@@ -544,7 +544,7 @@ func (state *State) load(ctx context.Context, oauthCredentials map[string]*OAuth
 				var function TransformationFunction
 				var format *string
 				pipeline := Pipeline{}
-				err := rows.Scan(&pipeline.ID, &connectionID, &pipeline.Target, &eventType, &pipeline.OrderingGroup, &pipeline.Name,
+				err := rows.Scan(&pipeline.ID, &connectionID, &pipeline.Target, &eventType, &pipeline.OrderingGroup, &pipeline.DeliveryEndpoint, &pipeline.Name,
 					&pipeline.Enabled, &pipeline.ScheduleStart, &pipeline.SchedulePeriod, &rawInSchema, &rawOutSchema,
 					&filter, &pipeline.RequiredConsents.Purposes, &pipeline.RequiredConsents.Operator, &mapping, &function.ID,
 					&function.Version, &function.Language, &function.Source, &function.PreserveJSON, &pipeline.Transformation.InPaths,

--- a/core/internal/state/state.go
+++ b/core/internal/state/state.go
@@ -1689,6 +1689,7 @@ type Pipeline struct {
 	Enabled            bool
 	EventType          string
 	OrderingGroup      string
+	DeliveryEndpoint   string
 	ScheduleStart      int16
 	SchedulePeriod     int16
 	InSchema           types.Type

--- a/core/pipeline.go
+++ b/core/pipeline.go
@@ -60,6 +60,7 @@ type Pipeline struct {
 	Enabled            bool             `json:"enabled"`
 	EventType          *string          `json:"eventType"`
 	OrderingGroup      *string          `json:"orderingGroup"`
+	DeliveryEndpoint   *string          `json:"deliveryEndpoint"`
 	Running            bool             `json:"running"`
 	ScheduleStart      *int             `json:"scheduleStart"`
 	SchedulePeriod     *SchedulePeriod  `json:"schedulePeriod"`
@@ -524,6 +525,7 @@ func (this *Pipeline) MarshalJSON() ([]byte, error) {
 				serializedPipeline
 				EventType        string           `json:"eventType"`
 				OrderingGroup    string           `json:"orderingGroup"`
+				DeliveryEndpoint string           `json:"deliveryEndpoint"`
 				Filter           *Filter          `json:"filter"`
 				RequiredConsents RequiredConsents `json:"requiredConsents"`
 				Transformation   *Transformation  `json:"transformation"`
@@ -533,6 +535,7 @@ func (this *Pipeline) MarshalJSON() ([]byte, error) {
 				serializedPipeline: p,
 				EventType:          *this.EventType,
 				OrderingGroup:      *this.OrderingGroup,
+				DeliveryEndpoint:   *this.DeliveryEndpoint,
 				Filter:             this.Filter,
 				RequiredConsents:   this.RequiredConsents,
 				Transformation:     this.Transformation,
@@ -1114,6 +1117,7 @@ func (this *Pipeline) fromState(core *Core, store *datastore.Store, pipeline *st
 	if pipeline.EventType != "" {
 		this.EventType = new(pipeline.EventType)
 		this.OrderingGroup = new(pipeline.OrderingGroup)
+		this.DeliveryEndpoint = new(pipeline.DeliveryEndpoint)
 	}
 	_, this.Running = this.pipeline.Run()
 	if pipeline.Target == state.TargetUser || pipeline.Target == state.TargetGroup {

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -372,11 +372,12 @@ func (this *Workspace) Connection(ctx context.Context, id string) (*Connection, 
 		eventTypes := make([]EventType, len(appEventTypes))
 		for i, et := range appEventTypes {
 			eventTypes[i] = EventType{
-				ID:            et.ID,
-				Name:          et.Name,
-				Description:   et.Description,
-				OrderingGroup: connectors.OrderingGroup(et),
-				DefaultFilter: et.DefaultFilter,
+				ID:               et.ID,
+				Name:             et.Name,
+				Description:      et.Description,
+				OrderingGroup:    connectors.OrderingGroup(et),
+				DeliveryEndpoint: et.DeliveryEndpoint,
+				DefaultFilter:    et.DefaultFilter,
 			}
 		}
 		connection.EventTypes = &eventTypes


### PR DESCRIPTION
```
connectors, core: add delivery endpoints to event types (#2401)

Ordering groups define which events for the same user must preserve their
delivery order, but they do not indicate which pipelines share the same
destination endpoint.

A connection may deliver different event types through independent endpoints.
If one endpoint becomes unavailable, future changes can use this information to
suspend only the pipelines that use that endpoint. Conversely, multiple
ordering groups may use the same endpoint and should share its availability
state.

Allow connectors to associate event types with a delivery endpoint. Event types
in the same ordering group must use the same endpoint because suspending either
endpoint independently could violate their shared delivery order.

This commit:

* Adds DeliveryEndpoint to connector event types.
* Uses the empty value as the connector's default endpoint, shared by all event
  types that do not declare an explicit endpoint.
* Applies the property-name syntax and a maximum length of 25 characters to
  explicit endpoint identifiers.
* Verifies that event types in the same ordering group use the same endpoint.
* Resolves and stores the endpoint when a pipeline is created, avoiding the
  need to load connector event type definitions during initialization.
* Makes the endpoint available through pipeline state and the API.
* Backfills existing pipelines with the default endpoint and adds the
  corresponding database constraint.

Future changes will use delivery endpoints to isolate consumption and failure
handling. This commit does not change event routing or delivery behavior.
```