### PR TITLE
core/internal/collector: reset the event decoder type between requests

### DIFF
--- a/core/internal/collector/decoder.go
+++ b/core/internal/collector/decoder.go
@@ -207,6 +207,7 @@ func (d *decoder) Reset(r *http.Request) error {
 	d.writeKey = ""
 	d.connectionId = ""
 	d.context = nil
+	d.typ = ""
 
 	path, _ := strings.CutPrefix(r.URL.Path, "/events")
 	switch path {

--- a/core/internal/collector/decoder_test.go
+++ b/core/internal/collector/decoder_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/netip"
 	"net/url"
 	"reflect"
@@ -586,6 +587,33 @@ func Test_Decoder(t *testing.T) {
 		})
 	}
 
+}
+
+// TestDecoderResetClearsType verifies that a generic request is not decoded
+// using the endpoint type from a previous request.
+func TestDecoderResetClearsType(t *testing.T) {
+	dec := &decoder{}
+	for _, test := range []struct {
+		path string
+		body string
+	}{
+		{path: "/events/track", body: `{"userId":"x","event":"click"}`},
+		{path: "/events", body: `{"userId":"x","event":"click"}`},
+	} {
+		r := httptest.NewRequest(http.MethodPost, test.path, strings.NewReader(test.body))
+		r.Header.Set("Content-Type", "application/json")
+		if err := dec.Reset(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, err := range dec.Events(decoderTestConnectionID, false) {
+		if want := errors.BadRequest("property 'type' is required for a single-event request"); !reflect.DeepEqual(err, want) {
+			t.Fatalf("expected event error %#v, got %#v", want, err)
+		}
+		return
+	}
+	t.Fatal("expected an event decoding error")
 }
 
 // Test_mergeDefaultContext verifies the merge semantics for event-level and


### PR DESCRIPTION
```
core/internal/collector: reset the event decoder type between requests (#2402)

A decoder retained the endpoint-specific event type after being reset.
When reused, it could therefore interpret a generic "/events" request
without a type as using the previous endpoint's type.

Clear the type in Reset and add regression coverage for decoder reuse.
```