### PR TITLE
core: track event acknowledgments across destinations

### DIFF
--- a/core/internal/collector/destination_pipeline.go
+++ b/core/internal/collector/destination_pipeline.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/krenalis/krenalis/core/internal/collector/sender"
-	"github.com/krenalis/krenalis/core/internal/metrics"
 	"github.com/krenalis/krenalis/core/internal/state"
 	"github.com/krenalis/krenalis/core/internal/streams"
 	"github.com/krenalis/krenalis/core/internal/transformers"
@@ -54,7 +53,8 @@ type destinationPipeline struct {
 
 // queuedEvent represents a queued event.
 type queuedEvent struct {
-	streamEvent streams.Event
+	attributes  map[string]any
+	ack         streams.Ack
 	senderEvent *sender.Event
 }
 
@@ -62,8 +62,14 @@ type queuedEvent struct {
 // transformed. Each destinationPipeline instance has its own
 // destinationPipelineQueue, even if the pipeline has no transformation.
 type destinationPipelineQueue struct {
-	metrics *metrics.Collector // metrics collector
-	sender  *sender.Sender     // sender associated with the connection
+	// metrics collector
+	metrics interface {
+		TransformationFailed(pipeline string, count int, message string)
+		TransformationPassed(pipeline string, count int)
+		OutputValidationFailed(pipeline string, count int, message string)
+		OutputValidationPassed(pipeline string, count int)
+	}
+	sender *sender.Sender // sender associated with the connection
 
 	mu     sync.Mutex
 	cond   *sync.Cond
@@ -94,47 +100,78 @@ func newDestinationPipeline(pipeline *state.Pipeline, schema types.Type, provide
 }
 
 // Close closes dp by discarding all queued events and canceling any in-progress
-// transformations, using the provided error as the cancellation cause.
-// It is called when the associated pipeline is disabled or deleted.
+// transformations, using the provided error as the cancellation cause. It is
+// idempotent and is called when the associated pipeline is disabled or deleted.
 func (dp *destinationPipeline) Close(cause error) {
 	dp.queue.mu.Lock()
-	dp.queue.close.closed = true
-	if len(dp.queue.events) > 0 {
-		dp.queue.metrics.TransformationFailed(dp.id, len(dp.queue.events), cause.Error())
-	}
-	clear(dp.queue.events)
-	dp.queue.resetTimerLocked()
-	dp.queue.cond.Broadcast()
-	dp.queue.close.cancel(cause)
-	dp.queue.mu.Unlock()
-}
-
-// QueueEvent queues an event for the pipeline.
-//
-// If the pipeline has a transformation, the event is transformed before being
-// queued.
-func (dp *destinationPipeline) QueueEvent(event streams.Event) {
-	se := dp.queue.sender.CreateEvent(dp.id, dp.eventType, dp.schema, event)
-	if dp.transformer == nil {
-		dp.queue.metrics.TransformationPassed(dp.id, 1)
-		dp.queue.metrics.OutputValidationPassed(dp.id, 1)
-		dp.queue.sender.SendEvent(se)
-		return
-	}
-	dp.queue.mu.Lock()
-	for !dp.queue.close.closed && len(dp.queue.events) >= maxQueuedEventSize {
-		dp.queue.cond.Wait()
-	}
 	if dp.queue.close.closed {
 		dp.queue.mu.Unlock()
 		return
 	}
-	dp.queue.events = append(dp.queue.events, queuedEvent{streamEvent: event, senderEvent: se})
-	n := len(dp.queue.events)
-	if n == 1 || n == minQueuedEventSize {
+	dp.queue.close.closed = true
+	// Detach the queued events while holding the lock. A concurrent QueueEvent
+	// either accepts its event before the pipeline is closed or observes the
+	// closed state.
+	events := dp.queue.events
+	dp.queue.events = nil
+	dp.queue.resetTimerLocked()
+	dp.queue.cond.Broadcast()
+	dp.queue.close.cancel(cause)
+	dp.queue.mu.Unlock()
+
+	if len(events) > 0 {
+		dp.queue.metrics.TransformationFailed(dp.id, len(events), cause.Error())
+		for _, event := range events {
+			dp.queue.discardEvent(event)
+		}
+	}
+}
+
+// QueueEvent submits an event and its corresponding acknowledgment to the
+// pipeline.
+//
+// If the pipeline has a transformation, the event is transformed before being
+// passed to the sender.
+func (dp *destinationPipeline) QueueEvent(attributes map[string]any, ack streams.Ack) {
+
+	dp.queue.mu.Lock()
+	if dp.queue.close.closed {
+		dp.queue.mu.Unlock()
+		ack.Acknowledge()
+		return
+	}
+
+	if dp.transformer == nil {
+		event := dp.queue.sender.CreateEvent(dp.id, dp.eventType, dp.schema, attributes, ack)
+		dp.queue.mu.Unlock()
+		dp.queue.metrics.TransformationPassed(dp.id, 1)
+		dp.queue.metrics.OutputValidationPassed(dp.id, 1)
+		dp.queue.sender.SendEvent(event)
+		return
+	}
+
+	for len(dp.queue.events) >= maxQueuedEventSize && !dp.queue.close.closed {
+		dp.queue.cond.Wait()
+	}
+	if dp.queue.close.closed {
+		dp.queue.mu.Unlock()
+		ack.Acknowledge()
+		return
+	}
+	event := dp.queue.sender.CreateEvent(dp.id, dp.eventType, dp.schema, attributes, ack)
+	dp.queue.events = append(dp.queue.events, queuedEvent{attributes: attributes, ack: ack, senderEvent: event})
+	if n := len(dp.queue.events); n == 1 || n == minQueuedEventSize {
 		dp.queue.resetTimerLocked()
 	}
 	dp.queue.mu.Unlock()
+
+}
+
+// discardEvent marks the event as discarded in the sender, allowing its
+// per-user sequence to advance, before acknowledging its pipeline branch.
+func (q *destinationPipelineQueue) discardEvent(event queuedEvent) {
+	q.sender.DiscardEvent(event.senderEvent)
+	event.ack.Acknowledge()
 }
 
 // resetTimerLocked schedules the timer so that the oldest queued event is
@@ -176,15 +213,14 @@ func (dp *destinationPipeline) transform() {
 	records := make([]transformers.Record, n)
 	for i := range n {
 		records[i].Purpose = transformers.Create
-		records[i].Attributes = events[i].streamEvent.Attributes
+		records[i].Attributes = events[i].attributes
 	}
 
 	// Transform the events.
 	err := dp.transformer.Transform(dp.queue.close.ctx, records)
 	if err != nil {
 		for i := range n {
-			dp.queue.sender.DiscardEvent(events[i].senderEvent)
-			events[i].streamEvent.Ack.Acknowledge()
+			dp.queue.discardEvent(events[i])
 		}
 		var msg string
 		if _, ok := err.(transformers.FunctionExecError); ok {
@@ -201,8 +237,7 @@ func (dp *destinationPipeline) transform() {
 
 	for i, record := range records {
 		if err := record.Err; err != nil {
-			dp.queue.sender.DiscardEvent(events[i].senderEvent)
-			events[i].streamEvent.Ack.Acknowledge()
+			dp.queue.discardEvent(events[i])
 			switch err.(type) {
 			case transformers.RecordTransformationError:
 				dp.queue.metrics.TransformationFailed(dp.id, 1, err.Error())

--- a/core/internal/collector/destination_pipeline_test.go
+++ b/core/internal/collector/destination_pipeline_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by an Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package collector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/krenalis/krenalis/connectors"
+	"github.com/krenalis/krenalis/core/internal/collector/sender"
+	"github.com/krenalis/krenalis/core/internal/streams"
+	"github.com/krenalis/krenalis/core/internal/transformers"
+	"github.com/krenalis/krenalis/tools/types"
+)
+
+// countingAck records how many times it is acknowledged.
+type countingAck struct {
+	count atomic.Int64
+}
+
+// Acknowledge records an acknowledgment.
+func (a *countingAck) Acknowledge() {
+	a.count.Add(1)
+}
+
+// testPipelineMetrics discards metrics recorded by destination pipeline tests.
+type testPipelineMetrics struct{}
+
+// TransformationFailed discards a failed transformation metric.
+func (*testPipelineMetrics) TransformationFailed(string, int, string) {}
+
+// TransformationPassed discards a successful transformation metric.
+func (*testPipelineMetrics) TransformationPassed(string, int) {}
+
+// OutputValidationFailed discards a failed output validation metric.
+func (*testPipelineMetrics) OutputValidationFailed(string, int, string) {}
+
+// OutputValidationPassed discards a successful output validation metric.
+func (*testPipelineMetrics) OutputValidationPassed(string, int) {}
+
+// testDestinationApplication records events delivered by a sender.
+type testDestinationApplication struct {
+	delivered chan string
+}
+
+// ID returns the test connection ID.
+func (*testDestinationApplication) ID() string {
+	return "test-connection"
+}
+
+// Connector returns the test connector name.
+func (*testDestinationApplication) Connector() string {
+	return "test"
+}
+
+// WaitTime returns no additional delay for test deliveries.
+func (*testDestinationApplication) WaitTime(string) (time.Duration, error) {
+	return 0, nil
+}
+
+// SendEvents records every event consumed by the test application.
+func (a *testDestinationApplication) SendEvents(_ context.Context, events connectors.Events) error {
+	for event := range events.All() {
+		a.delivered <- event.Received.MessageID()
+	}
+	return nil
+}
+
+// TestDestinationsQueueEventAcknowledgesMissingPipelines verifies that an
+// event's destinations are acknowledged when none of their pipelines exists.
+func TestDestinationsQueueEventAcknowledgesMissingPipelines(t *testing.T) {
+	first := new(countingAck)
+	second := new(countingAck)
+	d := destinations{
+		pipelines: map[string]destinationPipelines{
+			"connection": nil,
+		},
+	}
+	d.QueueEvent("connection", streams.Event{
+		Destinations: []streams.Destination{
+			{ID: "missing-1", Ack: first},
+			{ID: "missing-2", Ack: second},
+		},
+	})
+
+	if got := first.count.Load(); got != 1 {
+		t.Fatalf("expected 1 acknowledgment for the first missing pipeline, got %d", got)
+	}
+	if got := second.count.Load(); got != 1 {
+		t.Fatalf("expected 1 acknowledgment for the second missing pipeline, got %d", got)
+	}
+}
+
+// TestDestinationPipelineQueueEventAfterCloseAcknowledges verifies that a
+// closed pipeline completes an event without creating sender state for it.
+func TestDestinationPipelineQueueEventAfterCloseAcknowledges(t *testing.T) {
+	original := new(countingAck)
+	q := &destinationPipelineQueue{}
+	q.close.closed = true
+	dp := &destinationPipeline{queue: q}
+
+	dp.QueueEvent(nil, original)
+
+	if got := original.count.Load(); got != 1 {
+		t.Fatalf("expected 1 acknowledgment from the closed pipeline, got %d", got)
+	}
+}
+
+// TestDestinationPipelineCloseCompletesQueuedEvent verifies that closing a
+// pipeline does not panic, completes its queued event, and preserves sender
+// ordering for the following event of the same user.
+func TestDestinationPipelineCloseCompletesQueuedEvent(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		app := &testDestinationApplication{delivered: make(chan string, 1)}
+		s := sender.New(app, nil)
+		defer s.Close(t.Context())
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		q := &destinationPipelineQueue{
+			metrics: new(testPipelineMetrics),
+			sender:  s,
+			timer:   newStoppedTimer(),
+		}
+		q.cond = sync.NewCond(&q.mu)
+		q.close.ctx = ctx
+		q.close.cancel = cancel
+		dp := &destinationPipeline{
+			id:          "pipeline",
+			eventType:   "event",
+			transformer: new(transformers.Transformer),
+			queue:       q,
+		}
+
+		missingAck := new(countingAck)
+		queuedAck := new(countingAck)
+		first := streams.Event{
+			Attributes: map[string]any{
+				"anonymousId": "user",
+				"messageId":   "first",
+			},
+			Destinations: []streams.Destination{
+				{ID: "missing", Ack: missingAck},
+				{ID: dp.id, Ack: queuedAck},
+			},
+		}
+		d := destinations{
+			pipelines: map[string]destinationPipelines{
+				"connection": {dp},
+			},
+		}
+		d.QueueEvent("connection", first)
+
+		if got := missingAck.count.Load(); got != 1 {
+			t.Fatalf("expected 1 acknowledgment for the missing pipeline, got %d", got)
+		}
+		if got := queuedAck.count.Load(); got != 0 {
+			t.Fatalf("expected 0 acknowledgments while the queued pipeline is pending, got %d", got)
+		}
+
+		dp.Close(errors.New("pipeline has been disabled"))
+
+		if got := queuedAck.count.Load(); got != 1 {
+			t.Fatalf("expected 1 acknowledgment for the queued event, got %d", got)
+		}
+		if got := len(q.events); got != 0 {
+			t.Fatalf("expected 0 queued events after close, got %d", got)
+		}
+
+		second := map[string]any{
+			"anonymousId": "user",
+			"messageId":   "second",
+		}
+		s.SendEvent(s.CreateEvent(dp.id, dp.eventType, types.Type{}, second, new(countingAck)))
+
+		select {
+		case got := <-app.delivered:
+			if got != "second" {
+				t.Fatalf("expected delivered event %q, got %q", "second", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("expected the following event to be delivered, got timeout")
+		}
+
+		dp.Close(errors.New("pipeline has been disabled"))
+		if got := queuedAck.count.Load(); got != 1 {
+			t.Fatalf("expected 1 acknowledgment after closing twice, got %d", got)
+		}
+	})
+}
+
+// TestDestinationPipelineCloseUnblocksQueueEvent verifies that closing a full
+// pipeline queue completes a waiting event without leaving a sender sequence
+// gap.
+func TestDestinationPipelineCloseUnblocksQueueEvent(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		app := &testDestinationApplication{delivered: make(chan string, 1)}
+		s := sender.New(app, nil)
+		defer s.Close(t.Context())
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		q := &destinationPipelineQueue{
+			metrics: new(testPipelineMetrics),
+			sender:  s,
+			timer:   newStoppedTimer(),
+		}
+		q.cond = sync.NewCond(&q.mu)
+		q.close.ctx = ctx
+		q.close.cancel = cancel
+		dp := &destinationPipeline{
+			id:          "full-pipeline",
+			eventType:   "event",
+			transformer: new(transformers.Transformer),
+			queue:       q,
+		}
+
+		for i := range maxQueuedEventSize {
+			dp.QueueEvent(map[string]any{
+				"anonymousId": "user",
+				"messageId":   fmt.Sprintf("queued-%d", i),
+			}, new(countingAck))
+		}
+
+		waitingAck := new(countingAck)
+		go dp.QueueEvent(map[string]any{
+			"anonymousId": "user",
+			"messageId":   "waiting",
+		}, waitingAck)
+		synctest.Wait()
+		if got := waitingAck.count.Load(); got != 0 {
+			t.Fatalf("expected 0 acknowledgments before closing the full queue, got %d", got)
+		}
+
+		dp.Close(errors.New("pipeline has been disabled"))
+		synctest.Wait()
+		if got := waitingAck.count.Load(); got != 1 {
+			t.Fatalf("expected 1 acknowledgment after closing the full queue, got %d", got)
+		}
+
+		following := map[string]any{
+			"anonymousId": "user",
+			"messageId":   "following",
+		}
+		s.SendEvent(s.CreateEvent(dp.id, dp.eventType, types.Type{}, following, new(countingAck)))
+
+		select {
+		case got := <-app.delivered:
+			if got != "following" {
+				t.Fatalf("expected delivered event %q, got %q", "following", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("expected the following event to be delivered, got timeout")
+		}
+	})
+}

--- a/core/internal/collector/destinations.go
+++ b/core/internal/collector/destinations.go
@@ -84,9 +84,12 @@ func (d *destinations) QueueEvent(connection string, event streams.Event) {
 	d.mu.Lock()
 	pipelines := d.pipelines[connection]
 	d.mu.Unlock()
-	for _, id := range event.Destinations {
-		if p, _ := pipelines.find(id); p != nil {
-			p.QueueEvent(event)
+	for _, destination := range event.Destinations {
+		pipeline, _ := pipelines.find(destination.ID)
+		if pipeline == nil {
+			destination.Ack.Acknowledge()
+		} else {
+			pipeline.QueueEvent(event.Attributes, destination.Ack)
 		}
 	}
 }

--- a/core/internal/collector/identitywriter.go
+++ b/core/internal/collector/identitywriter.go
@@ -132,7 +132,7 @@ func (iw *identityWriter) transformAndWrite(events []streams.Event) {
 	err := transformer.Transform(ctx, records)
 	if err != nil {
 		for _, event := range events {
-			event.Ack.Acknowledge()
+			event.Destinations[0].Ack.Acknowledge()
 		}
 		if err2, ok := err.(transformers.FunctionExecError); ok {
 			iw.metrics.TransformationFailed(iw.pipeline, len(records), err2.Error())
@@ -151,7 +151,7 @@ func (iw *identityWriter) transformAndWrite(events []streams.Event) {
 				iw.metrics.TransformationPassed(iw.pipeline, 1)
 				iw.metrics.OutputValidationFailed(iw.pipeline, 1, err.Error())
 			}
-			events[i].Ack.Acknowledge()
+			events[i].Destinations[0].Ack.Acknowledge()
 			continue
 		}
 		iw.metrics.TransformationPassed(iw.pipeline, 1)
@@ -164,7 +164,7 @@ func (iw *identityWriter) transformAndWrite(events []streams.Event) {
 			AnonymousID: event.Attributes["anonymousId"].(string),
 			Attributes:  record.Attributes,
 			UpdatedAt:   event.Attributes["timestamp"].(time.Time),
-		}, event.Ack)
+		}, event.Destinations[0].Ack)
 		_ = err // TODO(marco): handle the error
 	}
 
@@ -178,5 +178,5 @@ func (iw *identityWriter) writeDirect(event streams.Event) error {
 		AnonymousID: event.Attributes["anonymousId"].(string),
 		Attributes:  map[string]any{},
 		UpdatedAt:   event.Attributes["timestamp"].(time.Time),
-	}, event.Ack)
+	}, event.Destinations[0].Ack)
 }

--- a/core/internal/collector/sender/sender.go
+++ b/core/internal/collector/sender/sender.go
@@ -226,13 +226,13 @@ func (s *Sender) Close(ctx context.Context) {
 	return
 }
 
-// CreateEvent creates a new event with the given pipeline, type, schema, and
-// original event.
+// CreateEvent creates a new event using the given pipeline, type, schema,
+// attributes, and acknowledgment.
 //
-// The returned event must be passed to SendEvent (optionally after setting the
-// Properties field) or to DiscardEvent if it should be discarded.
-func (s *Sender) CreateEvent(pipeline, typ string, schema types.Type, event streams.Event) *Event {
-	anonymousID, ok := event.Attributes["anonymousId"].(string)
+// The caller must pass the returned event to SendEvent, optionally after
+// setting Properties, or to DiscardEvent if the event should not be sent.
+func (s *Sender) CreateEvent(pipeline, typ string, schema types.Type, attributes map[string]any, ack streams.Ack) *Event {
+	anonymousID, ok := attributes["anonymousId"].(string)
 	if !ok {
 		panic("CreateEvent called with an event missing anonymousId")
 	}
@@ -247,7 +247,7 @@ func (s *Sender) CreateEvent(pipeline, typ string, schema types.Type, event stre
 	s.mu.Unlock()
 	ev := &Event{
 		Event: connectors.Event{
-			Received: connections.ReceivedEvent(event.Attributes),
+			Received: connections.ReceivedEvent(attributes),
 			Type: connectors.EventTypeInfo{
 				ID:     typ,
 				Schema: schema,
@@ -258,7 +258,7 @@ func (s *Sender) CreateEvent(pipeline, typ string, schema types.Type, event stre
 		pipeline:  pipeline,
 		user:      u,
 		sequence:  sequence,
-		ack:       event.Ack,
+		ack:       ack,
 	}
 	return ev
 }

--- a/core/internal/collector/sender/sender_randomized_test.go
+++ b/core/internal/collector/sender/sender_randomized_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/krenalis/krenalis/connectors"
-	"github.com/krenalis/krenalis/core/internal/streams"
 	"github.com/krenalis/krenalis/tools/types"
 )
 
@@ -101,13 +100,10 @@ func testSenderRandomScenario(t *testing.T, test senderRandomTest) senderRandomC
 		if !valid {
 			typ = "Invalid"
 		}
-		event := s.CreateEvent(testPipelineID, typ, types.Type{}, streams.Event{
-			Attributes: map[string]any{
-				"anonymousId": anonymousID,
-				"messageId":   messageID,
-			},
-			Ack: nopAck{},
-		})
+		event := s.CreateEvent(testPipelineID, typ, types.Type{}, map[string]any{
+			"anonymousId": anonymousID,
+			"messageId":   messageID,
+		}, nopAck{})
 		expectedEvents[messageID] = senderRandomExpectedEvent{
 			anonymousID: anonymousID,
 			valid:       valid,

--- a/core/internal/collector/sender/sender_test.go
+++ b/core/internal/collector/sender/sender_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/krenalis/krenalis/connectors"
-	"github.com/krenalis/krenalis/core/internal/streams"
 	"github.com/krenalis/krenalis/tools/types"
 )
 
@@ -193,20 +192,14 @@ func Test_Sender_DiscardedOutOfOrderEvent(t *testing.T) {
 		}
 		s := New(app, nil)
 
-		event0 := s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
-			Attributes: map[string]any{
-				"anonymousId": "user",
-				"messageId":   "msg-0",
-			},
-			Ack: nopAck{},
-		})
-		event1 := s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
-			Attributes: map[string]any{
-				"anonymousId": "user",
-				"messageId":   "msg-1",
-			},
-			Ack: nopAck{},
-		})
+		event0 := s.CreateEvent(testPipelineID, "Click", types.Type{}, map[string]any{
+			"anonymousId": "user",
+			"messageId":   "msg-0",
+		}, nopAck{})
+		event1 := s.CreateEvent(testPipelineID, "Click", types.Type{}, map[string]any{
+			"anonymousId": "user",
+			"messageId":   "msg-1",
+		}, nopAck{})
 
 		s.DiscardEvent(event1)
 		s.SendEvent(event0)
@@ -263,13 +256,10 @@ func Test_Sender_SameUserRebindPreservesOrder(t *testing.T) {
 		defer s.Close(t.Context())
 
 		newEvent := func(anonymousID, messageID string) *Event {
-			return s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
-				Attributes: map[string]any{
-					"anonymousId": anonymousID,
-					"messageId":   messageID,
-				},
-				Ack: nopAck{},
-			})
+			return s.CreateEvent(testPipelineID, "Click", types.Type{}, map[string]any{
+				"anonymousId": anonymousID,
+				"messageId":   messageID,
+			}, nopAck{})
 		}
 
 		// Discarding w-0 releases user-w, so the iteration binds to user-u
@@ -333,13 +323,10 @@ func Test_Sender_SequenceOverflowRescale(t *testing.T) {
 
 		makeEvent := func(messageID string) *Event {
 			t.Helper()
-			return s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
-				Attributes: map[string]any{
-					"anonymousId": userID,
-					"messageId":   messageID,
-				},
-				Ack: nopAck{},
-			})
+			return s.CreateEvent(testPipelineID, "Click", types.Type{}, map[string]any{
+				"anonymousId": userID,
+				"messageId":   messageID,
+			}, nopAck{})
 		}
 
 		e0 := makeEvent("msg-0")
@@ -386,13 +373,10 @@ func Test_Sender_RetryAfterSendEventsErrorWithoutIteration(t *testing.T) {
 		}
 		s := New(app, nil)
 
-		event := s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
-			Attributes: map[string]any{
-				"anonymousId": "user",
-				"messageId":   "msg-0",
-			},
-			Ack: nopAck{},
-		})
+		event := s.CreateEvent(testPipelineID, "Click", types.Type{}, map[string]any{
+			"anonymousId": "user",
+			"messageId":   "msg-0",
+		}, nopAck{})
 		s.SendEvent(event)
 
 		time.Sleep(maxQueueDelay)
@@ -590,13 +574,10 @@ func Test_Sender_UserRemoval(t *testing.T) {
 		s := New(app, nil)
 		defer s.Close(t.Context())
 
-		event := s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
-			Attributes: map[string]any{
-				"anonymousId": "user-1",
-				"messageId":   "msg-1",
-			},
-			Ack: nopAck{},
-		})
+		event := s.CreateEvent(testPipelineID, "Click", types.Type{}, map[string]any{
+			"anonymousId": "user-1",
+			"messageId":   "msg-1",
+		}, nopAck{})
 
 		s.DiscardEvent(event)
 
@@ -627,13 +608,10 @@ func Test_Sender_UserRemoval(t *testing.T) {
 		})
 		defer s.Close(t.Context())
 
-		event := s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
-			Attributes: map[string]any{
-				"anonymousId": "user-2",
-				"messageId":   "msg-2",
-			},
-			Ack: nopAck{},
-		})
+		event := s.CreateEvent(testPipelineID, "Click", types.Type{}, map[string]any{
+			"anonymousId": "user-2",
+			"messageId":   "msg-2",
+		}, nopAck{})
 		s.SendEvent(event)
 
 		select {
@@ -665,13 +643,10 @@ func Test_Sender_UserRemoval(t *testing.T) {
 		})
 		defer s.Close(t.Context())
 
-		event := s.CreateEvent(testPipelineID, "Click", types.Type{}, streams.Event{
-			Attributes: map[string]any{
-				"anonymousId": "user-3",
-				"messageId":   "msg-3",
-			},
-			Ack: nopAck{},
-		})
+		event := s.CreateEvent(testPipelineID, "Click", types.Type{}, map[string]any{
+			"anonymousId": "user-3",
+			"messageId":   "msg-3",
+		}, nopAck{})
 		s.SendEvent(event)
 
 		select {
@@ -691,11 +666,8 @@ func Test_Sender_UserRemoval(t *testing.T) {
 
 // createTestEvent creates a minimal event for tests.
 func createTestEvent(s *Sender, i int) *Event {
-	return s.CreateEvent(testPipelineID, "page", types.Type{}, streams.Event{
-		Attributes: map[string]any{
-			"anonymousId": "user123",
-			"messageId":   fmt.Sprintf("msg-%d", i),
-		},
-		Ack: nopAck{},
-	})
+	return s.CreateEvent(testPipelineID, "page", types.Type{}, map[string]any{
+		"anonymousId": "user123",
+		"messageId":   fmt.Sprintf("msg-%d", i),
+	}, nopAck{})
 }

--- a/core/internal/datastore/eventwriter.go
+++ b/core/internal/datastore/eventwriter.go
@@ -208,8 +208,10 @@ func (w *EventWriter) Write(ctx context.Context, event streams.Event, pipeline s
 	// userId
 	row[66] = event.Attributes["userId"]
 
+	ack := event.Destinations[0].Ack
+
 	select {
-	case w.events <- flusherRow[[]any]{pipeline: pipeline, row: row, ack: event.Ack}:
+	case w.events <- flusherRow[[]any]{pipeline: pipeline, row: row, ack: ack}:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/core/internal/streams/nats/nats.go
+++ b/core/internal/streams/nats/nats.go
@@ -554,7 +554,7 @@ func (s *stream) Consume(topic string, size int) streams.Consumer {
 
 // ack coordinates the destination acknowledgments of a NATS message.
 type ack struct {
-	mu        sync.Mutex // protects remaining and the done field of each destination acknowledgment.
+	mu        sync.Mutex // protects 'remaining' and every destinationAck.done field.
 	msg       jetstream.Msg
 	remaining int // number of destinations that have not acknowledged the message; protected by mu.
 }

--- a/core/internal/streams/nats/nats.go
+++ b/core/internal/streams/nats/nats.go
@@ -511,18 +511,19 @@ func (s *stream) Consume(topic string, size int) streams.Consumer {
 						err = fmt.Errorf("invalid event data: %s", err)
 						return
 					}
+					var destinations []string
 					if header := msg.Headers(); header != nil {
-						if destinations, ok := header["destinations"]; ok {
-							for _, d := range destinations {
-								if !isValidDestination(d) {
-									err = fmt.Errorf("invalid event destination: %q", d)
+						if ids, ok := header["destinations"]; ok {
+							for _, id := range ids {
+								if !isValidDestination(id) {
+									err = fmt.Errorf("invalid event destination: %q", id)
 									return
 								}
 							}
-							event.Destinations = destinations
+							destinations = ids
 						}
 					}
-					event.Ack = &ack{msg: msg}
+					event.Destinations = destinationsForMessage(msg, destinations)
 					select {
 					case consumer.events <- event:
 					case <-done:
@@ -551,15 +552,37 @@ func (s *stream) Consume(topic string, size int) streams.Consumer {
 	return consumer
 }
 
-// ack acknowledges a NATS event.
+// ack coordinates the destination acknowledgments of a NATS message.
 type ack struct {
-	msg jetstream.Msg
+	mu        sync.Mutex // protects remaining and the done field of each destination acknowledgment.
+	msg       jetstream.Msg
+	remaining int // number of destinations that have not acknowledged the message; protected by mu.
 }
 
-// Acknowledge acknowledges the event.
-func (a *ack) Acknowledge() {
-	if err := a.msg.Ack(); err != nil {
-		slog.Warn(fmt.Sprintf("collector: cannot ack event: %s", err))
+// destinationAck acknowledges one destination of a NATS message.
+type destinationAck struct {
+	parent *ack
+	done   bool // whether the destination has acknowledged the message; protected by parent.mu.
+}
+
+// Acknowledge marks the destination as complete and acknowledges the NATS
+// message after all of its destinations have completed.
+func (d *destinationAck) Acknowledge() {
+	p := d.parent
+	p.mu.Lock()
+	if d.done {
+		p.mu.Unlock()
+		return
+	}
+	d.done = true
+	p.remaining--
+	isLast := p.remaining == 0
+	p.mu.Unlock()
+	if isLast {
+		err := p.msg.Ack()
+		if err != nil {
+			slog.Warn(fmt.Sprintf("nats: cannot ack event: %s", err))
+		}
 	}
 }
 
@@ -640,6 +663,25 @@ func (batch *batch) Publish(ctx context.Context, topics []string, event map[stri
 		batch.futures = append(batch.futures, future)
 	}
 	return nil
+}
+
+// destinationsForMessage returns the destinations and their acknowledgments for
+// a NATS message. A message without explicit destinations has one destination
+// whose ID is empty.
+func destinationsForMessage(msg jetstream.Msg, ids []string) []streams.Destination {
+	parent := &ack{msg: msg, remaining: 1}
+	switch n := len(ids); n {
+	case 0:
+		return []streams.Destination{{Ack: &destinationAck{parent: parent}}}
+	default:
+		parent.remaining = n
+		destinations := make([]streams.Destination, n)
+		for i := range destinations {
+			destinations[i].ID = ids[i]
+			destinations[i].Ack = &destinationAck{parent: parent}
+		}
+		return destinations
+	}
 }
 
 // isValidDestination reports whether s is a valid destination identifier.

--- a/core/internal/streams/nats/nats_test.go
+++ b/core/internal/streams/nats/nats_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by an Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package nats
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// testJetStreamMsg records acknowledgments sent to a JetStream message.
+type testJetStreamMsg struct {
+	jetstream.Msg
+	acknowledgments atomic.Int64
+}
+
+// Ack records a JetStream message acknowledgment.
+func (m *testJetStreamMsg) Ack() error {
+	m.acknowledgments.Add(1)
+	return nil
+}
+
+// TestDestinationsForMessageCreatesAnonymousDestination verifies that a message
+// without explicit destinations receives one anonymous destination.
+func TestDestinationsForMessageCreatesAnonymousDestination(t *testing.T) {
+	msg := new(testJetStreamMsg)
+	destinations := destinationsForMessage(msg, nil)
+
+	if got := len(destinations); got != 1 {
+		t.Fatalf("expected 1 anonymous destination, got %d", got)
+	}
+	if got := destinations[0].ID; got != "" {
+		t.Fatalf("expected an empty anonymous destination ID, got %q", got)
+	}
+
+	destinations[0].Ack.Acknowledge()
+	destinations[0].Ack.Acknowledge()
+	if got := msg.acknowledgments.Load(); got != 1 {
+		t.Fatalf("expected 1 message acknowledgment, got %d", got)
+	}
+}
+
+// TestDestinationAcksAcknowledgeAfterEveryDestination verifies that a NATS
+// message is acknowledged after every destination has completed.
+func TestDestinationAcksAcknowledgeAfterEveryDestination(t *testing.T) {
+	msg := new(testJetStreamMsg)
+	destinations := destinationsForMessage(msg, []string{"first", "second"})
+
+	if got := len(destinations); got != 2 {
+		t.Fatalf("expected 2 destinations, got %d", got)
+	}
+	if got := destinations[0].ID; got != "first" {
+		t.Fatalf("expected first destination ID %q, got %q", "first", got)
+	}
+	if got := destinations[1].ID; got != "second" {
+		t.Fatalf("expected second destination ID %q, got %q", "second", got)
+	}
+
+	destinations[0].Ack.Acknowledge()
+	destinations[0].Ack.Acknowledge()
+	if got := msg.acknowledgments.Load(); got != 0 {
+		t.Fatalf("expected 0 message acknowledgments while one destination is pending, got %d", got)
+	}
+
+	destinations[1].Ack.Acknowledge()
+	destinations[1].Ack.Acknowledge()
+	if got := msg.acknowledgments.Load(); got != 1 {
+		t.Fatalf("expected 1 message acknowledgment after every destination completed, got %d", got)
+	}
+}
+
+// TestDestinationAcksAreConcurrent verifies that destination acknowledgments
+// remain idempotent when destinations complete concurrently.
+func TestDestinationAcksAreConcurrent(t *testing.T) {
+	msg := new(testJetStreamMsg)
+	ids := make([]string, 32)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("destination%d", i)
+	}
+	destinations := destinationsForMessage(msg, ids)
+
+	var wg sync.WaitGroup
+	for i := range destinations {
+		wg.Go(func() {
+			destinations[i].Ack.Acknowledge()
+			destinations[i].Ack.Acknowledge()
+		})
+	}
+	wg.Wait()
+
+	if got := msg.acknowledgments.Load(); got != 1 {
+		t.Fatalf("expected 1 concurrent message acknowledgment, got %d", got)
+	}
+}

--- a/core/internal/streams/stream.go
+++ b/core/internal/streams/stream.go
@@ -71,15 +71,24 @@ type BatchPublisher interface {
 	Done(ctx context.Context) error
 }
 
-// Ack acknowledges an event read from a stream.
+// Ack acknowledges that an event has been processed for one destination.
 type Ack interface {
-	// Acknowledge acknowledges the event.
+	// Acknowledge reports that processing for the destination is complete.
 	Acknowledge()
 }
 
+// Destination identifies an event destination and its acknowledgment.
+type Destination struct {
+	ID  string // empty when the destination is implied by the consumed topic
+	Ack Ack
+}
+
 // Event represents an event read from the stream.
+//
+// Destinations contains at least one destination. When the destination is
+// implied by the consumed topic, the slice contains a single destination with
+// an empty ID.
 type Event struct {
 	Attributes   map[string]any
-	Destinations []string
-	Ack          Ack
+	Destinations []Destination
 }


### PR DESCRIPTION
```
core: track acknowledgments per event destination (#2406)

A single event can be delivered through multiple destination pipelines.
In the existing implementation, those pipelines share a single
acknowledgment, so the first one to finish can acknowledge the NATS
message while the others are still processing their copies of the event.

Missing or closed pipelines also cause related issues:

 * events for those pipelines can be dropped without invoking the shared
   acknowledgment;
 * closing a pipeline can leave gaps in the sender's per-user sequence,
   preventing later events for that user from progressing.

This change gives each event destination its own idempotent
acknowledgment, coordinated through shared state associated with the
original NATS message.

As a result:

 * acknowledging one destination completes only that branch;
 * the NATS message is acknowledged only when all destinations are
   complete;
 * destinations whose pipelines are missing or closed are marked
   complete;
 * when a pipeline closes, its queued sender events are discarded before
   their destination branches are marked complete, allowing per-user
   ordering to continue.

A separate planned change will periodically send InProgress
acknowledgments to JetStream while a message is being processed. Each
acknowledgment resets the message's AckWait redelivery timer. The
completion paths in this change ensure that missing or closed pipelines
cannot cause these acknowledgments to continue indefinitely.

This change does not limit event processing time or alter delivery retry
behavior. Suspending unavailable destinations and moving long-lived
delivery work out of memory will be addressed separately.
```