### PR TITLE
core, warehouses: add identity counts to profiles

### DIFF
--- a/core/internal/datastore/records_test.go
+++ b/core/internal/datastore/records_test.go
@@ -83,6 +83,8 @@ func Test_Records(t *testing.T) {
 		Name: "krenalis_profiles_0",
 		Columns: []warehouses.Column{
 			{Name: "_kpid", Type: types.UUID()},
+			{Name: "_anonymous_count", Type: types.Int(32)},
+			{Name: "_recognized_count", Type: types.Int(32)},
 			{Name: "_updated_at", Type: types.DateTime()},
 			{Name: "id", Type: types.String()},
 			{Name: "other_id", Type: types.String()},
@@ -102,7 +104,7 @@ func Test_Records(t *testing.T) {
 		Keys: []string{"_pipeline", "_external_id"},
 	}
 
-	err = dw.Initialize(ctx, profilesTable.Columns[2:])
+	err = dw.Initialize(ctx, profilesTable.Columns[4:])
 	if err != nil {
 		t.Fatalf("cannot initialize the warehouse: %s", err)
 	}
@@ -110,13 +112,13 @@ func Test_Records(t *testing.T) {
 	now := time.Now().UTC()
 
 	initUsers := [][]any{
-		{"e5a5c059-bc78-4c9c-b4d1-e9fb187562b1", now, "1", "1", "Jake Thompson", 43},
-		{"943a0a39-fd0b-4f7b-a113-59046fb8a511", now, "2", "2", "Emily Davis", 58},
-		{"2a3654ca-a387-49c3-8eb8-8420ab8a7532", now, "3", "3", "Michael Carter", 31},
-		{"243abf79-cbc3-4c6e-8739-e1406f2f6b51", now, "2", "2", "Sophia Harris", 19},
-		{"445ab9fa-5689-4870-bc39-2d01c2a71b00", now, "6", "6", "Emily Johnson", 25},
-		{"ce8f366d-7144-4ec0-96e7-d0dc35597c02", now, "7", "7", "James Williams", 77},
-		{"a415976f-279e-4653-ab6a-64ea7f74e174", now, "7", "7", "Daniel Brown", 12},
+		{"e5a5c059-bc78-4c9c-b4d1-e9fb187562b1", 0, 1, now, "1", "1", "Jake Thompson", 43},
+		{"943a0a39-fd0b-4f7b-a113-59046fb8a511", 0, 1, now, "2", "2", "Emily Davis", 58},
+		{"2a3654ca-a387-49c3-8eb8-8420ab8a7532", 0, 1, now, "3", "3", "Michael Carter", 31},
+		{"243abf79-cbc3-4c6e-8739-e1406f2f6b51", 0, 1, now, "2", "2", "Sophia Harris", 19},
+		{"445ab9fa-5689-4870-bc39-2d01c2a71b00", 0, 1, now, "6", "6", "Emily Johnson", 25},
+		{"ce8f366d-7144-4ec0-96e7-d0dc35597c02", 0, 1, now, "7", "7", "James Williams", 77},
+		{"a415976f-279e-4653-ab6a-64ea7f74e174", 0, 1, now, "7", "7", "Daniel Brown", 12},
 	}
 	err = dw.Merge(ctx, profilesTable, initUsers, nil)
 	if err != nil {

--- a/core/internal/datastore/warehouses_identityresolution_test.go
+++ b/core/internal/datastore/warehouses_identityresolution_test.go
@@ -56,6 +56,11 @@ type identity struct {
 	attributes   map[string]any
 }
 
+type identityCounts struct {
+	anonymous  int
+	recognized int
+}
+
 const (
 	identityResolutionConnection1 = "6NpT4zB8QaR2"
 	identityResolutionConnection2 = "8QaT3mN7KxP5"
@@ -89,7 +94,14 @@ func TestWarehousesIdentityResolution(t *testing.T) {
 		primarySources   map[string]string
 		identities       []identity
 		expectedProfiles []map[string]any
+		expectedCounts   []identityCounts
 	}{
+		{
+			name:           "No identities",
+			identifiers:    []string{},
+			identities:     []identity{},
+			expectedCounts: []identityCounts{},
+		},
 		{
 			name:        "One identity, no identifiers",
 			identifiers: []string{},
@@ -104,6 +116,24 @@ func TestWarehousesIdentityResolution(t *testing.T) {
 			expectedProfiles: []map[string]any{
 				{"email": "a@b", "first_name": nil, "last_name": nil, "notes": nil},
 			},
+			expectedCounts: []identityCounts{{recognized: 1}},
+		},
+		{
+			name:        "One anonymous identity, no identifiers",
+			identifiers: []string{},
+			identities: []identity{
+				{
+					connection:  identityResolutionConnection1,
+					pipeline:    identityResolutionPipeline1,
+					isAnonymous: true,
+					id:          "anonymous-1",
+					attributes:  map[string]any{"email": nil, "first_name": nil, "last_name": nil, "notes": nil},
+				},
+			},
+			expectedProfiles: []map[string]any{
+				{"email": nil, "first_name": nil, "last_name": nil, "notes": nil},
+			},
+			expectedCounts: []identityCounts{{anonymous: 1}},
 		},
 		{
 			name:        "Two identities from the same connection (different ID), no identifiers",
@@ -147,6 +177,7 @@ func TestWarehousesIdentityResolution(t *testing.T) {
 			expectedProfiles: []map[string]any{
 				{"email": "c@d", "first_name": nil, "last_name": nil, "notes": nil},
 			},
+			expectedCounts: []identityCounts{{recognized: 1}},
 		},
 		{
 			name:        "Two identities from two different connections, no identifiers",
@@ -190,6 +221,7 @@ func TestWarehousesIdentityResolution(t *testing.T) {
 			expectedProfiles: []map[string]any{
 				{"email": "a@b", "first_name": nil, "last_name": nil, "notes": nil},
 			},
+			expectedCounts: []identityCounts{{recognized: 2}},
 		},
 		{
 			name:        "Two identities from two different connections, matching for an identifier with second-level priority, previous identifiers are both nil",
@@ -276,6 +308,30 @@ func TestWarehousesIdentityResolution(t *testing.T) {
 			expectedProfiles: []map[string]any{
 				{"email": nil, "first_name": "Luke", "last_name": nil, "notes": nil},
 			},
+			expectedCounts: []identityCounts{{anonymous: 1}},
+		},
+		{
+			name:        "Anonymous and recognized identities with the same text are different identities",
+			identifiers: []string{"email"},
+			identities: []identity{
+				{
+					connection:  identityResolutionConnection1,
+					pipeline:    identityResolutionPipeline1,
+					isAnonymous: true,
+					id:          "same-id",
+					attributes:  map[string]any{"email": "a@b", "first_name": nil, "last_name": nil, "notes": nil},
+				},
+				{
+					connection: identityResolutionConnection1,
+					pipeline:   identityResolutionPipeline2,
+					id:         "same-id",
+					attributes: map[string]any{"email": "a@b", "first_name": nil, "last_name": nil, "notes": nil},
+				},
+			},
+			expectedProfiles: []map[string]any{
+				{"email": "a@b", "first_name": nil, "last_name": nil, "notes": nil},
+			},
+			expectedCounts: []identityCounts{{anonymous: 1, recognized: 1}},
 		},
 		{
 			name:        "Two identities not merged as one is anonymous and one is not",
@@ -575,6 +631,7 @@ func TestWarehousesIdentityResolution(t *testing.T) {
 			}
 
 			mergeColumns := identitiesMergeColumns(columnByName)
+			profilesVersion := 0
 
 			for _, test := range tests {
 				t.Run(test.name, func(t *testing.T) {
@@ -636,6 +693,7 @@ func TestWarehousesIdentityResolution(t *testing.T) {
 							t.Fatal(err)
 						}
 					}
+					profilesVersion++
 
 					// Read the profiles from the warehouse and check that they match with
 					// the expected ones.
@@ -700,11 +758,63 @@ func TestWarehousesIdentityResolution(t *testing.T) {
 					if !reflect.DeepEqual(test.expectedProfiles, gotProfiles) {
 						t.Fatalf("\nexpected profiles:\n\t%v\ngot:\n\t%v", test.expectedProfiles, gotProfiles)
 					}
+
+					if test.expectedCounts != nil {
+						gotCounts := readIdentityCounts(t, ctx, dw, profilesVersion)
+						expectedCounts := slices.Clone(test.expectedCounts)
+						sortIdentityCounts(expectedCounts)
+						sortIdentityCounts(gotCounts)
+						if !slices.Equal(expectedCounts, gotCounts) {
+							t.Fatalf("expected identity counts %v, got %v", expectedCounts, gotCounts)
+						}
+					}
 				})
 			}
 		})
 	}
 
+}
+
+func readIdentityCounts(t *testing.T, ctx context.Context, dw warehouses.Warehouse, profilesVersion int) []identityCounts {
+	t.Helper()
+	countColumns := []warehouses.Column{
+		{Name: "_anonymous_count", Type: types.Int(32)},
+		{Name: "_recognized_count", Type: types.Int(32)},
+	}
+	r, _, err := dw.Query(ctx, warehouses.RowQuery{
+		Columns: countColumns,
+		Table:   fmt.Sprintf("krenalis_profiles_%d", profilesVersion),
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var counts []identityCounts
+	row := make([]any, len(countColumns))
+	for r.Next() {
+		if err := r.Scan(row...); err != nil {
+			t.Fatal(err)
+		}
+		counts = append(counts, identityCounts{
+			anonymous:  row[0].(int),
+			recognized: row[1].(int),
+		})
+	}
+	if err := r.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return counts
+}
+
+func sortIdentityCounts(counts []identityCounts) {
+	slices.SortFunc(counts, func(a, b identityCounts) int {
+		if n := cmp.Compare(a.anonymous, b.anonymous); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.recognized, b.recognized)
+	})
 }
 
 // identitiesMergeColumns returns the columns to be used during the identities

--- a/warehouses/postgresql/identityresolution.go
+++ b/warehouses/postgresql/identityresolution.go
@@ -87,6 +87,13 @@ func (warehouse *PostgreSQL) ResolveIdentities(ctx context.Context, opID string,
 		if err != nil {
 			return fmt.Errorf("cannot create profiles table (with name %s): %s", quoteIdent(newProfilesName), err)
 		}
+		// Add the identity count columns if they are not already present.
+		_, err = tx.Exec(ctx, `ALTER TABLE `+quoteIdent(newProfilesName)+
+			` ADD COLUMN IF NOT EXISTS "_anonymous_count" integer NOT NULL,`+
+			` ADD COLUMN IF NOT EXISTS "_recognized_count" integer NOT NULL`)
+		if err != nil {
+			return err
+		}
 		// Link the candidate version to this operation so it can be published on
 		// success or removed on failure.
 		_, err = tx.Exec(ctx, `INSERT INTO "krenalis_profile_schema_versions" ("version", "operation", "timestamp")`+
@@ -152,7 +159,7 @@ func (warehouse *PostgreSQL) ResolveIdentities(ctx context.Context, opID string,
 		mergeProfiles.WriteString(quoteIdent(c.Name))
 		mergeProfiles.WriteByte(',')
 	}
-	mergeProfiles.WriteString(`"_identities", "_kpid", "_updated_at"`)
+	mergeProfiles.WriteString(`"_identities", "_anonymous_count", "_recognized_count", "_kpid", "_updated_at"`)
 	mergeProfiles.WriteString(") SELECT\n")
 	for _, c := range profileColumns {
 		if c.Type.Kind() == types.ArrayKind {
@@ -177,6 +184,8 @@ func (warehouse *PostgreSQL) ResolveIdentities(ctx context.Context, opID string,
 	}
 	// Write the "_identities" column.
 	mergeProfiles.WriteString(`ARRAY_AGG(DISTINCT "_pk"), `)
+	mergeProfiles.WriteString(`COUNT(DISTINCT ("_connection", "_identity_id")) FILTER (WHERE "_is_anonymous"), `)
+	mergeProfiles.WriteString(`COUNT(DISTINCT ("_connection", "_identity_id")) FILTER (WHERE NOT "_is_anonymous"), `)
 	// Write the "_kpid" column.
 	// If all KPIDs are the same - ignoring the NULL ones, which refer to new
 	// identities - then take the common value as the profile's KPID; otherwise,

--- a/warehouses/postgresql/identityresolution_test.go
+++ b/warehouses/postgresql/identityresolution_test.go
@@ -46,6 +46,44 @@ func Test_finalizeIdentityResolutionPreservesPersistedSuccess(t *testing.T) {
 
 }
 
+// TestResolveIdentitiesAddsMissingIdentityCountColumns verifies that a new
+// profiles table includes identity count columns when copied from a previous
+// schema.
+func TestResolveIdentitiesAddsMissingIdentityCountColumns(t *testing.T) {
+
+	warehouse, pool := newTestPostgreSQLWarehouse(t)
+	profileColumns := []warehouses.Column{{Name: "email", Type: types.String(), Nullable: true}}
+	if err := warehouse.Initialize(t.Context(), profileColumns); err != nil {
+		t.Fatal(err)
+	}
+	for _, column := range []string{"_anonymous_count", "_recognized_count"} {
+		_, err := pool.Exec(t.Context(), `ALTER TABLE "krenalis_profiles_0" DROP COLUMN `+quoteIdent(column))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const opID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d7"
+	err := warehouse.ResolveIdentities(t.Context(), opID, profileColumns, profileColumns, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var countColumns int
+	err = pool.QueryRow(t.Context(), `SELECT COUNT(*)
+		FROM information_schema.columns
+		WHERE table_schema = current_schema()
+			AND table_name = 'krenalis_profiles_1'
+			AND column_name IN ('_anonymous_count', '_recognized_count')`).Scan(&countColumns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countColumns != 2 {
+		t.Fatalf("expected two identity count columns in the new profiles table, got %d", countColumns)
+	}
+
+}
+
 // TestResolveIdentitiesRemovesObsoleteProfileTables verifies that a successful
 // operation after a failure removes obsolete profile tables and retains only
 // the published table.

--- a/warehouses/postgresql/initrepair.go
+++ b/warehouses/postgresql/initrepair.go
@@ -187,6 +187,8 @@ func profilesSQLSchema(name string, profileColumns []warehouses.Column) string {
 	b.WriteString(` (
 		"_kpid" uuid,
 		"_identities" int [],
+		"_anonymous_count" integer NOT NULL,
+		"_recognized_count" integer NOT NULL,
 		"_updated_at" timestamp without time zone NOT NULL`)
 	for _, c := range profileColumns {
 		b.WriteString(",\n")

--- a/warehouses/snowflake/identityresolution.go
+++ b/warehouses/snowflake/identityresolution.go
@@ -89,6 +89,12 @@ func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, 
 		if err != nil {
 			return fmt.Errorf("cannot create profiles table (with name %s): %s", quoteIdent(newProfilesName), err)
 		}
+		// Add the identity count columns if they are not already present.
+		_, err = tx.ExecContext(ctx, `ALTER TABLE `+quoteIdent(newProfilesName)+` ADD COLUMN IF NOT EXISTS`+
+			` "_ANONYMOUS_COUNT" INTEGER NOT NULL, COLUMN IF NOT EXISTS "_RECOGNIZED_COUNT" INTEGER NOT NULL`)
+		if err != nil {
+			return snowflake(err)
+		}
 		// Link the candidate version to this operation so it can be published on
 		// success or removed on failure.
 		_, err = tx.ExecContext(ctx, `INSERT INTO "KRENALIS_PROFILE_SCHEMA_VERSIONS" ("VERSION", "OPERATION", "TIMESTAMP")`+
@@ -149,7 +155,7 @@ func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, 
 		mergeProfiles.WriteString(quoteIdent(c.Name))
 		mergeProfiles.WriteByte(',')
 	}
-	mergeProfiles.WriteString(`"_IDENTITIES", "_KPID", "_UPDATED_AT"`)
+	mergeProfiles.WriteString(`"_IDENTITIES", "_ANONYMOUS_COUNT", "_RECOGNIZED_COUNT", "_KPID", "_UPDATED_AT"`)
 	mergeProfiles.WriteString(") SELECT\n")
 	for _, c := range profileColumns {
 		if c.Type.Kind() == types.ArrayKind {
@@ -182,6 +188,14 @@ func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, 
 	}
 	// Write the "_identities" column.
 	mergeProfiles.WriteString(`ARRAY_AGG(DISTINCT "_PK"), `)
+	mergeProfiles.WriteString(`COUNT(DISTINCT
+		CASE WHEN "_IS_ANONYMOUS" THEN "_CONNECTION" END,
+		CASE WHEN "_IS_ANONYMOUS" THEN "_IDENTITY_ID" END
+	), `)
+	mergeProfiles.WriteString(`COUNT(DISTINCT
+		CASE WHEN NOT "_IS_ANONYMOUS" THEN "_CONNECTION" END,
+		CASE WHEN NOT "_IS_ANONYMOUS" THEN "_IDENTITY_ID" END
+	), `)
 	// Write the "_KPID" column.
 	// If all KPIDs are the same - ignoring the NULL ones, which refer to new
 	// identities - then take the common value as the profile's KPID; otherwise,
@@ -313,29 +327,33 @@ func createPendingViewQuery(currentProfilesName, newProfilesName, opID string, p
 			AND "ERROR" = ''
 	)`)
 
-	var b strings.Builder
-	b.WriteString(`CREATE OR REPLACE VIEW "PROFILES" AS SELECT` + "\n")
+	var columns strings.Builder
 	metaProps := []string{"_KPID", "_UPDATED_AT"}
 	for i, property := range metaProps {
 		if i > 0 {
-			b.WriteString(",\n")
+			columns.WriteString(",\n")
 		}
-		b.WriteString("\t")
-		b.WriteString(quoteIdent(property))
+		columns.WriteString("\t")
+		columns.WriteString(quoteIdent(property))
 	}
 	for _, column := range profileColumns {
-		b.WriteString(",\n\t")
-		b.WriteString(quoteIdent(column.Name))
+		columns.WriteString(",\n\t")
+		columns.WriteString(quoteIdent(column.Name))
 	}
-	b.WriteString("\nFROM (\n\tSELECT * FROM ")
+
+	var b strings.Builder
+	b.WriteString(`CREATE OR REPLACE VIEW "PROFILES" AS SELECT` + "\n")
+	b.WriteString(columns.String())
+	b.WriteString("\nFROM ")
 	b.WriteString(quoteIdent(newProfilesName))
 	b.WriteString(" WHERE ")
 	b.WriteString(completed.String())
-	b.WriteString("\n\tUNION ALL\n\tSELECT * FROM ")
+	b.WriteString("\nUNION ALL\nSELECT\n")
+	b.WriteString(columns.String())
+	b.WriteString("\nFROM ")
 	b.WriteString(quoteIdent(currentProfilesName))
 	b.WriteString(" WHERE NOT ")
 	b.WriteString(completed.String())
-	b.WriteString("\n) AS \"PUBLISHED_PROFILES\"")
 
 	return b.String()
 }

--- a/warehouses/snowflake/identityresolution_test.go
+++ b/warehouses/snowflake/identityresolution_test.go
@@ -21,13 +21,15 @@ func Test_createPendingViewQuery(t *testing.T) {
 		Name: "email",
 		Type: types.String(),
 	}})
+	columns := `SELECT` + "\n\t" + `"_KPID",` + "\n\t" + `"_UPDATED_AT",` + "\n\t" + `"EMAIL"`
 	wants := []string{
-		`SELECT` + "\n\t" + `"_KPID",` + "\n\t" + `"_UPDATED_AT",` + "\n\t" + `"EMAIL"`,
-		`SELECT * FROM "KRENALIS_PROFILES_2" WHERE EXISTS (`,
+		columns + `
+FROM "KRENALIS_PROFILES_2" WHERE EXISTS (`,
 		`WHERE "ID" = 'operation\'id'`,
 		`AND "COMPLETED_AT" IS NOT NULL`,
 		`AND "ERROR" = ''`,
-		`SELECT * FROM "KRENALIS_PROFILES_1" WHERE NOT EXISTS (`,
+		columns + `
+FROM "KRENALIS_PROFILES_1" WHERE NOT EXISTS (`,
 	}
 	for _, want := range wants {
 		if !strings.Contains(query, want) {
@@ -65,6 +67,44 @@ func Test_finalizeIdentityResolutionPreservesPersistedSuccess(t *testing.T) {
 	}
 	if operationError != "" {
 		t.Fatalf("expected successful operation to remain successful, got error %q", operationError)
+	}
+
+}
+
+// TestResolveIdentitiesAddsMissingIdentityCountColumns verifies that a new
+// profiles table includes identity count columns when copied from a previous
+// schema.
+func TestResolveIdentitiesAddsMissingIdentityCountColumns(t *testing.T) {
+
+	warehouse, db := newTestSnowflakeWarehouse(t)
+	profileColumns := []warehouses.Column{{Name: "email", Type: types.String(), Nullable: true}}
+	if err := warehouse.Initialize(t.Context(), profileColumns); err != nil {
+		t.Fatal(err)
+	}
+	for _, column := range []string{"_ANONYMOUS_COUNT", "_RECOGNIZED_COUNT"} {
+		_, err := db.ExecContext(t.Context(), `ALTER TABLE "KRENALIS_PROFILES_0" DROP COLUMN `+quoteIdent(column))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const opID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d7"
+	err := warehouse.ResolveIdentities(t.Context(), opID, profileColumns, profileColumns, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var countColumns int
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*)
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = CURRENT_SCHEMA()
+			AND TABLE_NAME = 'KRENALIS_PROFILES_1'
+			AND COLUMN_NAME IN ('_ANONYMOUS_COUNT', '_RECOGNIZED_COUNT')`).Scan(&countColumns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countColumns != 2 {
+		t.Fatalf("expected two identity count columns in the new profiles table, got %d", countColumns)
 	}
 
 }

--- a/warehouses/snowflake/initrepair.go
+++ b/warehouses/snowflake/initrepair.go
@@ -138,6 +138,8 @@ func profilesSQLSchema(name string, profileColumns []warehouses.Column) string {
 	b.WriteString(` (
 		"_KPID" VARCHAR(36),
 		"_IDENTITIES" ARRAY,
+		"_ANONYMOUS_COUNT" INTEGER NOT NULL,
+		"_RECOGNIZED_COUNT" INTEGER NOT NULL,
 		"_UPDATED_AT" TIMESTAMP NOT NULL`)
 	for _, c := range profileColumns {
 		b.WriteString(",\n")


### PR DESCRIPTION
```
core, warehouses: add identity counts to profiles (#2410)

Add _anonymous_count and _recognized_count to profile tables and
populate them during Identity Resolution.

The counts represent the number of distinct anonymous and non-anonymous
identities that are part of each profile, without counting the same
identity multiple times when processed by multiple pipelines.

Existing warehouse schemas are not migrated by this commit.
```