### PR TITLE
core/internal/connections: restore event iterator state after preview

### DIFF
--- a/core/internal/connections/application.go
+++ b/core/internal/connections/application.go
@@ -401,6 +401,7 @@ func (iter *singleEventIterator) All() iter.Seq[*connectors.Event] {
 	return func(yield func(event *connectors.Event) bool) {
 		iter.iterating = true
 		yield(iter.event)
+		iter.iterating = false
 	}
 }
 
@@ -466,6 +467,7 @@ func (iter *singleEventIterator) SameUser() iter.Seq[*connectors.Event] {
 	return func(yield func(event *connectors.Event) bool) {
 		iter.iterating = true
 		yield(iter.event)
+		iter.iterating = false
 	}
 }
 

--- a/core/internal/connections/application_test.go
+++ b/core/internal/connections/application_test.go
@@ -5,8 +5,10 @@
 package connections
 
 import (
+	"iter"
 	"testing"
 
+	"github.com/krenalis/krenalis/connectors"
 	"github.com/krenalis/krenalis/tools/json"
 	"github.com/krenalis/krenalis/tools/types"
 )
@@ -55,4 +57,49 @@ func Test_sameValue(t *testing.T) {
 		})
 	}
 
+}
+
+// Test_singleEventIterator_Peek verifies Peek's behavior before, during, and
+// after iterating over a single event.
+func Test_singleEventIterator_Peek(t *testing.T) {
+
+	tests := []struct {
+		name string
+		seq  func(*singleEventIterator) iter.Seq[*connectors.Event]
+	}{
+		{name: "All", seq: (*singleEventIterator).All},
+		{name: "SameUser", seq: (*singleEventIterator).SameUser},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := new(connectors.Event)
+			events := newSingleEventIterator(event, "test")
+
+			for range 2 {
+				got, ok := events.Peek()
+				if !ok || got != event {
+					t.Fatalf("Peek before iteration: expected event %p and true, got %p and %t", event, got, ok)
+				}
+			}
+
+			yielded := 0
+			for range test.seq(events) {
+				yielded++
+				if got, ok := events.Peek(); ok || got != nil {
+					t.Fatalf("Peek during iteration: expected nil and false, got %p and %t", got, ok)
+				}
+			}
+			if yielded != 1 {
+				t.Fatalf("expected one event, got %d", yielded)
+			}
+
+			defer func() {
+				if recover() == nil {
+					t.Fatal("Peek after iteration: expected panic")
+				}
+			}()
+			events.Peek()
+		})
+	}
 }

--- a/core/internal/connections/application_test.go
+++ b/core/internal/connections/application_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/krenalis/krenalis/connectors"
+	"github.com/krenalis/krenalis/tools/errors"
 	"github.com/krenalis/krenalis/tools/json"
 	"github.com/krenalis/krenalis/tools/types"
 )
@@ -102,4 +103,45 @@ func Test_singleEventIterator_Peek(t *testing.T) {
 			events.Peek()
 		})
 	}
+}
+
+// Test_singleEventIterator_UsageAfterIteration verifies that methods available
+// only during an active iteration panic after the iteration completes.
+func Test_singleEventIterator_UsageAfterIteration(t *testing.T) {
+
+	sequences := []struct {
+		name string
+		seq  func(*singleEventIterator) iter.Seq[*connectors.Event]
+	}{
+		{name: "All", seq: (*singleEventIterator).All},
+		{name: "SameUser", seq: (*singleEventIterator).SameUser},
+	}
+	methods := []struct {
+		name string
+		call func(*singleEventIterator)
+	}{
+		{name: "Discard", call: func(events *singleEventIterator) {
+			events.Discard(errors.New("event is invalid"))
+		}},
+		{name: "Postpone", call: func(events *singleEventIterator) {
+			events.Postpone()
+		}},
+	}
+
+	for _, sequence := range sequences {
+		for _, method := range methods {
+			t.Run(sequence.name+"/"+method.name, func(t *testing.T) {
+				events := newSingleEventIterator(&connectors.Event{}, "test")
+				for range sequence.seq(events) {
+				}
+				defer func() {
+					if recover() == nil {
+						t.Fatal(method.name + " after iteration: expected panic")
+					}
+				}()
+				method.call(events)
+			})
+		}
+	}
+
 }


### PR DESCRIPTION
```
core/internal/connections: restore event iterator state after preview (#2415)

Peek, Discard, and Postpone cannot be called after an iteration has
completed; doing so correctly causes a panic.

However, the single-event iterator used by PreviewSendEvent did not
reset its iterating field after All or SameUser completed. As a result,
Peek returned no event, and Discard and Postpone did not panic.

Reset the iterator state and add tests covering the single-event
iterator before, during, and after All and SameUser iterations.
```