### PR TITLE
core: preserve incremental cursor on record errors

### DIFF
--- a/core/run_import.go
+++ b/core/run_import.go
@@ -104,7 +104,7 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 	users := make([]connections.Record, 0, 100)
 	transformationRecords := make([]transformers.Record, 0, 100)
 
-	var cursor time.Time
+	cursor := run.Cursor
 
 	// Read the users.
 	for user := range records.All(ctx) {

--- a/test/import_from_database_test.go
+++ b/test/import_from_database_test.go
@@ -6,7 +6,9 @@ package test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/krenalis/krenalis/core"
 	"github.com/krenalis/krenalis/test/krenalistester"
 	"github.com/krenalis/krenalis/tools/types"
 )
@@ -60,4 +62,88 @@ func TestImportFromDatabase(t *testing.T) {
 			t.Fatalf("expected identity pipeline %s, got %s", importUsers, identity.Pipeline)
 		}
 	}
+}
+
+// TestImportFromDatabasePreservesCursorOnRecordError verifies that an
+// incremental import preserves its cursor when the only source result is a
+// record-level error whose update time was not read and remains zero.
+func TestImportFromDatabasePreservesCursorOnRecordError(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip()
+	}
+	k := krenalistester.NewKrenalisInstance(t)
+	k.Start()
+	defer k.Stop()
+
+	ctx := t.Context()
+	k.ExecQueryTestDatabase(ctx, `
+		CREATE TABLE import_cursor_records (
+			id TEXT,
+			email TEXT,
+			updated_at TIMESTAMPTZ NOT NULL
+		)`)
+	defer k.ExecQueryTestDatabase(ctx, "DROP TABLE import_cursor_records")
+
+	firstUpdatedAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	k.ExecQueryTestDatabase(ctx,
+		"INSERT INTO import_cursor_records (id, email, updated_at) VALUES ($1, $2, $3)",
+		"user-1", "user-1@example.com", firstUpdatedAt)
+
+	pgSQL := k.CreateSourcePostgreSQL()
+	pipeline := k.CreatePipeline(pgSQL, "User", krenalistester.PipelineToSet{
+		Name:        "Import users incrementally",
+		Enabled:     true,
+		Incremental: true,
+		InSchema: types.Object([]types.Property{
+			{Name: "id", Type: types.String(), Nullable: true},
+			{Name: "email", Type: types.String(), Nullable: true},
+			{Name: "updated_at", Type: types.DateTime(), Nullable: true},
+		}),
+		OutSchema: types.Object([]types.Property{
+			{Name: "email", Type: types.String().WithMaxLength(300), ReadOptional: true},
+		}),
+		Transformation: &krenalistester.Transformation{
+			Mapping: map[string]string{
+				"email": "email",
+			},
+		},
+		Query: `
+			SELECT id, email, updated_at
+			FROM import_cursor_records
+			WHERE updated_at >= COALESCE(${updated_at}, '-infinity'::timestamptz)
+			ORDER BY updated_at
+			LIMIT ${limit}`,
+		UserIDColumn:    "id",
+		UpdatedAtColumn: "updated_at",
+	})
+
+	run := k.StartPipelineRun(pipeline)
+	k.WaitForRunsCompletion(run)
+
+	var cursor time.Time
+	k.QueryRowTestDatabase(ctx, &cursor, "SELECT cursor FROM pipelines WHERE id = $1", pipeline)
+	if !cursor.Equal(firstUpdatedAt) {
+		t.Fatalf("expected initial cursor %s, got %s", firstUpdatedAt, cursor)
+	}
+
+	secondUpdatedAt := firstUpdatedAt.Add(time.Hour)
+	k.ExecQueryTestDatabase(ctx, "TRUNCATE import_cursor_records")
+	k.ExecQueryTestDatabase(ctx,
+		"INSERT INTO import_cursor_records (id, email, updated_at) VALUES (NULL, $1, $2)",
+		"invalid@example.com", secondUpdatedAt)
+
+	run = k.StartPipelineRun(pipeline)
+	k.WaitForRunsCompletionAllowFailed(run)
+
+	completedRun := k.PipelineRun(run)
+	if failed := completedRun.Failed[core.ReceiveStep]; failed != 1 {
+		t.Fatalf("expected one record receive failure, got %d", failed)
+	}
+
+	k.QueryRowTestDatabase(ctx, &cursor, "SELECT cursor FROM pipelines WHERE id = $1", pipeline)
+	if !cursor.Equal(firstUpdatedAt) {
+		t.Fatalf("expected cursor to remain %s after a record error, got %s", firstUpdatedAt, cursor)
+	}
+
 }


### PR DESCRIPTION
```
core: preserve incremental cursor on record errors (#2418)

When an incremental import returned only errored records, their update
times were not read, causing the pipeline cursor to be reset to zero.

Initialize the import cursor from the run cursor so it remains unchanged
when no valid update time is read.
```