### PR TITLE
warehouses: rename `Expr`-related types

### DIFF
--- a/core/internal/datastore/batch_identitywriter.go
+++ b/core/internal/datastore/batch_identitywriter.go
@@ -144,9 +144,9 @@ func (w *BatchIdentityWriter) Close(ctx context.Context) error {
 		if w.skipPurge {
 			return ErrPurgeSkipped
 		}
-		where := warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
-			warehouses.NewBaseExpr(warehouses.Column{Name: "_pipeline", Type: types.String()}, warehouses.OpIs, w.pipeline),
-			warehouses.NewBaseExpr(warehouses.Column{Name: "_run", Type: types.String()}, warehouses.OpIsNot, w.run),
+		where := warehouses.NewLogicalExpr(warehouses.OpAnd, []warehouses.Expr{
+			warehouses.NewConditionExpr(warehouses.Column{Name: "_pipeline", Type: types.String()}, warehouses.OpIs, w.pipeline),
+			warehouses.NewConditionExpr(warehouses.Column{Name: "_run", Type: types.String()}, warehouses.OpIsNot, w.run),
 		})
 		err = w.store.warehouse().Delete(ctx, "krenalis_identities", where)
 	}

--- a/core/internal/datastore/query.go
+++ b/core/internal/datastore/query.go
@@ -53,25 +53,25 @@ type Query struct {
 // "exists" and "does not exist" operators are mapped to OpIsNotNull and
 // OpIsNull, respectively.
 func convertWhere(where *state.Where, columnFromProperty map[string]warehouses.Column) (warehouses.Expr, error) {
-	exp := warehouses.NewMultiExpr(warehouses.LogicalOperator(where.Logical), make([]warehouses.Expr, len(where.Conditions)))
+	exp := warehouses.NewLogicalExpr(warehouses.LogicalOperator(where.Logical), make([]warehouses.Expr, len(where.Conditions)))
 	for i, cond := range where.Conditions {
 		path := strings.Join(cond.Property, ".") // TODO(marco): How can I avoid this allocation?
 		if column, ok := columnFromProperty[path]; ok {
-			var op warehouses.Operator
+			var op warehouses.ConditionOperator
 			switch cond.Operator {
 			case state.OpExists:
 				op = warehouses.OpIsNotNull
 			case state.OpDoesNotExist:
 				op = warehouses.OpIsNull
 			default:
-				op = warehouses.Operator(cond.Operator)
+				op = warehouses.ConditionOperator(cond.Operator)
 			}
-			exp.Operands[i] = warehouses.NewBaseExpr(column, op, cond.Values...)
+			exp.Operands[i] = warehouses.NewConditionExpr(column, op, cond.Values...)
 			continue
 		}
 		// The property is an object; apply it to all sub-property columns.
 		var logical warehouses.LogicalOperator
-		var op warehouses.Operator
+		var op warehouses.ConditionOperator
 		switch cond.Operator {
 		case state.OpExists:
 			logical = warehouses.OpOr
@@ -85,16 +85,16 @@ func convertWhere(where *state.Where, columnFromProperty map[string]warehouses.C
 		var operands []warehouses.Expr
 		for name, column := range columnFromProperty {
 			if strings.HasPrefix(name, path) && name[len(path)] == '.' {
-				operands = append(operands, warehouses.NewBaseExpr(column, op))
+				operands = append(operands, warehouses.NewConditionExpr(column, op))
 			}
 		}
 		if operands == nil {
 			return nil, fmt.Errorf("property %q does not exist in where expression", path)
 		}
 		slices.SortFunc(operands, func(a, b warehouses.Expr) int {
-			return cmp.Compare(a.(*warehouses.BaseExpr).Column.Name, b.(*warehouses.BaseExpr).Column.Name)
+			return cmp.Compare(a.(*warehouses.ConditionExpr).Column.Name, b.(*warehouses.ConditionExpr).Column.Name)
 		})
-		exp.Operands[i] = warehouses.NewMultiExpr(logical, operands)
+		exp.Operands[i] = warehouses.NewLogicalExpr(logical, operands)
 	}
 	return exp, nil
 }

--- a/core/internal/datastore/query_test.go
+++ b/core/internal/datastore/query_test.go
@@ -29,8 +29,8 @@ func TestConvertWhereSimple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("convertWhere returned error: %v", err)
 	}
-	want := warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
-		warehouses.NewBaseExpr(column, warehouses.OpIs, 1),
+	want := warehouses.NewLogicalExpr(warehouses.OpAnd, []warehouses.Expr{
+		warehouses.NewConditionExpr(column, warehouses.OpIs, 1),
 	})
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("expected %#v, got %#v", want, got)
@@ -56,9 +56,9 @@ func TestConvertWhereMultiple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("convertWhere returned error: %v", err)
 	}
-	want := warehouses.NewMultiExpr(warehouses.OpOr, []warehouses.Expr{
-		warehouses.NewBaseExpr(colA, warehouses.OpIsGreaterThan, 5),
-		warehouses.NewBaseExpr(colBC, warehouses.OpIsLessThanOrEqualTo, 10),
+	want := warehouses.NewLogicalExpr(warehouses.OpOr, []warehouses.Expr{
+		warehouses.NewConditionExpr(colA, warehouses.OpIsGreaterThan, 5),
+		warehouses.NewConditionExpr(colBC, warehouses.OpIsLessThanOrEqualTo, 10),
 	})
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("expected %#v, got %#v", want, got)
@@ -91,15 +91,15 @@ func TestConvertWhereExistsOperators(t *testing.T) {
 	if err != nil {
 		t.Fatalf("convertWhere returned error: %v", err)
 	}
-	want := warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
-		warehouses.NewBaseExpr(colA, warehouses.OpIsNotNull),
-		warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
-			warehouses.NewBaseExpr(colBC, warehouses.OpIsNull),
-			warehouses.NewBaseExpr(colBD, warehouses.OpIsNull),
+	want := warehouses.NewLogicalExpr(warehouses.OpAnd, []warehouses.Expr{
+		warehouses.NewConditionExpr(colA, warehouses.OpIsNotNull),
+		warehouses.NewLogicalExpr(warehouses.OpAnd, []warehouses.Expr{
+			warehouses.NewConditionExpr(colBC, warehouses.OpIsNull),
+			warehouses.NewConditionExpr(colBD, warehouses.OpIsNull),
 		}),
-		warehouses.NewMultiExpr(warehouses.OpOr, []warehouses.Expr{
-			warehouses.NewBaseExpr(colEF, warehouses.OpIsNotNull),
-			warehouses.NewBaseExpr(colEG, warehouses.OpIsNotNull),
+		warehouses.NewLogicalExpr(warehouses.OpOr, []warehouses.Expr{
+			warehouses.NewConditionExpr(colEF, warehouses.OpIsNotNull),
+			warehouses.NewConditionExpr(colEG, warehouses.OpIsNotNull),
 		}),
 	})
 	if !reflect.DeepEqual(want, got) {

--- a/core/internal/datastore/records.go
+++ b/core/internal/datastore/records.go
@@ -99,9 +99,9 @@ func records(ctx context.Context, warehouse warehouses.Warehouse, query Query, i
 		joins = []warehouses.Join{
 			{
 				Table: "krenalis_destination_profiles",
-				Condition: warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
-					warehouses.NewBaseExpr(warehouses.Column{Name: "_pipeline", Type: types.String()}, warehouses.OpIs, matching.Pipeline),
-					warehouses.NewBaseExpr(inPropertyColumn, warehouses.OpIs, warehouses.Column{Name: "_out_matching_value", Type: types.String()}),
+				Condition: warehouses.NewLogicalExpr(warehouses.OpAnd, []warehouses.Expr{
+					warehouses.NewConditionExpr(warehouses.Column{Name: "_pipeline", Type: types.String()}, warehouses.OpIs, matching.Pipeline),
+					warehouses.NewConditionExpr(inPropertyColumn, warehouses.OpIs, warehouses.Column{Name: "_out_matching_value", Type: types.String()}),
 				}),
 			},
 		}
@@ -111,13 +111,13 @@ func records(ctx context.Context, warehouse warehouses.Warehouse, query Query, i
 			joins[0].Type = warehouses.InnerJoin
 		case state.CreateOnly:
 			// Include only users without a corresponding match.
-			where = andExpressions(where, warehouses.NewBaseExpr(warehouses.Column{Name: "_pipeline", Type: types.String()}, warehouses.OpIsNull))
+			where = andExpressions(where, warehouses.NewConditionExpr(warehouses.Column{Name: "_pipeline", Type: types.String()}, warehouses.OpIsNull))
 			fallthrough
 		case state.CreateOrUpdate:
 			// Perform a LEFT JOIN to also return users without a matching destination user.
 			joins[0].Type = warehouses.LeftJoin
 			// Include only users with a value for the input matching property.
-			where = andExpressions(where, warehouses.NewBaseExpr(inPropertyColumn, warehouses.OpIsNotNull))
+			where = andExpressions(where, warehouses.NewConditionExpr(inPropertyColumn, warehouses.OpIsNotNull))
 		}
 		// Sort the results by the input matching property, user ID, and external ID.
 		orderBy = []warehouses.Column{
@@ -157,17 +157,16 @@ func records(ctx context.Context, warehouse warehouses.Warehouse, query Query, i
 	return records, err
 }
 
-// andExpressions returns an expression resulting from the AND of expr with
-// base.
-func andExpressions(expr warehouses.Expr, base *warehouses.BaseExpr) warehouses.Expr {
+// andExpressions returns the logical AND of expr and condition.
+func andExpressions(expr warehouses.Expr, condition *warehouses.ConditionExpr) warehouses.Expr {
 	if expr == nil {
-		return base
+		return condition
 	}
-	if e, ok := expr.(*warehouses.MultiExpr); ok && e.Operator == warehouses.OpAnd {
-		e.Operands = append(e.Operands, base)
+	if e, ok := expr.(*warehouses.LogicalExpr); ok && e.Operator == warehouses.OpAnd {
+		e.Operands = append(e.Operands, condition)
 		return e
 	}
-	return warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{expr, base})
+	return warehouses.NewLogicalExpr(warehouses.OpAnd, []warehouses.Expr{expr, condition})
 }
 
 // Records represents records read from the data warehouse.

--- a/core/internal/datastore/store.go
+++ b/core/internal/datastore/store.go
@@ -186,7 +186,7 @@ func (store *Store) DeleteDestinationProfiles(ctx context.Context, pipeline stri
 		return err
 	}
 	defer done()
-	where := warehouses.NewBaseExpr(
+	where := warehouses.NewConditionExpr(
 		warehouses.Column{Name: "_pipeline", Type: types.String()}, warehouses.OpIs, pipeline)
 	return store.warehouse().Delete(ctx, "krenalis_destination_profiles", where)
 }
@@ -446,7 +446,7 @@ func (store *Store) PurgePipelines(ctx context.Context, pipelines []string) erro
 	for i, pipeline := range pipelines {
 		values[i] = pipeline
 	}
-	where := warehouses.NewBaseExpr(warehouses.Column{Name: "_pipeline", Type: types.String()}, warehouses.OpIsOneOf, values...)
+	where := warehouses.NewConditionExpr(warehouses.Column{Name: "_pipeline", Type: types.String()}, warehouses.OpIsOneOf, values...)
 	err = store.warehouse().Delete(ctx, "krenalis_identities", where)
 	if err != nil {
 		return err

--- a/warehouses/postgresql/query_test.go
+++ b/warehouses/postgresql/query_test.go
@@ -18,7 +18,7 @@ func Test_appendJoins(t *testing.T) {
 	join := warehouses.Join{
 		Type:  warehouses.InnerJoin,
 		Table: "t2",
-		Condition: warehouses.NewBaseExpr(
+		Condition: warehouses.NewConditionExpr(
 			warehouses.Column{Name: "id", Type: types.Int(32)},
 			warehouses.OpIs,
 			warehouses.Column{Name: "fk", Type: types.Int(32)},
@@ -36,7 +36,7 @@ func Test_appendJoins(t *testing.T) {
 	bad := warehouses.Join{
 		Type:      warehouses.InnerJoin,
 		Table:     "t3",
-		Condition: warehouses.NewBaseExpr(warehouses.Column{Name: "bad name", Type: types.Int(32)}, warehouses.OpIs, 1),
+		Condition: warehouses.NewConditionExpr(warehouses.Column{Name: "bad name", Type: types.Int(32)}, warehouses.OpIs, 1),
 	}
 	b.Reset()
 	if err := appendJoins(&b, []warehouses.Join{bad}); err == nil {

--- a/warehouses/postgresql/renderexpr.go
+++ b/warehouses/postgresql/renderexpr.go
@@ -19,39 +19,39 @@ import (
 // representing a boolean expression.
 func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 
-	// Handle MultiExpr expression.
-	if multiExpr, ok := exp.(*warehouses.MultiExpr); ok {
+	// Handle logical expressions.
+	if logicalExpr, ok := exp.(*warehouses.LogicalExpr); ok {
 		var op string
-		switch multiExpr.Operator {
+		switch logicalExpr.Operator {
 		case warehouses.OpAnd:
 			op = " AND "
 		case warehouses.OpOr:
 			op = " OR "
 		default:
-			return fmt.Errorf("invalid operator %d", multiExpr.Operator)
+			return fmt.Errorf("invalid operator %d", logicalExpr.Operator)
 		}
-		for i, operand := range multiExpr.Operands {
+		for i, operand := range logicalExpr.Operands {
 			if i > 0 {
 				b.WriteString(op)
 			}
-			_, isMultiExpr := operand.(*warehouses.MultiExpr)
-			if isMultiExpr {
+			_, isLogicalExpr := operand.(*warehouses.LogicalExpr)
+			if isLogicalExpr {
 				b.WriteByte('(')
 			}
 			err := renderExpr(b, operand)
 			if err != nil {
 				return err
 			}
-			if isMultiExpr {
+			if isLogicalExpr {
 				b.WriteByte(')')
 			}
 		}
 		return nil
 	}
 
-	// Handle BaseExpr expressions.
-	baseExpr := exp.(*warehouses.BaseExpr)
-	c := baseExpr.Column
+	// Handle condition expressions.
+	conditionExpr := exp.(*warehouses.ConditionExpr)
+	c := conditionExpr.Column
 
 	// Validate the column name.
 	if !warehouses.IsValidIdentifier(c.Name) {
@@ -61,7 +61,7 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 	qname := quoteIdent(c.Name)
 
 	// Render the column identifier, the operator, and, if necessary, the values.
-	switch op := baseExpr.Operator; op {
+	switch op := conditionExpr.Operator; op {
 	case
 		warehouses.OpIs,
 		warehouses.OpIsNot,
@@ -90,7 +90,7 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 		case warehouses.OpIsGreaterThanOrEqualTo, warehouses.OpIsOnOrAfter:
 			b.WriteString(" >= ")
 		}
-		serializeValue(b, baseExpr.Values[0], c.Type)
+		serializeValue(b, conditionExpr.Values[0], c.Type)
 
 	case warehouses.OpIsBetween, warehouses.OpIsNotBetween:
 		b.WriteString(qname)
@@ -98,15 +98,15 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 			b.WriteString(" NOT")
 		}
 		b.WriteString(" BETWEEN ")
-		serializeValue(b, baseExpr.Values[0], c.Type)
+		serializeValue(b, conditionExpr.Values[0], c.Type)
 		b.WriteString(" AND ")
-		serializeValue(b, baseExpr.Values[1], c.Type)
+		serializeValue(b, conditionExpr.Values[1], c.Type)
 
 	case warehouses.OpContains, warehouses.OpDoesNotContain:
 		switch c.Type.Kind() {
 		case types.StringKind:
 			b.WriteString("POSITION(")
-			serializeValue(b, baseExpr.Values[0], c.Type)
+			serializeValue(b, conditionExpr.Values[0], c.Type)
 			b.WriteString(" IN ")
 			b.WriteString(qname)
 			if op == warehouses.OpContains {
@@ -118,7 +118,7 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 			if op == warehouses.OpDoesNotContain {
 				b.WriteString("NOT (")
 			}
-			serializeValue(b, baseExpr.Values[0], c.Type.Elem())
+			serializeValue(b, conditionExpr.Values[0], c.Type.Elem())
 			b.WriteString(" = ANY(")
 			b.WriteString(qname)
 			b.WriteByte(')')
@@ -134,7 +134,7 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 		} else {
 			b.WriteString(" NOT IN (")
 		}
-		for i, v := range baseExpr.Values {
+		for i, v := range conditionExpr.Values {
 			if i > 0 {
 				b.WriteByte(',')
 			}
@@ -150,9 +150,9 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 		}
 		b.WriteString(qname)
 		b.WriteString(", LENGTH(")
-		serializeValue(b, baseExpr.Values[0], c.Type)
+		serializeValue(b, conditionExpr.Values[0], c.Type)
 		b.WriteString(")) = ")
-		serializeValue(b, baseExpr.Values[0], c.Type)
+		serializeValue(b, conditionExpr.Values[0], c.Type)
 
 	case warehouses.OpIsTrue:
 		b.WriteString(qname)

--- a/warehouses/postgresql/renderexpr_test.go
+++ b/warehouses/postgresql/renderexpr_test.go
@@ -23,156 +23,156 @@ func Test_renderExpr(t *testing.T) {
 		invalid bool
 	}{
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "qwerty"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "qwerty"),
 			query: `"id" = 'qwerty'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "ip_addr", Type: types.IP()}, warehouses.OpIs, "127.0.0.1"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "ip_addr", Type: types.IP()}, warehouses.OpIs, "127.0.0.1"),
 			query: `"ip_addr" = '127.0.0.1'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "age", Type: types.Int(32)}, warehouses.OpIsNot, 18),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "age", Type: types.Int(32)}, warehouses.OpIsNot, 18),
 			query: `"age" <> 18`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "a", Type: types.String()}, warehouses.OpIs, warehouses.Column{Name: "b", Type: types.String()}),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "a", Type: types.String()}, warehouses.OpIs, warehouses.Column{Name: "b", Type: types.String()}),
 			query: `"a" = "b"`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsLessThan, 6.5),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsLessThan, 6.5),
 			query: `"weight" < 6.5`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsLessThanOrEqualTo, 6.5),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsLessThanOrEqualTo, 6.5),
 			query: `"weight" <= 6.5`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "weight", Type: types.Float(64)}, warehouses.OpIsGreaterThan, 6.5092373641509225),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "weight", Type: types.Float(64)}, warehouses.OpIsGreaterThan, 6.5092373641509225),
 			query: `"weight" > 6.5092373641509225`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIsGreaterThanOrEqualTo, decimal.MustInt(3289)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIsGreaterThanOrEqualTo, decimal.MustInt(3289)),
 			query: `"count" >= 3289`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsBefore, time.Date(1900, 1, 2, 23, 32, 11, 940253000, time.UTC)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsBefore, time.Date(1900, 1, 2, 23, 32, 11, 940253000, time.UTC)),
 			query: `"timestamp" < '1900-01-02 23:32:11.940253'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsOnOrBefore, time.Date(1900, 1, 2, 23, 32, 11, 940253000, time.UTC)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsOnOrBefore, time.Date(1900, 1, 2, 23, 32, 11, 940253000, time.UTC)),
 			query: `"timestamp" <= '1900-01-02 23:32:11.940253'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.Date()}, warehouses.OpIsAfter, time.Date(1900, 1, 2, 0, 0, 0, 0, time.UTC)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.Date()}, warehouses.OpIsAfter, time.Date(1900, 1, 2, 0, 0, 0, 0, time.UTC)),
 			query: `"timestamp" > '1900-01-02'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.Date()}, warehouses.OpIsOnOrAfter, time.Date(1900, 1, 2, 0, 0, 0, 0, time.UTC)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.Date()}, warehouses.OpIsOnOrAfter, time.Date(1900, 1, 2, 0, 0, 0, 0, time.UTC)),
 			query: `"timestamp" >= '1900-01-02'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.Int(32)}, warehouses.OpIsBetween, 5, 10),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.Int(32)}, warehouses.OpIsBetween, 5, 10),
 			query: `"id" BETWEEN 5 AND 10`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpContains, "foo"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpContains, "foo"),
 			query: `POSITION('foo' IN "name") > 0`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpDoesNotContain, "boo"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpDoesNotContain, "boo"),
 			query: `POSITION('boo' IN "name") = 0`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "values", Type: types.Array(types.Int(32))}, warehouses.OpContains, 5),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "values", Type: types.Array(types.Int(32))}, warehouses.OpContains, 5),
 			query: `5 = ANY("values")`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "values", Type: types.Array(types.Int(32))}, warehouses.OpDoesNotContain, 7),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "values", Type: types.Array(types.Int(32))}, warehouses.OpDoesNotContain, 7),
 			query: `NOT (7 = ANY("values"))`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.Int(32)}, warehouses.OpIsOneOf, 3, 9, 5),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.Int(32)}, warehouses.OpIsOneOf, 3, 9, 5),
 			query: `"id" IN (3,9,5)`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "a", Type: types.Float(64)}, warehouses.OpIsOneOf, 5.3, 12.6, 9.0),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "a", Type: types.Float(64)}, warehouses.OpIsOneOf, 5.3, 12.6, 9.0),
 			query: `"a" IN (5.3,12.6,9)`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpStartsWith, "foo"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpStartsWith, "foo"),
 			query: `LEFT("name", LENGTH('foo')) = 'foo'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpEndsWith, "foo"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpEndsWith, "foo"),
 			query: `RIGHT("name", LENGTH('foo')) = 'foo'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "active", Type: types.Boolean()}, warehouses.OpIsTrue),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "active", Type: types.Boolean()}, warehouses.OpIsTrue),
 			query: `"active"`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "active", Type: types.Boolean()}, warehouses.OpIsFalse),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "active", Type: types.Boolean()}, warehouses.OpIsFalse),
 			query: `NOT "active"`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIsNull),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIsNull),
 			query: `"id" IS NULL`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIsNotNull),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIsNotNull),
 			query: `"id" IS NOT NULL`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpAnd,
 				[]warehouses.Expr{
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 870000000, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 870000000, time.UTC)),
 				}),
 			query: `"timestamp" < '1900-01-02 23:32:11.87'`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpAnd,
 				[]warehouses.Expr{
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsGreaterThan, time.Date(1700, 1, 2, 23, 32, 11, 0, time.UTC)),
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 0, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsGreaterThan, time.Date(1700, 1, 2, 23, 32, 11, 0, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 0, time.UTC)),
 				}),
 			query: `"timestamp" > '1700-01-02 23:32:11' AND "timestamp" < '1900-01-02 23:32:11'`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpOr,
 				[]warehouses.Expr{
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsGreaterThan, time.Date(1700, 1, 2, 23, 32, 11, 0, time.UTC)),
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 0, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsGreaterThan, time.Date(1700, 1, 2, 23, 32, 11, 0, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 0, time.UTC)),
 				}),
 			query: `"timestamp" > '1700-01-02 23:32:11' OR "timestamp" < '1900-01-02 23:32:11'`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpAnd,
 				[]warehouses.Expr{
-					warehouses.NewMultiExpr(warehouses.OpOr, []warehouses.Expr{
-						warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_42"),
-						warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_50"),
-						warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_60"),
+					warehouses.NewLogicalExpr(warehouses.OpOr, []warehouses.Expr{
+						warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_42"),
+						warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_50"),
+						warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_60"),
 					}),
-					warehouses.NewMultiExpr(warehouses.OpOr, []warehouses.Expr{
-						warehouses.NewBaseExpr(warehouses.Column{Name: "count", Type: types.Int(32)}, warehouses.OpIs, 100),
-						warehouses.NewBaseExpr(warehouses.Column{Name: "count", Type: types.Int(32)}, warehouses.OpIs, 200),
-						warehouses.NewBaseExpr(warehouses.Column{Name: "count", Type: types.Int(32)}, warehouses.OpIs, 300),
+					warehouses.NewLogicalExpr(warehouses.OpOr, []warehouses.Expr{
+						warehouses.NewConditionExpr(warehouses.Column{Name: "count", Type: types.Int(32)}, warehouses.OpIs, 100),
+						warehouses.NewConditionExpr(warehouses.Column{Name: "count", Type: types.Int(32)}, warehouses.OpIs, 200),
+						warehouses.NewConditionExpr(warehouses.Column{Name: "count", Type: types.Int(32)}, warehouses.OpIs, 300),
 					}),
 				}),
 			query: `("id" = 'abc_42' OR "id" = 'abc_50' OR "id" = 'abc_60') AND ("count" = 100 OR "count" = 200 OR "count" = 300)`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpOr,
 				[]warehouses.Expr{
-					warehouses.NewBaseExpr(warehouses.Column{Name: "type", Type: types.String(), Nullable: true}, warehouses.OpIsNotEmpty),
-					// warehouses.NewBaseExpr(warehouses.Column{Name: "properties", Type: types.JSON()}, warehouses.OpIsEmpty), // See issue https://github.com/krenalis/krenalis/issues/1804.
-					warehouses.NewBaseExpr(warehouses.Column{Name: "scores", Type: types.Array(types.Int(32)), Nullable: true}, warehouses.OpIsEmpty),
-					warehouses.NewBaseExpr(warehouses.Column{Name: "properties", Type: types.Map(types.String())}, warehouses.OpIsNotEmpty),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "type", Type: types.String(), Nullable: true}, warehouses.OpIsNotEmpty),
+					// warehouses.NewConditionExpr(warehouses.Column{Name: "properties", Type: types.JSON()}, warehouses.OpIsEmpty), // See issue https://github.com/krenalis/krenalis/issues/1804.
+					warehouses.NewConditionExpr(warehouses.Column{Name: "scores", Type: types.Array(types.Int(32)), Nullable: true}, warehouses.OpIsEmpty),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "properties", Type: types.Map(types.String())}, warehouses.OpIsNotEmpty),
 				}),
 			query: `("type" IS NOT NULL AND "type" <> '') OR array_length("scores", 1) IS NULL OR "properties" <> '{}'::jsonb`,
 		},
@@ -201,13 +201,13 @@ func Test_renderExpr(t *testing.T) {
 // Test_renderExpr_errors ensures that invalid expressions trigger an error
 // during SQL rendering.
 func Test_renderExpr_errors(t *testing.T) {
-	invalidColumn := warehouses.NewBaseExpr(warehouses.Column{Name: "bad name", Type: types.String()}, warehouses.OpIs, "v")
+	invalidColumn := warehouses.NewConditionExpr(warehouses.Column{Name: "bad name", Type: types.String()}, warehouses.OpIs, "v")
 	var b strings.Builder
 	if err := renderExpr(&b, invalidColumn); err == nil {
 		t.Fatal("expected error for invalid column name")
 	}
 
-	badOp := warehouses.NewMultiExpr(warehouses.LogicalOperator(99), []warehouses.Expr{invalidColumn})
+	badOp := warehouses.NewLogicalExpr(warehouses.LogicalOperator(99), []warehouses.Expr{invalidColumn})
 	b.Reset()
 	if err := renderExpr(&b, badOp); err == nil {
 		t.Fatal("expected error for invalid operator")

--- a/warehouses/snowflake/renderexpr.go
+++ b/warehouses/snowflake/renderexpr.go
@@ -20,39 +20,39 @@ import (
 // representing a boolean expression.
 func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 
-	// Handle MultiExpr expression.
-	if multiExpr, ok := exp.(*warehouses.MultiExpr); ok {
+	// Handle logical expressions.
+	if logicalExpr, ok := exp.(*warehouses.LogicalExpr); ok {
 		var op string
-		switch multiExpr.Operator {
+		switch logicalExpr.Operator {
 		case warehouses.OpAnd:
 			op = " AND "
 		case warehouses.OpOr:
 			op = " OR "
 		default:
-			return fmt.Errorf("invalid operator %d", multiExpr.Operator)
+			return fmt.Errorf("invalid operator %d", logicalExpr.Operator)
 		}
-		for i, operand := range multiExpr.Operands {
+		for i, operand := range logicalExpr.Operands {
 			if i > 0 {
 				b.WriteString(op)
 			}
-			_, isMultiExpr := operand.(*warehouses.MultiExpr)
-			if isMultiExpr {
+			_, isLogicalExpr := operand.(*warehouses.LogicalExpr)
+			if isLogicalExpr {
 				b.WriteByte('(')
 			}
 			err := renderExpr(b, operand)
 			if err != nil {
 				return err
 			}
-			if isMultiExpr {
+			if isLogicalExpr {
 				b.WriteByte(')')
 			}
 		}
 		return nil
 	}
 
-	// Handle BaseExpr expressions.
-	baseExpr := exp.(*warehouses.BaseExpr)
-	c := baseExpr.Column
+	// Handle condition expressions.
+	conditionExpr := exp.(*warehouses.ConditionExpr)
+	c := conditionExpr.Column
 
 	// Validate the column name.
 	if !warehouses.IsValidIdentifier(c.Name) {
@@ -62,7 +62,7 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 	qname := quoteIdent(c.Name)
 
 	// Render the column identifier, the operator, and, if necessary, the values.
-	switch op := baseExpr.Operator; op {
+	switch op := conditionExpr.Operator; op {
 	case
 		warehouses.OpIs,
 		warehouses.OpIsNot,
@@ -91,7 +91,7 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 		case warehouses.OpIsGreaterThanOrEqualTo, warehouses.OpIsOnOrAfter:
 			b.WriteString(" >= ")
 		}
-		serializeValue(b, baseExpr.Values[0], c.Type)
+		serializeValue(b, conditionExpr.Values[0], c.Type)
 
 	case warehouses.OpIsBetween, warehouses.OpIsNotBetween:
 		b.WriteString(qname)
@@ -99,9 +99,9 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 			b.WriteString(" NOT")
 		}
 		b.WriteString(" BETWEEN ")
-		serializeValue(b, baseExpr.Values[0], c.Type)
+		serializeValue(b, conditionExpr.Values[0], c.Type)
 		b.WriteString(" AND ")
-		serializeValue(b, baseExpr.Values[1], c.Type)
+		serializeValue(b, conditionExpr.Values[1], c.Type)
 
 	case warehouses.OpContains, warehouses.OpDoesNotContain:
 		if op == warehouses.OpDoesNotContain {
@@ -110,7 +110,7 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 		b.WriteString("CONTAINS(")
 		b.WriteString(qname)
 		b.WriteString(", ")
-		serializeValue(b, baseExpr.Values[0], c.Type)
+		serializeValue(b, conditionExpr.Values[0], c.Type)
 		b.WriteString(")")
 
 	case warehouses.OpIsOneOf, warehouses.OpIsNotOneOf:
@@ -120,7 +120,7 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 		} else {
 			b.WriteString(" NOT IN (")
 		}
-		for i, v := range baseExpr.Values {
+		for i, v := range conditionExpr.Values {
 			if i > 0 {
 				b.WriteByte(',')
 			}
@@ -136,7 +136,7 @@ func renderExpr(b *strings.Builder, exp warehouses.Expr) error {
 		}
 		b.WriteString(qname)
 		b.WriteString(", ")
-		serializeValue(b, baseExpr.Values[0], c.Type)
+		serializeValue(b, conditionExpr.Values[0], c.Type)
 		b.WriteString(")")
 
 	case warehouses.OpIsTrue:

--- a/warehouses/snowflake/renderexpr_test.go
+++ b/warehouses/snowflake/renderexpr_test.go
@@ -22,148 +22,148 @@ func Test_renderExpr(t *testing.T) {
 		invalid bool
 	}{
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "qwerty"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "qwerty"),
 			query: `"ID" = 'qwerty'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "age", Type: types.Float(32)}, warehouses.OpIsNot, 18.0),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "age", Type: types.Float(32)}, warehouses.OpIsNot, 18.0),
 			query: `"AGE" <> 18`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "a", Type: types.String()}, warehouses.OpIs, warehouses.Column{Name: "b", Type: types.String()}),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "a", Type: types.String()}, warehouses.OpIs, warehouses.Column{Name: "b", Type: types.String()}),
 			query: `"A" = "B"`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "values", Type: types.JSON()}, warehouses.OpIs, json.Value(`{"foo":2,"boo":true}`)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "values", Type: types.JSON()}, warehouses.OpIs, json.Value(`{"foo":2,"boo":true}`)),
 			query: `"VALUES" = PARSE_JSON('{"foo":2,"boo":true}')`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsLessThan, 6.5),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsLessThan, 6.5),
 			query: `"WEIGHT" < 6.5`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsLessThanOrEqualTo, 6.5),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsLessThanOrEqualTo, 6.5),
 			query: `"WEIGHT" <= 6.5`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsGreaterThan, 6.5),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "weight", Type: types.Float(32)}, warehouses.OpIsGreaterThan, 6.5),
 			query: `"WEIGHT" > 6.5`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIsGreaterThanOrEqualTo, decimal.MustInt(3289)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIsGreaterThanOrEqualTo, decimal.MustInt(3289)),
 			query: `"COUNT" >= 3289`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsBefore, time.Date(1900, 1, 2, 23, 32, 11, 940253621, time.UTC)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsBefore, time.Date(1900, 1, 2, 23, 32, 11, 940253621, time.UTC)),
 			query: `"TIMESTAMP" < '1900-01-02 23:32:11.940253621'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsOnOrBefore, time.Date(1900, 1, 2, 23, 32, 11, 940253621, time.UTC)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsOnOrBefore, time.Date(1900, 1, 2, 23, 32, 11, 940253621, time.UTC)),
 			query: `"TIMESTAMP" <= '1900-01-02 23:32:11.940253621'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.Date()}, warehouses.OpIsAfter, time.Date(1900, 1, 2, 0, 0, 0, 0, time.UTC)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.Date()}, warehouses.OpIsAfter, time.Date(1900, 1, 2, 0, 0, 0, 0, time.UTC)),
 			query: `"TIMESTAMP" > '1900-01-02'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.Date()}, warehouses.OpIsOnOrAfter, time.Date(1900, 1, 2, 0, 0, 0, 0, time.UTC)),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.Date()}, warehouses.OpIsOnOrAfter, time.Date(1900, 1, 2, 0, 0, 0, 0, time.UTC)),
 			query: `"TIMESTAMP" >= '1900-01-02'`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.Float(64)}, warehouses.OpIsBetween, 5.0, 10.0),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.Float(64)}, warehouses.OpIsBetween, 5.0, 10.0),
 			query: `"ID" BETWEEN 5 AND 10`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpContains, "foo"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpContains, "foo"),
 			query: `CONTAINS("NAME", 'foo')`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpDoesNotContain, "boo"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpDoesNotContain, "boo"),
 			query: `NOT CONTAINS("NAME", 'boo')`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.Float(32)}, warehouses.OpIsOneOf, 3.5, 9.2, 5.0),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.Float(32)}, warehouses.OpIsOneOf, 3.5, 9.2, 5.0),
 			query: `"ID" IN (3.5,9.2,5)`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "a", Type: types.Float(64)}, warehouses.OpIsOneOf, 5.3, 12.6, 9.0),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "a", Type: types.Float(64)}, warehouses.OpIsOneOf, 5.3, 12.6, 9.0),
 			query: `"A" IN (5.3,12.6,9)`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpStartsWith, "foo"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpStartsWith, "foo"),
 			query: `STARTSWITH("NAME", 'foo')`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpEndsWith, "foo"),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "name", Type: types.String()}, warehouses.OpEndsWith, "foo"),
 			query: `ENDSWITH("NAME", 'foo')`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "active", Type: types.Boolean()}, warehouses.OpIsTrue),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "active", Type: types.Boolean()}, warehouses.OpIsTrue),
 			query: `"ACTIVE"`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "active", Type: types.Boolean()}, warehouses.OpIsFalse),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "active", Type: types.Boolean()}, warehouses.OpIsFalse),
 			query: `NOT "ACTIVE"`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIsNull),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIsNull),
 			query: `"ID" IS NULL`,
 		},
 		{
-			expr:  warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIsNotNull),
+			expr:  warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIsNotNull),
 			query: `"ID" IS NOT NULL`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpAnd,
 				[]warehouses.Expr{
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 870000000, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 870000000, time.UTC)),
 				}),
 			query: `"TIMESTAMP" < '1900-01-02 23:32:11.87'`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpAnd,
 				[]warehouses.Expr{
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsGreaterThan, time.Date(1700, 1, 2, 23, 32, 11, 0, time.UTC)),
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 0, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsGreaterThan, time.Date(1700, 1, 2, 23, 32, 11, 0, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 0, time.UTC)),
 				}),
 			query: `"TIMESTAMP" > '1700-01-02 23:32:11' AND "TIMESTAMP" < '1900-01-02 23:32:11'`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpOr,
 				[]warehouses.Expr{
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsGreaterThan, time.Date(1700, 1, 2, 23, 32, 11, 0, time.UTC)),
-					warehouses.NewBaseExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 0, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsGreaterThan, time.Date(1700, 1, 2, 23, 32, 11, 0, time.UTC)),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "timestamp", Type: types.DateTime()}, warehouses.OpIsLessThan, time.Date(1900, 1, 2, 23, 32, 11, 0, time.UTC)),
 				}),
 			query: `"TIMESTAMP" > '1700-01-02 23:32:11' OR "TIMESTAMP" < '1900-01-02 23:32:11'`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpAnd,
 				[]warehouses.Expr{
-					warehouses.NewMultiExpr(warehouses.OpOr, []warehouses.Expr{
-						warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_42"),
-						warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_50"),
-						warehouses.NewBaseExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_60"),
+					warehouses.NewLogicalExpr(warehouses.OpOr, []warehouses.Expr{
+						warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_42"),
+						warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_50"),
+						warehouses.NewConditionExpr(warehouses.Column{Name: "id", Type: types.String()}, warehouses.OpIs, "abc_60"),
 					}),
-					warehouses.NewMultiExpr(warehouses.OpOr, []warehouses.Expr{
-						warehouses.NewBaseExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIs, decimal.MustInt(100)),
-						warehouses.NewBaseExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIs, decimal.MustInt(200)),
-						warehouses.NewBaseExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIs, decimal.MustInt(300)),
+					warehouses.NewLogicalExpr(warehouses.OpOr, []warehouses.Expr{
+						warehouses.NewConditionExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIs, decimal.MustInt(100)),
+						warehouses.NewConditionExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIs, decimal.MustInt(200)),
+						warehouses.NewConditionExpr(warehouses.Column{Name: "count", Type: types.Decimal(5, 0)}, warehouses.OpIs, decimal.MustInt(300)),
 					}),
 				}),
 			query: `("ID" = 'abc_42' OR "ID" = 'abc_50' OR "ID" = 'abc_60') AND ("COUNT" = 100 OR "COUNT" = 200 OR "COUNT" = 300)`,
 		},
 		{
-			expr: warehouses.NewMultiExpr(
+			expr: warehouses.NewLogicalExpr(
 				warehouses.OpOr,
 				[]warehouses.Expr{
-					warehouses.NewBaseExpr(warehouses.Column{Name: "type", Type: types.String(), Nullable: true}, warehouses.OpIsNotEmpty),
-					// warehouses.NewBaseExpr(warehouses.Column{Name: "properties", Type: types.JSON()}, warehouses.OpIsEmpty), // See issue https://github.com/krenalis/krenalis/issues/1804.
-					warehouses.NewBaseExpr(warehouses.Column{Name: "scores", Type: types.Array(types.Int(32)), Nullable: true}, warehouses.OpIsEmpty),
-					warehouses.NewBaseExpr(warehouses.Column{Name: "properties", Type: types.Map(types.String())}, warehouses.OpIsNotEmpty),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "type", Type: types.String(), Nullable: true}, warehouses.OpIsNotEmpty),
+					// warehouses.NewConditionExpr(warehouses.Column{Name: "properties", Type: types.JSON()}, warehouses.OpIsEmpty), // See issue https://github.com/krenalis/krenalis/issues/1804.
+					warehouses.NewConditionExpr(warehouses.Column{Name: "scores", Type: types.Array(types.Int(32)), Nullable: true}, warehouses.OpIsEmpty),
+					warehouses.NewConditionExpr(warehouses.Column{Name: "properties", Type: types.Map(types.String())}, warehouses.OpIsNotEmpty),
 				}),
 			query: `("TYPE" IS NOT NULL AND "TYPE" <> '') OR ("SCORES" IS NULL OR "SCORES" = ARRAY_CONSTRUCT()) OR "PROPERTIES" <> OBJECT_CONSTRUCT()`,
 		},

--- a/warehouses/warehouses.go
+++ b/warehouses/warehouses.go
@@ -635,23 +635,22 @@ type Expr interface {
 	expr()
 }
 
-// MultiExpr represents an SQL expression with a logical operator, which can be
-// both And or Or, and a list of SQL expressions on which the operator is
-// applied.
-type MultiExpr struct {
+// LogicalExpr combines SQL expressions using a logical operator.
+type LogicalExpr struct {
 	Operator LogicalOperator
 	Operands []Expr
 }
 
-func (*MultiExpr) expr() {}
-
-// NewMultiExpr returns a new MultiExpr expression with the given operator and
+// NewLogicalExpr returns a logical expression with the given operator and
 // operands.
-func NewMultiExpr(operator LogicalOperator, operands []Expr) *MultiExpr {
-	return &MultiExpr{Operator: operator, Operands: operands}
+func NewLogicalExpr(operator LogicalOperator, operands []Expr) *LogicalExpr {
+	return &LogicalExpr{Operator: operator, Operands: operands}
 }
 
-// LogicalOperator represents the logical operator of a MultiExpr.
+// expr marks LogicalExpr as an expression.
+func (*LogicalExpr) expr() {}
+
+// LogicalOperator identifies the logical operator used by a LogicalExpr.
 type LogicalOperator int
 
 const (
@@ -659,49 +658,48 @@ const (
 	OpOr
 )
 
-// BaseExpr represents an SQL expression that refers to a property, on which an
-// operator is applied, an eventually an operand, if the operator is binary.
-type BaseExpr struct {
+// ConditionExpr applies an operator to a column and zero or more values.
+type ConditionExpr struct {
 	Column   Column
-	Operator Operator
+	Operator ConditionOperator
 	Values   []any // may be nil for unary expressions.
 }
 
-func (*BaseExpr) expr() {}
-
-// NewBaseExpr returns a new BaseExpr expression that applies to the given
-// column with the given operator and values.
-// If the operator is unary, value should be nil.
-func NewBaseExpr(column Column, operator Operator, values ...any) *BaseExpr {
-	return &BaseExpr{Column: column, Operator: operator, Values: values}
+// NewConditionExpr returns a condition expression for the given column,
+// operator, and values. If the operator is unary, values should be empty.
+func NewConditionExpr(column Column, operator ConditionOperator, values ...any) *ConditionExpr {
+	return &ConditionExpr{Column: column, Operator: operator, Values: values}
 }
 
-// Operator presents a unary or binary operator of a BaseExpr.
-type Operator int
+// expr marks ConditionExpr as an expression.
+func (*ConditionExpr) expr() {}
+
+// ConditionOperator represents the operator used by a ConditionExpr.
+type ConditionOperator int
 
 const (
-	OpIs                     Operator = iota // is
-	OpIsNot                                  // is not
-	OpIsLessThan                             // is less than
-	OpIsLessThanOrEqualTo                    // is less than or equal to
-	OpIsGreaterThan                          // is greater than
-	OpIsGreaterThanOrEqualTo                 // is greater than or equal to
-	OpIsBetween                              // is between
-	OpIsNotBetween                           // is not between
-	OpContains                               // contains
-	OpDoesNotContain                         // does not contain
-	OpIsOneOf                                // is one of
-	OpIsNotOneOf                             // is not one of
-	OpStartsWith                             // starts with
-	OpEndsWith                               // ends with
-	OpIsBefore                               // is before
-	OpIsOnOrBefore                           // is on or before
-	OpIsAfter                                // is after
-	OpIsOnOrAfter                            // is on or after
-	OpIsTrue                                 // is true
-	OpIsFalse                                // is false
-	OpIsEmpty                                // is empty
-	OpIsNotEmpty                             // is not empty
-	OpIsNull                                 // is null
-	OpIsNotNull                              // is not null
+	OpIs                     ConditionOperator = iota // is
+	OpIsNot                                           // is not
+	OpIsLessThan                                      // is less than
+	OpIsLessThanOrEqualTo                             // is less than or equal to
+	OpIsGreaterThan                                   // is greater than
+	OpIsGreaterThanOrEqualTo                          // is greater than or equal to
+	OpIsBetween                                       // is between
+	OpIsNotBetween                                    // is not between
+	OpContains                                        // contains
+	OpDoesNotContain                                  // does not contain
+	OpIsOneOf                                         // is one of
+	OpIsNotOneOf                                      // is not one of
+	OpStartsWith                                      // starts with
+	OpEndsWith                                        // ends with
+	OpIsBefore                                        // is before
+	OpIsOnOrBefore                                    // is on or before
+	OpIsAfter                                         // is after
+	OpIsOnOrAfter                                     // is on or after
+	OpIsTrue                                          // is true
+	OpIsFalse                                         // is false
+	OpIsEmpty                                         // is empty
+	OpIsNotEmpty                                      // is not empty
+	OpIsNull                                          // is null
+	OpIsNotNull                                       // is not null
 )


### PR DESCRIPTION
```
warehouses: rename `Expr`-related types (#2423)

Rename some Expr-related types in preparation for the filter refactor.
```