### PR TITLE
test/krenalistester: fix in-process event dispatch

### DIFF
--- a/test/krenalistester/krenalistester.go
+++ b/test/krenalistester/krenalistester.go
@@ -396,6 +396,7 @@ func (k *Krenalis) Start() {
 		setts.NATS.Password = testsSettings.NATS.Password
 		setts.Transformers.Local.PythonExecutable = testsSettings.PythonExecutable
 		setts.Transformers.Local.FunctionsDir = k.transformationsTempDir
+		setts.MaxQueuedEventsPerDestination = 50_000
 		err := os.Setenv("KRENALIS_CONNECTOR_FILESYSTEM_ROOT", k.fileSystemRoot)
 		if err != nil {
 			k.t.Fatal(err)


### PR DESCRIPTION
```
test/krenalistester: fix in-process event dispatch (#2425)

The in-process test launcher builds cmd.Config directly, bypassing the
defaults applied by the standard configuration loader. As a result, the
destination queue limit is left at 0 instead of using the default of
50,000.

This prevents events from being dispatched in in-process tests,
including TestDispatchEventsToDummy.

Set the destination queue limit to 50,000 so events are not blocked
before dispatch.
```