### PR TITLE
all: replace flat filters with compound filter groups

### DIFF
--- a/admin/src/components/routes/PipelineWrapper/Pipeline.css
+++ b/admin/src/components/routes/PipelineWrapper/Pipeline.css
@@ -207,35 +207,195 @@
 	display: flex;
 }
 
-.pipeline__filters-logical {
-	min-width: 100px;
-	margin-right: 9px;
+.pipeline__filters-group {
+	--pipeline-filters-action-color: var(--sl-color-primary-600);
+	--pipeline-filters-connector-width: 54px;
+	--sl-input-font-family: var(--system-fonts);
+
+	border: 1px solid var(--sl-color-neutral-200);
+	border-radius: 6px;
+	margin-bottom: 14px;
+	padding: 12px;
 }
 
-.pipeline__filters-logical sl-button {
-	width: 50px;
+.pipeline__filters-group--root {
+	border: 0;
+	margin-bottom: 0;
+	padding: 0;
 }
 
-.pipeline__filters-logical--text {
-	color: var(--text-light);
-	font-size: 14px;
-	position: relative;
-	top: 4px;
-	text-align: center;
-}
-
-.pipeline__filters-logical sl-button[variant='default']::part(base) {
-	color: var(--sl-color-neutral-400);
+.pipeline__filters-group:not(.pipeline__filters-group--root) {
 	background-color: var(--bg-primary);
+	transition: background-color 150ms ease;
+}
+
+.pipeline__filters-group-header,
+.pipeline__filters-group-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.pipeline__filters-group-header {
+	font-size: 14px;
+	margin-bottom: 14px;
+	min-height: var(--sl-input-height-small);
+}
+
+.pipeline__filters-group-actions {
+	margin-top: -6px;
+}
+
+.pipeline__filters-group-actions sl-button::part(base),
+.pipeline__filters-group-actions .pipeline__filters-add-condition sl-icon,
+.pipeline__filters-group-actions .pipeline__filters-add-group sl-icon {
+	color: var(--pipeline-filters-action-color);
+	transition: color 150ms ease;
+}
+
+.pipeline__filters-group-actions sl-button::part(base) {
+	font-weight: 400;
+}
+
+.pipeline__filters-remove-group-wrapper {
+	margin-left: auto;
+}
+
+sl-button.pipeline__filters-remove-rule[variant='text']::part(base) {
+	align-items: center;
+	background-color: transparent;
+	border: 0;
+	justify-content: center;
+	min-height: var(--sl-input-height-small);
+	padding: 0;
+	width: var(--sl-input-height-small);
+}
+
+sl-button.pipeline__filters-remove-rule[variant='text']::part(label) {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	line-height: 1;
+	padding: 0;
+}
+
+.pipeline__filters-remove-rule[variant='text'] sl-icon {
+	color: var(--pipeline-filters-action-color);
+	pointer-events: none;
+	transition: color 0.3s;
+}
+
+.pipeline__filters-remove-rule.pipeline__filters-remove-group sl-icon {
+	color: var(--pipeline-filters-remove-group-color, var(--pipeline-filters-action-color));
+}
+
+.pipeline__filters-remove-rule:hover sl-icon {
+	color: var(--sl-color-danger-600);
+}
+
+.pipeline__filters-remove-rule[disabled] sl-icon {
+	color: var(--sl-color-neutral-300);
+}
+
+.pipeline__filters-remove-rule-label {
+	border: 0;
+	clip: rect(0, 0, 0, 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}
+
+.pipeline__filters-logical {
+	width: 88px;
+}
+
+.pipeline__filters-rule {
+	display: grid;
+	grid-template-columns: var(--pipeline-filters-connector-width) minmax(0, 1fr);
+}
+
+.pipeline__filters-rule:first-child > .pipeline__filters-rule-content {
+	grid-column: 1 / -1;
+}
+
+.pipeline__filters-rule-content {
+	grid-column: 2;
+	min-width: 0;
+}
+
+.pipeline__filters-connector {
+	align-items: center;
+	align-self: start;
+	color: var(--sl-color-neutral-950);
+	display: flex;
+	font-size: 14px;
+	grid-column: 1;
+	grid-row: 1;
+	height: var(--sl-input-height-small);
+	justify-content: center;
+}
+
+.pipeline__filters-rule--group > .pipeline__filters-connector {
+	margin-top: 12px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+	.pipeline__filters-group {
+		--pipeline-filters-action-color: var(--sl-color-neutral-500);
+	}
+
+	.pipeline__filters:not(:has(> .section__content:hover))
+		.pipeline__filters-group:focus-within:not(:has(.pipeline__filters-group:focus-within)) {
+		--pipeline-filters-action-color: var(--sl-color-primary-600);
+	}
+
+	.pipeline__filters:hover
+		.pipeline__filters-group:not(.pipeline__filters-group--root):hover:not(:has(.pipeline__filters-group:hover)) {
+		background-color: var(--bg-gray);
+	}
+
+	.pipeline__filters-group:not(.pipeline__filters-group--root):has(
+			> .pipeline__filters-group-header .pipeline__filters-remove-group:not([disabled]):hover
+		),
+	.pipeline__filters-group:not(.pipeline__filters-group--root):has(
+			> .pipeline__filters-group-header .pipeline__filters-remove-group:not([disabled]):hover
+		)
+		.pipeline__filters-group:not(.pipeline__filters-group--root) {
+		--pipeline-filters-remove-group-color: var(--sl-color-danger-600);
+
+		background-color: var(--bg-gray);
+	}
+
+	.pipeline__filters
+		> .section__content:hover
+		> .pipeline__filters-group--root:not(:has(.pipeline__filters-group:hover)),
+	.pipeline__filters:hover .pipeline__filters-group:hover:not(:has(.pipeline__filters-group:hover)) {
+		--pipeline-filters-action-color: var(--sl-color-primary-600);
+	}
+}
+
+.pipeline__filters-group:not(.pipeline__filters-group--root):has(
+		> .pipeline__filters-group-header .pipeline__filters-remove-group:not([disabled]):focus-within
+	),
+.pipeline__filters-group:not(.pipeline__filters-group--root):has(
+		> .pipeline__filters-group-header .pipeline__filters-remove-group:not([disabled]):focus-within
+	)
+	.pipeline__filters-group:not(.pipeline__filters-group--root) {
+	--pipeline-filters-remove-group-color: var(--sl-color-danger-600);
+
+	background-color: var(--bg-gray);
 }
 
 .pipeline__filters-condition {
+	align-items: stretch;
 	display: flex;
 	flex-flow: row wrap;
 	gap: 10px;
 	margin-bottom: 20px;
-	align-items: baseline;
-	align-items: stretch;
 }
 
 .pipeline__filters-condition .combobox-input__error {
@@ -245,7 +405,14 @@
 
 .pipeline__filters-condition--is-one-of {
 	flex-flow: row nowrap;
-	gap: 10px;
+}
+
+.pipeline__filters-remove-condition-wrapper {
+	align-items: center;
+	align-self: flex-start;
+	display: flex;
+	height: var(--sl-input-height-small);
+	transform: translateX(-6px);
 }
 
 .pipeline__filters-value-input {
@@ -301,41 +468,16 @@
 	left: -25px;
 }
 
-.pipeline__filters-condition + .pipeline__filters-add-condition {
-	margin-bottom: -12px;
-}
-
 .pipeline__filters-add-condition::part(base) {
 	padding-left: 0;
 }
 
-.pipeline__filters-add-condition::part(label) {
-	padding-left: 8px;
-}
-
-.pipeline__filters-add-condition sl-icon {
+.pipeline__filters-add-condition sl-icon,
+.pipeline__filters-add-group sl-icon,
+.pipeline__filters-remove-rule sl-icon {
 	font-size: 15px;
 	height: 18px;
-}
-
-.pipeline__filters-remove-condition::part(base) {
-	border: 0 !important;
-	padding: 0 !important;
-	background-color: transparent !important;
-}
-
-.pipeline__filters-remove-condition::part(label) {
-	display: none;
-}
-
-.pipeline__filters-remove-condition sl-icon {
-	font-size: 20px;
-	width: 25px;
-	transition: color 0.3s;
-}
-
-.pipeline__filters-remove-condition:hover sl-icon {
-	color: var(--sl-color-danger-600);
+	width: 18px;
 }
 
 .pipeline__filters-property-and-operator {

--- a/admin/src/components/routes/PipelineWrapper/Pipeline.css
+++ b/admin/src/components/routes/PipelineWrapper/Pipeline.css
@@ -210,7 +210,6 @@
 .pipeline__filters-group {
 	--pipeline-filters-action-color: var(--sl-color-primary-600);
 	--pipeline-filters-connector-width: 54px;
-	--sl-input-font-family: var(--system-fonts);
 
 	border: 1px solid var(--sl-color-neutral-200);
 	border-radius: 6px;
@@ -310,6 +309,8 @@ sl-button.pipeline__filters-remove-rule[variant='text']::part(label) {
 }
 
 .pipeline__filters-logical {
+	--sl-input-font-family: var(--system-fonts);
+
 	width: 88px;
 }
 
@@ -417,6 +418,16 @@ sl-button.pipeline__filters-remove-rule[variant='text']::part(label) {
 
 .pipeline__filters-value-input {
 	width: 150px;
+}
+
+.pipeline__filters-operator,
+.pipeline__filters-path,
+.pipeline__filters-value-input {
+	--sl-input-font-family: var(--monospace-fonts);
+}
+
+.pipeline__filters-value-input sl-option::part(base) {
+	font-family: var(--monospace-fonts);
 }
 
 .pipeline__filters-operator sl-option::part(base),

--- a/admin/src/components/routes/PipelineWrapper/Pipeline.helpers.ts
+++ b/admin/src/components/routes/PipelineWrapper/Pipeline.helpers.ts
@@ -1,5 +1,72 @@
 import { getHierarchicalPaths, TransformedPipeline, FlatSchema } from '../../../lib/core/pipeline';
+import TransformedConnection from '../../../lib/core/connection';
 import { SampleIdentifiers } from './Pipeline.types';
+
+type PipelineObjectLabelMode = 'compact' | 'full' | 'plural';
+
+const PIPELINE_OBJECT_LABELS: Record<PipelineObjectLabelMode, Record<string, [string, string]>> = {
+	compact: {
+		'source:sdk': ['Event schema', 'Profile schema'],
+		'source:webhook': ['Event schema', 'Profile schema'],
+		'source:database': ['Database user schema', 'Profile schema'],
+		'source:file': ['File user schema', 'Profile schema'],
+		'source:application': ['Application user schema', 'Profile schema'],
+		'destination:event': ['Event schema', 'Sending event parameters'],
+		'destination:database': ['Profile schema', 'Database table schema'],
+		'destination:application': ['Profile schema', 'Application user schema'],
+	},
+	full: {
+		'source:sdk': ['Event', 'Profile'],
+		'source:webhook': ['Event', 'Profile'],
+		'source:database': ['Database user', 'Profile'],
+		'source:file': ['File user', 'Profile'],
+		'source:application': ['Application user', 'Profile'],
+		'destination:event': ['Event', 'Sending event'],
+		'destination:database': ['Profile', 'Database table'],
+		'destination:application': ['Profile', 'Application user'],
+	},
+	plural: {
+		'source:sdk': ['Events', 'Profiles'],
+		'source:webhook': ['Events', 'Profiles'],
+		'source:database': ['Database users', 'Profiles'],
+		'source:file': ['File users', 'Profiles'],
+		'source:application': ['Application users', 'Profiles'],
+		'destination:event': ['Events', 'Sending events'],
+		'destination:database': ['Profiles', 'Database tables'],
+		'destination:application': ['Profiles', 'Application users'],
+	},
+};
+
+// pipelineObjectLabels reports the input and output labels for a pipeline.
+const pipelineObjectLabels = (
+	connection: TransformedConnection,
+	pipeline: TransformedPipeline,
+	mode: PipelineObjectLabelMode = 'compact',
+): [string, string] => {
+	let scenario: string;
+
+	if (connection.isSource) {
+		if (connection.isSDK) {
+			scenario = 'source:sdk';
+		} else if (connection.isWebhook) {
+			scenario = 'source:webhook';
+		} else if (connection.isDatabase) {
+			scenario = 'source:database';
+		} else if (connection.isFileStorage || connection.isFile) {
+			scenario = 'source:file';
+		} else {
+			scenario = 'source:application';
+		}
+	} else if (pipeline.target === 'Event') {
+		scenario = 'destination:event';
+	} else if (connection.isDatabase) {
+		scenario = 'destination:database';
+	} else {
+		scenario = 'destination:application';
+	}
+
+	return PIPELINE_OBJECT_LABELS[mode][scenario];
+};
 
 const updateMappingProperty = (
 	pipeline: TransformedPipeline,
@@ -137,4 +204,10 @@ const getSampleIdentifiers = (sample: Record<string, any>): SampleIdentifiers | 
 	};
 };
 
-export { updateMappingProperty, updateMappingPropertyError, checkIfPropertyExists, getSampleIdentifiers };
+export {
+	updateMappingProperty,
+	updateMappingPropertyError,
+	checkIfPropertyExists,
+	getSampleIdentifiers,
+	pipelineObjectLabels,
+};

--- a/admin/src/components/routes/PipelineWrapper/PipelineFilters.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFilters.tsx
@@ -54,6 +54,10 @@ const filterConditionAt = (filter: Filter, path: number[]): FilterCondition => {
 	return rule;
 };
 
+// filterConditionValues returns the values of condition, initializing them
+// when they are absent from the API representation.
+const filterConditionValues = (condition: FilterCondition): string[] => (condition.values ??= []);
+
 // newFilterCondition returns an empty condition for the visual editor.
 const newFilterCondition = (): FilterCondition => ({ property: '', operator: '', values: [''] });
 
@@ -220,20 +224,21 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 	const changeOperator = (path: number[], operator: FilterOperator, updatedPipeline?: TransformedPipeline) => {
 		const p = updatedPipeline ?? structuredClone(pipeline);
 		const condition = filterConditionAt(p.filter!, path);
+		const values = filterConditionValues(condition);
 		condition.operator = operator;
 		if (isUnaryOperator(operator)) {
 			condition.values = [];
 		} else if (isBetweenOperator(operator)) {
-			condition.values = condition.values.slice(0, 2);
+			condition.values = values.slice(0, 2);
 			while (condition.values.length < 2) {
 				condition.values.push('');
 			}
 		} else if (isOneOfOperator(operator)) {
-			if (condition.values.length === 0) {
+			if (values.length === 0) {
 				condition.values = [''];
 			}
 		} else {
-			condition.values = [condition.values[0] ?? ''];
+			condition.values = [values[0] ?? ''];
 		}
 		setPipeline(p);
 	};
@@ -260,15 +265,16 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 
 	const onChangeValue = (path: number[], position: number, value: string) => {
 		const p = structuredClone(pipeline);
-		filterConditionAt(p.filter!, path).values[position] = value;
+		filterConditionValues(filterConditionAt(p.filter!, path))[position] = value;
 		setPipeline(p);
 	};
 
 	const onAddValue = (path: number[]) => {
 		const p = structuredClone(pipeline);
 		const condition = filterConditionAt(p.filter!, path);
-		const position = condition.values.length;
-		condition.values.push('');
+		const values = filterConditionValues(condition);
+		const position = values.length;
+		values.push('');
 		setPipeline(p);
 		setTimeout(() => {
 			const property: any = document.querySelector(`[data-id="property-${pathID(path)}"]`);
@@ -290,7 +296,7 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 	const onRemoveValue = (path: number[], position: number) => {
 		const p = structuredClone(pipeline);
 		const condition = filterConditionAt(p.filter!, path);
-		condition.values.splice(position, 1);
+		filterConditionValues(condition).splice(position, 1);
 		setPipeline(p);
 	};
 
@@ -308,6 +314,7 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 		const isOneOf = isOneOfOperator(condition.operator);
 		const isInvalidProperty = property == null;
 		const propertyValues = getPropertyValues(property) ?? [];
+		const values = condition.values ?? [];
 
 		const propertyInput = (
 			<Combobox
@@ -379,7 +386,7 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 				<PipelineFilterValueControl
 					key={`value-${id}-0`}
 					name={`value-${id}-0`}
-					value={condition.values[0] ?? ''}
+					value={values[0] ?? ''}
 					options={propertyValues}
 					disabled={isInvalidProperty || isDisabled}
 					onValueChange={(value) => onChangeValue(path, 0, value)}
@@ -393,14 +400,14 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 					<PipelineFilterValueControl
 						key={`value-${id}-1`}
 						name={`value-${id}-1`}
-						value={condition.values[1] ?? ''}
+						value={values[1] ?? ''}
 						options={propertyValues}
 						disabled={isInvalidProperty || isDisabled}
 						onValueChange={(value) => onChangeValue(path, 1, value)}
 					/>,
 				);
 			} else if (isOneOf) {
-				for (const [position, value] of condition.values.slice(1).entries()) {
+				for (const [position, value] of values.slice(1).entries()) {
 					const valuePosition = position + 1;
 					valueElements.push(
 						<div className='pipeline__filters-value' key={`value-${id}-${valuePosition}`}>

--- a/admin/src/components/routes/PipelineWrapper/PipelineFilters.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFilters.tsx
@@ -11,6 +11,8 @@ import SlTooltip from '@shoelace-style/shoelace/dist/react/tooltip/index.js';
 import { Combobox } from '../../base/Combobox/Combobox';
 import {
 	FILTER_OPERATORS,
+	MAX_FILTER_DEPTH,
+	MAX_FILTER_RULE_COUNT,
 	flattenSchema,
 	getCompatibleFilterOperators,
 	isBetweenOperator,
@@ -25,9 +27,6 @@ import { Filter, FilterCondition, FilterLogical, FilterOperator } from '../../..
 import { checkIfPropertyExists, pipelineObjectLabels } from './Pipeline.helpers';
 import { StringType } from '../../../lib/api/types/types';
 
-const MAX_FILTER_DEPTH = 4;
-const MAX_FILTER_RULE_COUNT = 100;
-
 // countFilterRules returns the number of groups and conditions below filter.
 const countFilterRules = (filter: Filter): number =>
 	filter.rules.reduce((count, rule) => count + 1 + (isFilterGroup(rule) ? countFilterRules(rule) : 0), 0);
@@ -37,7 +36,9 @@ const filterGroupAt = (filter: Filter, path: number[]): Filter => {
 	let group = filter;
 	for (const index of path) {
 		const rule = group.rules[index];
-		if (!isFilterGroup(rule)) throw new Error('Filter path does not identify a group');
+		if (!isFilterGroup(rule)) {
+			throw new Error('Filter path does not identify a group');
+		}
 		group = rule;
 	}
 	return group;
@@ -47,7 +48,9 @@ const filterGroupAt = (filter: Filter, path: number[]): Filter => {
 const filterConditionAt = (filter: Filter, path: number[]): FilterCondition => {
 	const group = filterGroupAt(filter, path.slice(0, -1));
 	const rule = group.rules[path[path.length - 1]];
-	if (isFilterGroup(rule)) throw new Error('Filter path does not identify a condition');
+	if (isFilterGroup(rule)) {
+		throw new Error('Filter path does not identify a condition');
+	}
 	return rule;
 };
 
@@ -76,67 +79,75 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 	const filterRuleCount = pipeline.filter == null ? 0 : countFilterRules(pipeline.filter);
 
 	const findPropertyInSchema = (propertyName: string): TransformedProperty | undefined => {
-		if (propertyName == null || propertyName === '') return undefined;
+		if (propertyName == null || propertyName === '') {
+			return undefined;
+		}
 		return flatInputSchema[propertyName] ?? flatInputSchema[splitPropertyAndPath(propertyName, flatInputSchema)[0]];
 	};
 
 	const getPropertyValues = (property: TransformedProperty | undefined): string[] | null => {
-		if (property == null || property.type !== 'string') return null;
+		if (property == null || property.type !== 'string') {
+			return null;
+		}
 		return (property.full.type as StringType).values ?? null;
 	};
 
 	const onAddCondition = (groupPath: number[]) => {
-		const updated = structuredClone(pipeline);
-		if (updated.filter == null) updated.filter = { operator: 'and', rules: [] };
-		filterGroupAt(updated.filter, groupPath).rules.push(newFilterCondition());
-		setPipeline(updated);
+		const p = structuredClone(pipeline);
+		if (p.filter == null) {
+			p.filter = { operator: 'and', rules: [] };
+		}
+		filterGroupAt(p.filter, groupPath).rules.push(newFilterCondition());
+		setPipeline(p);
 	};
 
 	const onAddGroup = (groupPath: number[]) => {
-		const updated = structuredClone(pipeline);
-		const parent = filterGroupAt(updated.filter!, groupPath);
+		const p = structuredClone(pipeline);
+		const parent = filterGroupAt(p.filter!, groupPath);
 		parent.rules.push({
 			operator: parent.operator === 'and' ? 'or' : 'and',
 			rules: [newFilterCondition()],
 		});
-		setPipeline(updated);
+		setPipeline(p);
 	};
 
 	const onRemoveRule = (path: number[]) => {
-		const updated = structuredClone(pipeline);
-		const filter = updated.filter!;
-		let groupPath = path.slice(0, -1);
-		filterGroupAt(filter, groupPath).rules.splice(path[path.length - 1], 1);
+		const p = structuredClone(pipeline);
+		const filter = p.filter!;
+		const groupPath = path.slice(0, -1);
+		const group = filterGroupAt(filter, groupPath);
+		group.rules.splice(path[path.length - 1], 1);
 
-		while (groupPath.length > 0) {
-			const group = filterGroupAt(filter, groupPath);
-			if (group.rules.length > 0) break;
-			const index = groupPath[groupPath.length - 1];
-			groupPath = groupPath.slice(0, -1);
-			filterGroupAt(filter, groupPath).rules.splice(index, 1);
+		if (group.rules.length === 0) {
+			if (groupPath.length === 0) {
+				p.filter = null;
+			} else {
+				group.rules.push(newFilterCondition());
+			}
 		}
-		if (filter.rules.length === 0) updated.filter = null;
-		setPipeline(updated);
+		setPipeline(p);
 	};
 
 	const onLogicalChange = (groupPath: number[], operator: FilterLogical) => {
-		const updated = structuredClone(pipeline);
-		filterGroupAt(updated.filter!, groupPath).operator = operator;
-		setPipeline(updated);
+		const p = structuredClone(pipeline);
+		filterGroupAt(p.filter!, groupPath).operator = operator;
+		setPipeline(p);
 	};
 
 	const updateProperty = (path: number[], value: string): TransformedPipeline => {
-		const updated = structuredClone(pipeline);
-		const condition = filterConditionAt(updated.filter!, path);
+		const p = structuredClone(pipeline);
+		const condition = filterConditionAt(p.filter!, path);
 		const previousPropertyName = condition.property;
 		const previousPropertyValues = getPropertyValues(findPropertyInSchema(previousPropertyName));
 		const [, previousPath] = splitPropertyAndPath(previousPropertyName, flatInputSchema);
-		const hasPath = previousPath !== '';
-		const newPropertyName = hasPath && flatInputSchema[value]?.type === 'json' ? `${value}.${previousPath}` : value;
+		const newPropertyName =
+			previousPath !== '' && flatInputSchema[value]?.type === 'json' ? `${value}.${previousPath}` : value;
+		const newProperty = findPropertyInSchema(newPropertyName);
+		const [, newPath] = splitPropertyAndPath(newPropertyName, flatInputSchema);
 
 		const compatibleOperators = getCompatibleFilterOperators(
-			flatInputSchema[newPropertyName],
-			hasPath,
+			newProperty,
+			newPath !== '',
 			connection.role,
 			pipeline.target,
 		);
@@ -146,17 +157,17 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 		}
 
 		condition.property = newPropertyName;
-		const newPropertyValues = getPropertyValues(findPropertyInSchema(newPropertyName));
+		const newPropertyValues = getPropertyValues(newProperty);
 		if (previousPropertyName !== newPropertyName && (previousPropertyValues != null || newPropertyValues != null)) {
 			condition.values = isBetweenOperator(condition.operator) ? ['', ''] : [''];
 		}
-		setPipeline(updated);
-		return updated;
+		setPipeline(p);
+		return p;
 	};
 
 	const onSelectProperty = (path: number[], value: string) => {
-		const updated = updateProperty(path, value);
-		const condition = filterConditionAt(updated.filter!, path);
+		const p = updateProperty(path, value);
+		const condition = filterConditionAt(p.filter!, path);
 		const [, propertyPath] = splitPropertyAndPath(condition.property, flatInputSchema);
 		const compatibleOperators = getCompatibleFilterOperators(
 			flatInputSchema[value],
@@ -168,7 +179,7 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 		const isJSON = flatInputSchema[value]?.type === 'json';
 
 		if (!compatibleOperators.includes(currentOperatorIndex) && compatibleOperators.length > 0) {
-			changeOperator(path, FILTER_OPERATORS[compatibleOperators[0]], updated);
+			changeOperator(path, FILTER_OPERATORS[compatibleOperators[0]], p);
 			if (!isJSON) {
 				setTimeout(() => {
 					const property: any = document.querySelector(`[data-id="property-${pathID(path)}"]`);
@@ -189,72 +200,98 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 	};
 
 	const onInputPath = (path: number[], value: string) => {
-		const updated = structuredClone(pipeline);
-		const condition = filterConditionAt(updated.filter!, path);
+		const p = structuredClone(pipeline);
+		const condition = filterConditionAt(p.filter!, path);
 		const [base] = splitPropertyAndPath(condition.property, flatInputSchema);
+		const compatibleOperators = getCompatibleFilterOperators(
+			flatInputSchema[base],
+			value !== '',
+			connection.role,
+			pipeline.target,
+		);
+		if (condition.operator !== '' && !compatibleOperators.includes(FILTER_OPERATORS.indexOf(condition.operator))) {
+			condition.operator = '';
+			condition.values = [''];
+		}
 		condition.property = value === '' ? base : `${base}.${value}`;
-		setPipeline(updated);
+		setPipeline(p);
 	};
 
-	const changeOperator = (path: number[], operator: FilterOperator, current?: TransformedPipeline) => {
-		const updated = current ?? structuredClone(pipeline);
-		const condition = filterConditionAt(updated.filter!, path);
+	const changeOperator = (path: number[], operator: FilterOperator, updatedPipeline?: TransformedPipeline) => {
+		const p = updatedPipeline ?? structuredClone(pipeline);
+		const condition = filterConditionAt(p.filter!, path);
 		condition.operator = operator;
 		if (isUnaryOperator(operator)) {
 			condition.values = [];
 		} else if (isBetweenOperator(operator)) {
 			condition.values = condition.values.slice(0, 2);
-			while (condition.values.length < 2) condition.values.push('');
+			while (condition.values.length < 2) {
+				condition.values.push('');
+			}
 		} else if (isOneOfOperator(operator)) {
-			if (condition.values.length === 0) condition.values = [''];
+			if (condition.values.length === 0) {
+				condition.values = [''];
+			}
 		} else {
 			condition.values = [condition.values[0] ?? ''];
 		}
-		setPipeline(updated);
+		setPipeline(p);
 	};
 
 	const onOperatorSelectClose = (event: any) => {
 		const operator = FILTER_OPERATORS[event.target.value];
-		if (operator == null || isUnaryOperator(operator)) return;
+		if (operator == null || isUnaryOperator(operator)) {
+			return;
+		}
 		setTimeout(() => {
 			const valueInput = event.target
 				.closest('.pipeline__filters-condition')
 				?.querySelector('.pipeline__filters-value-input');
-			if (valueInput == null) return;
-			if (valueInput.tagName === 'SL-SELECT') valueInput.show();
-			else valueInput.focus();
+			if (valueInput == null) {
+				return;
+			}
+			if (valueInput.tagName === 'SL-SELECT') {
+				valueInput.show();
+			} else {
+				valueInput.focus();
+			}
 		}, 50);
 	};
 
 	const onChangeValue = (path: number[], position: number, value: string) => {
-		const updated = structuredClone(pipeline);
-		filterConditionAt(updated.filter!, path).values[position] = value;
-		setPipeline(updated);
+		const p = structuredClone(pipeline);
+		filterConditionAt(p.filter!, path).values[position] = value;
+		setPipeline(p);
 	};
 
 	const onAddValue = (path: number[]) => {
-		const updated = structuredClone(pipeline);
-		const condition = filterConditionAt(updated.filter!, path);
+		const p = structuredClone(pipeline);
+		const condition = filterConditionAt(p.filter!, path);
 		const position = condition.values.length;
 		condition.values.push('');
-		setPipeline(updated);
+		setPipeline(p);
 		setTimeout(() => {
 			const property: any = document.querySelector(`[data-id="property-${pathID(path)}"]`);
 			const inputs = property
 				?.closest('.pipeline__filters-condition')
 				?.querySelectorAll('.pipeline__filters-value-input');
 			const input = inputs?.[position];
-			if (input == null) return;
-			if (input.tagName === 'SL-SELECT') input.show();
-			else input.focus();
+			if (input == null) {
+				return;
+			}
+			if (input.tagName === 'SL-SELECT') {
+				input.show();
+			} else {
+				input.focus();
+			}
 		}, 50);
 	};
 
 	const onRemoveValue = (path: number[], position: number) => {
-		const updated = structuredClone(pipeline);
-		const condition = filterConditionAt(updated.filter!, path);
+		const p = structuredClone(pipeline);
+		const condition = filterConditionAt(p.filter!, path);
 		condition.values.splice(position, 1);
-		setPipeline(updated);
+		setPipeline(p);
 	};
 
 	const renderCondition = (condition: FilterCondition, path: number[]): ReactNode => {

--- a/admin/src/components/routes/PipelineWrapper/PipelineFilters.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineFilters.tsx
@@ -4,138 +4,135 @@ import { getFilterPropertyComboboxItems } from '../../helpers/getSchemaComboboxI
 import PipelineContext from '../../../context/PipelineContext';
 import SlOption from '@shoelace-style/shoelace/dist/react/option/index.js';
 import SlSelect from '@shoelace-style/shoelace/dist/react/select/index.js';
-import SlButtonGroup from '@shoelace-style/shoelace/dist/react/button-group/index.js';
 import SlButton from '@shoelace-style/shoelace/dist/react/button/index.js';
 import SlInput from '@shoelace-style/shoelace/dist/react/input/index.js';
 import SlIcon from '@shoelace-style/shoelace/dist/react/icon/index.js';
+import SlTooltip from '@shoelace-style/shoelace/dist/react/tooltip/index.js';
 import { Combobox } from '../../base/Combobox/Combobox';
 import {
 	FILTER_OPERATORS,
 	flattenSchema,
 	getCompatibleFilterOperators,
 	isBetweenOperator,
+	isFilterGroup,
 	isOneOfOperator,
 	isUnaryOperator,
 	splitPropertyAndPath,
 	TransformedPipeline,
 	TransformedProperty,
 } from '../../../lib/core/pipeline';
-import { FilterLogical, FilterOperator } from '../../../lib/api/types/pipeline';
-import { checkIfPropertyExists } from './Pipeline.helpers';
+import { Filter, FilterCondition, FilterLogical, FilterOperator } from '../../../lib/api/types/pipeline';
+import { checkIfPropertyExists, pipelineObjectLabels } from './Pipeline.helpers';
 import { StringType } from '../../../lib/api/types/types';
+
+const MAX_FILTER_DEPTH = 4;
+const MAX_FILTER_RULE_COUNT = 100;
+
+// countFilterRules returns the number of groups and conditions below filter.
+const countFilterRules = (filter: Filter): number =>
+	filter.rules.reduce((count, rule) => count + 1 + (isFilterGroup(rule) ? countFilterRules(rule) : 0), 0);
+
+// filterGroupAt returns the group at path in filter.
+const filterGroupAt = (filter: Filter, path: number[]): Filter => {
+	let group = filter;
+	for (const index of path) {
+		const rule = group.rules[index];
+		if (!isFilterGroup(rule)) throw new Error('Filter path does not identify a group');
+		group = rule;
+	}
+	return group;
+};
+
+// filterConditionAt returns the condition at path in filter.
+const filterConditionAt = (filter: Filter, path: number[]): FilterCondition => {
+	const group = filterGroupAt(filter, path.slice(0, -1));
+	const rule = group.rules[path[path.length - 1]];
+	if (isFilterGroup(rule)) throw new Error('Filter path does not identify a condition');
+	return rule;
+};
+
+// newFilterCondition returns an empty condition for the visual editor.
+const newFilterCondition = (): FilterCondition => ({ property: '', operator: '', values: [''] });
+
+// pathID returns a stable identifier for a rule path.
+const pathID = (path: number[]): string => path.join('-');
 
 const PipelineFilters = forwardRef<any>((_, ref) => {
 	const { pipeline, setPipeline, pipelineType, connection, isTransformationDisabled, isImport } =
 		useContext(PipelineContext);
-	const targetTerm =
-		pipelineType.target === 'Event'
-			? 'events'
-			: connection.connector.terms.users?.trim()
-				? connection.connector.terms.users.toLowerCase()
-				: 'contacts';
+	const [filterSubject] = pipelineObjectLabels(connection, pipeline, 'plural');
+	const filterSubjectTerm = filterSubject.toLowerCase();
 	const actionVerb = isImport ? 'import' : pipelineType.target === 'Event' ? 'send' : 'export';
 
-	const flatInputSchema = useMemo(() => {
-		return flattenSchema(pipelineType.inputSchema);
-	}, [pipelineType.inputSchema]);
+	const flatInputSchema = useMemo(() => flattenSchema(pipelineType.inputSchema), [pipelineType.inputSchema]);
+
+	const isEventBasedUserImport = connection.isEventBased && connection.isSource && pipeline.target === 'User';
+	const isAppEventsExport = connection.isApplication && connection.isDestination && pipeline.target === 'Event';
+	const isEventImport = connection.isSource && pipeline.target === 'Event';
+	const propertiesToHide = isEventBasedUserImport || isAppEventsExport || isEventImport ? ['kpid'] : [];
+
+	const isFileStorageImport = connection.isFileStorage && connection.isSource;
+	const isDisabled = isFileStorageImport && isTransformationDisabled;
+	const filterRuleCount = pipeline.filter == null ? 0 : countFilterRules(pipeline.filter);
 
 	const findPropertyInSchema = (propertyName: string): TransformedProperty | undefined => {
-		if (propertyName == null || propertyName === '') {
-			return undefined;
-		}
+		if (propertyName == null || propertyName === '') return undefined;
 		return flatInputSchema[propertyName] ?? flatInputSchema[splitPropertyAndPath(propertyName, flatInputSchema)[0]];
 	};
 
 	const getPropertyValues = (property: TransformedProperty | undefined): string[] | null => {
-		if (property == null || property.type !== 'string') {
-			return null;
-		}
-		const stringType = property.full.type as StringType;
-		return stringType.values ?? null;
+		if (property == null || property.type !== 'string') return null;
+		return (property.full.type as StringType).values ?? null;
 	};
 
-	const onAddCondition = () => {
-		const p = structuredClone(pipeline);
-		if (p.filter == null) {
-			p.filter = { logical: 'and', conditions: [] };
-		}
-		p.filter.conditions = [...p.filter.conditions, { property: '', operator: '', values: [''] }];
-		setPipeline(p);
+	const onAddCondition = (groupPath: number[]) => {
+		const updated = structuredClone(pipeline);
+		if (updated.filter == null) updated.filter = { operator: 'and', rules: [] };
+		filterGroupAt(updated.filter, groupPath).rules.push(newFilterCondition());
+		setPipeline(updated);
 	};
 
-	const onRemoveCondition = (id: number) => {
-		const p = structuredClone(pipeline);
-		p.filter!.conditions.splice(id, 1);
-		if (p.filter!.conditions.length === 0) {
-			p.filter = null;
-		}
-		setPipeline(p);
+	const onAddGroup = (groupPath: number[]) => {
+		const updated = structuredClone(pipeline);
+		const parent = filterGroupAt(updated.filter!, groupPath);
+		parent.rules.push({
+			operator: parent.operator === 'and' ? 'or' : 'and',
+			rules: [newFilterCondition()],
+		});
+		setPipeline(updated);
 	};
 
-	const onInputPropertyFragment = (name: string, value: string) => {
-		updatePropertyFragment(name, value);
+	const onRemoveRule = (path: number[]) => {
+		const updated = structuredClone(pipeline);
+		const filter = updated.filter!;
+		let groupPath = path.slice(0, -1);
+		filterGroupAt(filter, groupPath).rules.splice(path[path.length - 1], 1);
+
+		while (groupPath.length > 0) {
+			const group = filterGroupAt(filter, groupPath);
+			if (group.rules.length > 0) break;
+			const index = groupPath[groupPath.length - 1];
+			groupPath = groupPath.slice(0, -1);
+			filterGroupAt(filter, groupPath).rules.splice(index, 1);
+		}
+		if (filter.rules.length === 0) updated.filter = null;
+		setPipeline(updated);
 	};
 
-	const onSelectPropertyFragment = (name: string, value: string) => {
-		const updated = updatePropertyFragment(name, value);
-
-		const id = Number(name.split('-')[1]);
-		const hasPath = 'path' in updated.filter!.conditions[id];
-		const currentOperator = updated.filter!.conditions[id]['operator'];
-		const currentOperatorIndex = FILTER_OPERATORS.findIndex((op) => op === currentOperator);
-		const compatibleOperators = getCompatibleFilterOperators(
-			flatInputSchema[value],
-			hasPath,
-			connection.role,
-			pipeline.target,
-		);
-		const isCompatible = compatibleOperators.includes(currentOperatorIndex);
-		const isJson = flatInputSchema[value]?.type === 'json';
-
-		if (!isCompatible) {
-			// Select the first compatible operator.
-			const operator = FILTER_OPERATORS[compatibleOperators[0]];
-			changeOperator(id, operator, updated);
-			if (!isJson) {
-				setTimeout(() => {
-					const operatorSelect: any = document
-						.querySelector(`[data-id=property-${id}]`)
-						.closest('.pipeline__filters-condition')
-						.querySelector('.pipeline__filters-operator');
-					operatorSelect.show();
-				}, 10);
-			}
-		}
-
-		if (isJson) {
-			setTimeout(() => {
-				const pathInput: any = document
-					.querySelector(`[data-id=property-${id}]`)
-					.closest('.pipeline__filters-condition')
-					.querySelector('.pipeline__filters-path');
-				pathInput.select();
-			}, 10);
-		}
+	const onLogicalChange = (groupPath: number[], operator: FilterLogical) => {
+		const updated = structuredClone(pipeline);
+		filterGroupAt(updated.filter!, groupPath).operator = operator;
+		setPipeline(updated);
 	};
 
-	const updatePropertyFragment = (name: string, value: string): TransformedPipeline => {
-		const p = structuredClone(pipeline);
-		const id = Number(name.split('-')[1]);
-
-		const condition = p.filter!.conditions[id];
-
-		const previousPropertyName = condition['property'];
-		const previousProperty = findPropertyInSchema(previousPropertyName);
-		const previousPropertyValues = getPropertyValues(previousProperty);
-
-		const [_, path] = splitPropertyAndPath(previousPropertyName, flatInputSchema);
-		let newPropertyName = '';
-		let hasPath = path !== '';
-		if (hasPath && flatInputSchema[value]?.type === 'json') {
-			newPropertyName = `${value}.${path}`;
-		} else {
-			newPropertyName = value;
-		}
+	const updateProperty = (path: number[], value: string): TransformedPipeline => {
+		const updated = structuredClone(pipeline);
+		const condition = filterConditionAt(updated.filter!, path);
+		const previousPropertyName = condition.property;
+		const previousPropertyValues = getPropertyValues(findPropertyInSchema(previousPropertyName));
+		const [, previousPath] = splitPropertyAndPath(previousPropertyName, flatInputSchema);
+		const hasPath = previousPath !== '';
+		const newPropertyName = hasPath && flatInputSchema[value]?.type === 'json' ? `${value}.${previousPath}` : value;
 
 		const compatibleOperators = getCompatibleFilterOperators(
 			flatInputSchema[newPropertyName],
@@ -143,426 +140,393 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 			connection.role,
 			pipeline.target,
 		);
-		const currentOperator = condition['operator'];
-		if (currentOperator != null && currentOperator !== '') {
-			const index = FILTER_OPERATORS.indexOf(currentOperator);
-			if (!compatibleOperators.includes(index)) {
-				// The current operator is not compatible with the new property.
-				// Reset the operator and the values.
-				condition['operator'] = '';
-				condition['values'] = [''];
+		if (condition.operator !== '' && !compatibleOperators.includes(FILTER_OPERATORS.indexOf(condition.operator))) {
+			condition.operator = '';
+			condition.values = [''];
+		}
+
+		condition.property = newPropertyName;
+		const newPropertyValues = getPropertyValues(findPropertyInSchema(newPropertyName));
+		if (previousPropertyName !== newPropertyName && (previousPropertyValues != null || newPropertyValues != null)) {
+			condition.values = isBetweenOperator(condition.operator) ? ['', ''] : [''];
+		}
+		setPipeline(updated);
+		return updated;
+	};
+
+	const onSelectProperty = (path: number[], value: string) => {
+		const updated = updateProperty(path, value);
+		const condition = filterConditionAt(updated.filter!, path);
+		const [, propertyPath] = splitPropertyAndPath(condition.property, flatInputSchema);
+		const compatibleOperators = getCompatibleFilterOperators(
+			flatInputSchema[value],
+			propertyPath !== '',
+			connection.role,
+			pipeline.target,
+		);
+		const currentOperatorIndex = FILTER_OPERATORS.findIndex((operator) => operator === condition.operator);
+		const isJSON = flatInputSchema[value]?.type === 'json';
+
+		if (!compatibleOperators.includes(currentOperatorIndex) && compatibleOperators.length > 0) {
+			changeOperator(path, FILTER_OPERATORS[compatibleOperators[0]], updated);
+			if (!isJSON) {
+				setTimeout(() => {
+					const property: any = document.querySelector(`[data-id="property-${pathID(path)}"]`);
+					property
+						?.closest('.pipeline__filters-condition')
+						?.querySelector('.pipeline__filters-operator')
+						?.show();
+				}, 10);
 			}
 		}
 
-		condition['property'] = newPropertyName;
-		const newProperty = findPropertyInSchema(newPropertyName);
-		const newPropertyValues = getPropertyValues(newProperty);
-		const hasDifferentValues =
-			previousPropertyName !== newPropertyName && (previousPropertyValues != null || newPropertyValues != null);
-		if (hasDifferentValues) {
-			// Reset the old values, because the new property has a different
-			// set of enumerated values.
-			const op = condition.operator;
-			if (isBetweenOperator(op)) {
-				condition.values = ['', ''];
-			} else {
-				condition.values = [''];
-			}
-		}
-
-		setPipeline(p);
-		return p;
-	};
-
-	const onInputPathFragment = (e) => {
-		const p = structuredClone(pipeline);
-		const id = Number(e.target.name.split('-')[1]);
-		const propertyName = p.filter!.conditions[id]['property'];
-		const [base, _] = splitPropertyAndPath(propertyName, flatInputSchema);
-		let newPropertyName = '';
-		const newPath = e.target.value;
-		if (newPath !== '') {
-			newPropertyName = `${base}.${newPath}`;
-		} else {
-			newPropertyName = base;
-		}
-		p.filter!.conditions[id]['property'] = newPropertyName;
-		setPipeline(p);
-	};
-
-	const onChangeOperatorFragment = (e: any) => {
-		const id = Number(e.target.name.split('-')[1]);
-		const operator = FILTER_OPERATORS[e.target.value];
-		changeOperator(id, operator);
-	};
-
-	const onOperatorSelectClose = (e: any) => {
-		const operator = FILTER_OPERATORS[e.target.value];
-		if (!isUnaryOperator(operator)) {
-			// Focus the first value input.
+		if (isJSON) {
 			setTimeout(() => {
-				const valueInput = e.target
-					.closest('.pipeline__filters-condition')
-					.querySelector('.pipeline__filters-value-input');
-				const isSelect = valueInput.tagName === 'SL-SELECT';
-				if (isSelect) {
-					valueInput.show();
-				} else {
-					valueInput.focus();
-				}
-			}, 50);
+				const property: any = document.querySelector(`[data-id="property-${pathID(path)}"]`);
+				property?.closest('.pipeline__filters-condition')?.querySelector('.pipeline__filters-path')?.select();
+			}, 10);
 		}
 	};
 
-	const changeOperator = (conditionID: number, operator: FilterOperator, updatedPipeline?: TransformedPipeline) => {
-		const id = conditionID;
-		let p: TransformedPipeline;
-		if (updatedPipeline != null) {
-			p = updatedPipeline;
-		} else {
-			p = structuredClone(pipeline);
-		}
-		p.filter!.conditions[id]['operator'] = operator;
+	const onInputPath = (path: number[], value: string) => {
+		const updated = structuredClone(pipeline);
+		const condition = filterConditionAt(updated.filter!, path);
+		const [base] = splitPropertyAndPath(condition.property, flatInputSchema);
+		condition.property = value === '' ? base : `${base}.${value}`;
+		setPipeline(updated);
+	};
+
+	const changeOperator = (path: number[], operator: FilterOperator, current?: TransformedPipeline) => {
+		const updated = current ?? structuredClone(pipeline);
+		const condition = filterConditionAt(updated.filter!, path);
+		condition.operator = operator;
 		if (isUnaryOperator(operator)) {
-			p.filter!.conditions[id]['values'] = null;
+			condition.values = [];
+		} else if (isBetweenOperator(operator)) {
+			condition.values = condition.values.slice(0, 2);
+			while (condition.values.length < 2) condition.values.push('');
+		} else if (isOneOfOperator(operator)) {
+			if (condition.values.length === 0) condition.values = [''];
 		} else {
-			const isBetween = isBetweenOperator(operator);
-			const isOneOf = isOneOfOperator(operator);
-
-			let values: string[] | null;
-			if (isBetween) {
-				let v = ['', ''];
-				if (p.filter!.conditions[id]['values'] != null) {
-					v = p.filter!.conditions[id]['values'].slice(0, 2);
-					if (v.length === 1) {
-						v.push('');
-					}
-				}
-				values = v;
-			} else if (isOneOf) {
-				let v = p.filter!.conditions[id]['values'];
-				if (v == null) {
-					v = [''];
-				}
-				values = v;
-			} else {
-				let v = '';
-				if (p.filter!.conditions[id]['values'] != null) {
-					v = p.filter!.conditions[id]['values'][0];
-				}
-				values = [v];
-			}
-
-			p.filter!.conditions[id]['values'] = values;
+			condition.values = [condition.values[0] ?? ''];
 		}
-		setPipeline(p);
+		setPipeline(updated);
 	};
 
-	const onChangeValueFragment = (name: string, value: string) => {
-		const p = structuredClone(pipeline);
-		const split = name.split('-');
-		const id = Number(split[1]);
-		const position = Number(split[2]);
-		p.filter!.conditions[id]['values'][position] = value;
-		setPipeline(p);
-	};
-
-	const onLogicalClick = (logical: FilterLogical) => {
-		const p = structuredClone(pipeline);
-		p.filter!.logical = logical;
-		setPipeline(p);
-	};
-
-	const onAddValue = (index: number) => {
-		const p = structuredClone(pipeline);
-		const currentLength = p.filter!.conditions[index]['values'].length;
-		p.filter!.conditions[index]['values'] = [...p.filter!.conditions[index]['values'], ''];
-		setPipeline(p);
+	const onOperatorSelectClose = (event: any) => {
+		const operator = FILTER_OPERATORS[event.target.value];
+		if (operator == null || isUnaryOperator(operator)) return;
 		setTimeout(() => {
-			// focus the new input.
-			const valueInputs: any = document
-				.querySelector(`[data-id=property-${index}]`)
+			const valueInput = event.target
 				.closest('.pipeline__filters-condition')
-				.querySelectorAll('.pipeline__filters-value-input');
-			const newValueInput = valueInputs[currentLength];
-			const isSelect = newValueInput.tagName === 'SL-SELECT';
-			if (isSelect) {
-				newValueInput.show();
-			} else {
-				newValueInput.focus();
-			}
+				?.querySelector('.pipeline__filters-value-input');
+			if (valueInput == null) return;
+			if (valueInput.tagName === 'SL-SELECT') valueInput.show();
+			else valueInput.focus();
 		}, 50);
 	};
 
-	const onRemoveValue = (conditionIndex: number, valueIndex: number) => {
-		const p = structuredClone(pipeline);
-		const values = p.filter!.conditions[conditionIndex]['values'];
-		const filtered = [];
-		for (const [i, v] of values.entries()) {
-			if (i !== valueIndex) {
-				filtered.push(v);
-			}
-		}
-		p.filter!.conditions[conditionIndex]['values'] = filtered;
-		setPipeline(p);
+	const onChangeValue = (path: number[], position: number, value: string) => {
+		const updated = structuredClone(pipeline);
+		filterConditionAt(updated.filter!, path).values[position] = value;
+		setPipeline(updated);
 	};
 
-	const isFileStorageImport = connection.isFileStorage && connection.isSource;
+	const onAddValue = (path: number[]) => {
+		const updated = structuredClone(pipeline);
+		const condition = filterConditionAt(updated.filter!, path);
+		const position = condition.values.length;
+		condition.values.push('');
+		setPipeline(updated);
+		setTimeout(() => {
+			const property: any = document.querySelector(`[data-id="property-${pathID(path)}"]`);
+			const inputs = property
+				?.closest('.pipeline__filters-condition')
+				?.querySelectorAll('.pipeline__filters-value-input');
+			const input = inputs?.[position];
+			if (input == null) return;
+			if (input.tagName === 'SL-SELECT') input.show();
+			else input.focus();
+		}, 50);
+	};
 
-	// For file storage imports, the filter section is displayed
-	// together with the transformation section when the file's settings
-	// are confirmed. It must be disabled when the settings are changed
-	// and not yet re-confirmed.
-	const isDisabled = isFileStorageImport && isTransformationDisabled;
+	const onRemoveValue = (path: number[], position: number) => {
+		const updated = structuredClone(pipeline);
+		const condition = filterConditionAt(updated.filter!, path);
+		condition.values.splice(position, 1);
+		setPipeline(updated);
+	};
 
-	const conditions: ReactNode[] = [];
-	if (pipeline.filter != null) {
-		for (const [i, condition] of pipeline.filter.conditions.entries()) {
-			const [base, path] = splitPropertyAndPath(condition.property, flatInputSchema);
+	const renderCondition = (condition: FilterCondition, path: number[]): ReactNode => {
+		const id = pathID(path);
+		const groupPath = path.slice(0, -1);
+		const isOnlyRuleInNestedGroup =
+			groupPath.length > 0 && filterGroupAt(pipeline.filter!, groupPath).rules.length === 1;
+		const isRemoveDisabled = isDisabled || isOnlyRuleInNestedGroup;
+		const [base, propertyPath] = splitPropertyAndPath(condition.property, flatInputSchema);
+		const property = flatInputSchema?.[base];
+		const isUnary = isUnaryOperator(condition.operator);
+		const isJSON = property?.type === 'json';
+		const isBetween = isBetweenOperator(condition.operator);
+		const isOneOf = isOneOfOperator(condition.operator);
+		const isInvalidProperty = property == null;
+		const propertyValues = getPropertyValues(property) ?? [];
 
-			let property = flatInputSchema?.[base];
-			const isUnary = isUnaryOperator(condition.operator);
-			const isJSON = property?.type === 'json';
-			const isBetween = isBetweenOperator(condition.operator);
-			const isOneOf = isOneOfOperator(condition.operator);
-			const isInvalidProperty = property == null;
-
-			let logicalElement: ReactNode;
-			let propertyInput: ReactNode;
-			let pathInput: ReactNode;
-			let operatorSelect: ReactNode;
-			let valueElements: ReactNode[] = [];
-
-			// Logical
-			if (i === 0) {
-				if (pipeline.filter.conditions.length > 1) {
-					// Add a placeholder to maintain alignment.
-					logicalElement = (
-						<div className='pipeline__filters-logical pipeline__filters-logical--placeholder'></div>
-					);
+		const propertyInput = (
+			<Combobox
+				onInput={(_, value) => updateProperty(path, value)}
+				onSelect={(_, value) => onSelectProperty(path, value)}
+				value={isJSON ? base : condition.property}
+				className='pipeline__filters-property'
+				size='small'
+				name={`property-${id}`}
+				items={getFilterPropertyComboboxItems(
+					pipelineType.inputSchema,
+					connection,
+					pipeline.target,
+					propertiesToHide,
+				)}
+				isExpression={false}
+				disabled={isDisabled}
+				placeholder='Property'
+				caret={true}
+				controlled={true}
+				autoResize={true}
+				error={
+					condition.property !== '' &&
+					checkIfPropertyExists(isJSON ? base : condition.property, flatInputSchema, propertiesToHide)
 				}
-			} else if (i === 1) {
-				logicalElement = (
-					<SlButtonGroup className='pipeline__filters-logical'>
-						<SlButton
-							size='small'
-							variant={pipeline.filter!.logical === 'and' ? 'primary' : 'default'}
-							onClick={() => onLogicalClick('and')}
-							disabled={isDisabled}
-						>
-							and
-						</SlButton>
-						<SlButton
-							size='small'
-							variant={pipeline.filter!.logical === 'or' ? 'primary' : 'default'}
-							onClick={() => onLogicalClick('or')}
-							disabled={isDisabled}
-						>
-							or
-						</SlButton>
-					</SlButtonGroup>
-				);
-			} else if (i > 1) {
-				logicalElement = (
-					<div className='pipeline__filters-logical pipeline__filters-logical--text'>
-						{pipeline.filter!.logical}
-					</div>
-				);
-			}
-
-			// Property
-			const isEventBasedUserImport = connection.isEventBased && connection.isSource && pipeline.target === 'User';
-			const isAppEventsExport =
-				connection.isApplication && connection.isDestination && pipeline.target === 'Event';
-			const isEventImport = connection.isSource && pipeline.target === 'Event';
-
-			let propertiesToHide = [];
-			if (isEventBasedUserImport || isAppEventsExport || isEventImport) {
-				propertiesToHide = ['kpid'];
-			}
-
-			propertyInput = (
-				<Combobox
-					onInput={onInputPropertyFragment}
-					onSelect={onSelectPropertyFragment}
-					value={isJSON ? base : condition.property}
-					className='pipeline__filters-property'
-					size='small'
-					name={`property-${i}`}
-					items={getFilterPropertyComboboxItems(
-						pipelineType.inputSchema,
-						connection,
-						pipeline.target,
-						propertiesToHide,
-					)}
-					isExpression={false}
-					disabled={isDisabled}
-					placeholder={'Property'}
-					caret={true}
-					controlled={true}
-					autoResize={true}
-					error={
-						condition.property !== '' &&
-						checkIfPropertyExists(isJSON ? base : condition.property, flatInputSchema, propertiesToHide)
-					}
-				/>
-			);
-
-			if (isJSON) {
-				pathInput = (
-					<SlInput
-						size='small'
-						className='pipeline__filters-path'
-						value={path}
-						onSlInput={onInputPathFragment}
-						name={`path-${i}`}
-						disabled={isDisabled}
-						placeholder='Path (optional)'
-					/>
-				);
-			}
-
-			// Operator
-			operatorSelect = (
-				<SlSelect
-					size='small'
-					name={`operator-${i}`}
-					className='pipeline__filters-operator'
-					value={String(FILTER_OPERATORS.findIndex((op) => op === condition.operator))}
-					onSlChange={onChangeOperatorFragment}
-					onSlHide={onOperatorSelectClose}
-					placeholder='Operator'
-					disabled={isInvalidProperty || isDisabled}
-				>
-					{property != null
-						? getCompatibleFilterOperators(property, path !== '', connection.role, pipeline.target).map(
-								(i) => (
-									<SlOption key={i} value={String(i)}>
-										{FILTER_OPERATORS[i]}
-									</SlOption>
-								),
-							)
-						: Object.keys(FILTER_OPERATORS).map((i) => (
-								<SlOption key={i} value={String(i)}>
-									{FILTER_OPERATORS[i]}
+			/>
+		);
+		const pathInput = isJSON ? (
+			<SlInput
+				size='small'
+				className='pipeline__filters-path'
+				value={propertyPath}
+				onSlInput={(event: any) => onInputPath(path, event.target.value)}
+				name={`path-${id}`}
+				disabled={isDisabled}
+				placeholder='Path (optional)'
+			/>
+		) : null;
+		const operatorSelect = (
+			<SlSelect
+				size='small'
+				name={`operator-${id}`}
+				className='pipeline__filters-operator'
+				value={String(FILTER_OPERATORS.findIndex((operator) => operator === condition.operator))}
+				onSlChange={(event: any) => changeOperator(path, FILTER_OPERATORS[event.target.value])}
+				onSlHide={onOperatorSelectClose}
+				placeholder='Operator'
+				disabled={isInvalidProperty || isDisabled}
+			>
+				{property != null
+					? getCompatibleFilterOperators(property, propertyPath !== '', connection.role, pipeline.target).map(
+							(index) => (
+								<SlOption key={index} value={String(index)}>
+									{FILTER_OPERATORS[index]}
 								</SlOption>
-							))}
-				</SlSelect>
+							),
+						)
+					: FILTER_OPERATORS.map((operator, index) => (
+							<SlOption key={operator} value={String(index)}>
+								{operator}
+							</SlOption>
+						))}
+			</SlSelect>
+		);
+
+		const valueElements: ReactNode[] = [];
+		if (!isUnary) {
+			valueElements.push(
+				<PipelineFilterValueControl
+					key={`value-${id}-0`}
+					name={`value-${id}-0`}
+					value={condition.values[0] ?? ''}
+					options={propertyValues}
+					disabled={isInvalidProperty || isDisabled}
+					onValueChange={(value) => onChangeValue(path, 0, value)}
+				/>,
 			);
-
-			// Values
-			if (!isUnary) {
-				const id = `value-${i}-0`;
-
-				let propertyValues = [];
-				if (!isInvalidProperty && property.type === 'string') {
-					const typ = property.full.type as StringType;
-					propertyValues = typ.values || [];
-				}
-
+			if (isBetween) {
 				valueElements.push(
+					<span className='pipeline__filters-value-and' key='and'>
+						and
+					</span>,
 					<PipelineFilterValueControl
-						key={id}
-						name={id}
-						value={condition.values != null ? condition.values[0] : ''}
+						key={`value-${id}-1`}
+						name={`value-${id}-1`}
+						value={condition.values[1] ?? ''}
 						options={propertyValues}
 						disabled={isInvalidProperty || isDisabled}
-						onValueChange={onChangeValueFragment}
+						onValueChange={(value) => onChangeValue(path, 1, value)}
 					/>,
 				);
-
-				if (isBetween) {
+			} else if (isOneOf) {
+				for (const [position, value] of condition.values.slice(1).entries()) {
+					const valuePosition = position + 1;
 					valueElements.push(
-						<span className='pipeline__filters-value-and' key='and'>
-							and
-						</span>,
-					);
-					const id = `value-${i}-1`;
-					valueElements.push(
-						<PipelineFilterValueControl
-							key={id}
-							name={id}
-							value={condition.values != null ? (condition.values[1] ? condition.values[1] : '') : ''}
-							options={propertyValues}
-							disabled={isInvalidProperty || isDisabled}
-							onValueChange={onChangeValueFragment}
-						/>,
-					);
-				} else if (isOneOf) {
-					const additionalValues = condition.values.slice(1);
-					let k = 1;
-					for (const value of additionalValues) {
-						const currentK = k;
-						const id = `value-${i}-${currentK}`;
-						const input = (
+						<div className='pipeline__filters-value' key={`value-${id}-${valuePosition}`}>
 							<PipelineFilterValueControl
-								key={id}
-								name={id}
+								name={`value-${id}-${valuePosition}`}
 								value={value}
 								options={propertyValues}
 								disabled={isInvalidProperty || isDisabled}
-								onValueChange={onChangeValueFragment}
+								onValueChange={(value) => onChangeValue(path, valuePosition, value)}
 								removable={true}
-								onRemove={() => onRemoveValue(i, currentK)}
+								onRemove={() => onRemoveValue(path, valuePosition)}
 							/>
-						);
-						valueElements.push(
-							<div className='pipeline__filters-value pipeline__filters-value--additional' key={id}>
-								{input}
-							</div>,
-						);
-						k++;
-					}
-					valueElements.push(
-						<SlButton
-							className='pipeline__filters-add-value'
-							key='add-button'
-							variant='default'
-							size='small'
-							disabled={isDisabled}
-							onClick={() => onAddValue(i)}
-						>
-							Add value
-						</SlButton>,
+						</div>,
 					);
 				}
-			}
-
-			let values: ReactNode;
-			if (isOneOf) {
-				values = <div className='pipeline__filters-is-one-of-values'>{valueElements}</div>;
-			} else {
-				values = valueElements;
-			}
-
-			conditions.push(
-				<div className='pipeline__filters-filter'>
-					{logicalElement}
-					<div
-						key={i}
-						className={`pipeline__filters-condition${isOneOf ? ' pipeline__filters-condition--is-one-of' : ''}`}
+				valueElements.push(
+					<SlButton
+						className='pipeline__filters-add-value'
+						key='add-button'
+						variant='default'
+						size='small'
+						disabled={isDisabled}
+						onClick={() => onAddValue(path)}
 					>
-						<div className='pipeline__filters-property-and-operator'>
-							{propertyInput}
-							{pathInput}
-							{operatorSelect}
-						</div>
-						{values}
-						<div className='pipeline__filters-remove-condition-wrapper'>
-							<SlButton
-								className='pipeline__filters-remove-condition'
-								size='small'
-								onClick={() => onRemoveCondition(i)}
-								disabled={isDisabled}
-							>
-								<SlIcon name='x-circle' slot='prefix' />
-							</SlButton>
-						</div>
-					</div>
-				</div>,
-			);
+						Add value
+					</SlButton>,
+				);
+			}
 		}
-	}
+
+		const removeButton = (
+			<SlButton
+				className='pipeline__filters-remove-condition pipeline__filters-remove-rule'
+				size='small'
+				variant='text'
+				onClick={() => onRemoveRule(path)}
+				disabled={isRemoveDisabled}
+			>
+				<SlIcon name='x-circle' aria-hidden='true' />
+				<span className='pipeline__filters-remove-rule-label'>Remove condition</span>
+			</SlButton>
+		);
+
+		return (
+			<div className='pipeline__filters-filter' key={id}>
+				<div
+					className={`pipeline__filters-condition${isOneOf ? ' pipeline__filters-condition--is-one-of' : ''}`}
+				>
+					<div className='pipeline__filters-property-and-operator'>
+						{propertyInput}
+						{pathInput}
+						{operatorSelect}
+					</div>
+					{isOneOf ? (
+						<div className='pipeline__filters-is-one-of-values'>{valueElements}</div>
+					) : (
+						valueElements
+					)}
+					<div className='pipeline__filters-remove-condition-wrapper'>
+						{isRemoveDisabled ? (
+							removeButton
+						) : (
+							<SlTooltip content='Remove condition' hoist={true}>
+								{removeButton}
+							</SlTooltip>
+						)}
+					</div>
+				</div>
+			</div>
+		);
+	};
+
+	const renderGroup = (group: Filter, groupPath: number[], depth: number): ReactNode => {
+		const isRoot = depth === 1;
+		const removeGroupTooltip = group.rules.some(isFilterGroup) ? 'Remove groups' : 'Remove group';
+
+		return (
+			<div
+				className={`pipeline__filters-group${isRoot ? ' pipeline__filters-group--root' : ''}`}
+				key={pathID(groupPath) || 'root'}
+			>
+				<div className='pipeline__filters-group-header'>
+					<span className='pipeline__filters-group-subject'>
+						{isRoot ? `${filterSubject} matching` : 'matching'}
+					</span>
+					<SlSelect
+						className='pipeline__filters-logical'
+						size='small'
+						value={group.operator}
+						onSlChange={(event: any) => onLogicalChange(groupPath, event.target.value as FilterLogical)}
+						disabled={isDisabled}
+						aria-label='Match rules'
+					>
+						<SlOption value='and'>all</SlOption>
+						<SlOption value='or'>any</SlOption>
+					</SlSelect>
+					<span>of the following:</span>
+					{!isRoot && (
+						<div className='pipeline__filters-remove-group-wrapper'>
+							<SlTooltip content={removeGroupTooltip} hoist={true}>
+								<SlButton
+									className='pipeline__filters-remove-group pipeline__filters-remove-rule'
+									size='small'
+									variant='text'
+									onClick={() => onRemoveRule(groupPath)}
+									disabled={isDisabled}
+								>
+									<SlIcon name='x-circle' aria-hidden='true' />
+									<span className='pipeline__filters-remove-rule-label'>Remove group</span>
+								</SlButton>
+							</SlTooltip>
+						</div>
+					)}
+				</div>
+				<div className='pipeline__filters-group-rules'>
+					{group.rules.map((rule, index) => {
+						const path = [...groupPath, index];
+						const isGroup = isFilterGroup(rule);
+
+						return (
+							<div
+								className={`pipeline__filters-rule${isGroup ? ' pipeline__filters-rule--group' : ''}`}
+								key={pathID(path)}
+							>
+								{index > 0 && (
+									<div className='pipeline__filters-connector' aria-hidden='true'>
+										{group.operator}
+									</div>
+								)}
+								<div className='pipeline__filters-rule-content'>
+									{isGroup ? renderGroup(rule, path, depth + 1) : renderCondition(rule, path)}
+								</div>
+							</div>
+						);
+					})}
+				</div>
+				<div className='pipeline__filters-group-actions'>
+					<SlButton
+						className='pipeline__filters-add-condition'
+						size='medium'
+						variant='text'
+						onClick={() => onAddCondition(groupPath)}
+						disabled={isDisabled || filterRuleCount >= MAX_FILTER_RULE_COUNT}
+					>
+						<SlIcon slot='prefix' name='plus-circle' />
+						Add a condition
+					</SlButton>
+					<SlButton
+						className='pipeline__filters-add-group'
+						size='medium'
+						variant='text'
+						onClick={() => onAddGroup(groupPath)}
+						disabled={
+							isDisabled || depth >= MAX_FILTER_DEPTH || filterRuleCount > MAX_FILTER_RULE_COUNT - 2
+						}
+					>
+						<SlIcon slot='prefix' name='plus-circle' />
+						Add a group
+					</SlButton>
+				</div>
+			</div>
+		);
+	};
 
 	return (
 		<Section
@@ -570,7 +534,7 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 			title='Filters'
 			description={
 				<>
-					<span>{`Choose which ${targetTerm} to ${actionVerb}. Leave empty to ${actionVerb} all ${targetTerm}.`}</span>
+					<span>{`Choose which ${filterSubjectTerm} to ${actionVerb}. Leave empty to ${actionVerb} all ${filterSubjectTerm}.`}</span>
 					<a href='https://www.krenalis.com/docs/ref/admin/filters' target='_blank' rel='noopener'>
 						Learn more about filters
 					</a>
@@ -580,17 +544,20 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 			ref={ref}
 			annotated={true}
 		>
-			{conditions}
-			<SlButton
-				className='pipeline__filters-add-condition'
-				size='medium'
-				variant='text'
-				onClick={onAddCondition}
-				disabled={isDisabled}
-			>
-				<SlIcon slot='prefix' name='plus-circle' />
-				Add {conditions.length > 0 ? 'new ' : ''}filter
-			</SlButton>
+			{pipeline.filter == null ? (
+				<SlButton
+					className='pipeline__filters-add-condition'
+					size='medium'
+					variant='text'
+					onClick={() => onAddCondition([])}
+					disabled={isDisabled || filterRuleCount >= MAX_FILTER_RULE_COUNT}
+				>
+					<SlIcon slot='prefix' name='plus-circle' />
+					Add filter
+				</SlButton>
+			) : (
+				renderGroup(pipeline.filter, [], 1)
+			)}
 		</Section>
 	);
 });
@@ -598,9 +565,9 @@ const PipelineFilters = forwardRef<any>((_, ref) => {
 interface PipelineFilterValueControlProps {
 	name: string;
 	value: string;
-	options: string[] | null;
+	options: string[];
 	disabled: boolean;
-	onValueChange: (name: string, value: string) => void;
+	onValueChange: (value: string) => void;
 	removable?: boolean;
 	onRemove?: () => void;
 }
@@ -615,20 +582,32 @@ const PipelineFilterValueControl = ({
 	onRemove,
 }: PipelineFilterValueControlProps) => {
 	const handleInput = (event: any) => {
-		onValueChange(name, event.target.value);
+		onValueChange(event.target.value);
 	};
 
 	const handleSelect = (event: any) => {
 		const target = event.target as any;
 		const v = event.detail?.value ?? target.value;
-		onValueChange(name, v);
+		onValueChange(v);
 	};
 
-	if (options != null && options.length > 0) {
+	const removeButton = removable ? (
+		<SlButton
+			slot='suffix'
+			variant='default'
+			size='small'
+			circle
+			className='pipeline__filters-value-remove'
+			onClick={onRemove}
+			disabled={disabled}
+		>
+			<SlIcon name='x' />
+		</SlButton>
+	) : null;
+
+	if (options.length > 0) {
 		return (
-			<div
-				className={`pipeline__filters-value-control${removable ? ' pipeline__filters-value-control--removable' : ''}`}
-			>
+			<div className={removable ? 'pipeline__filters-value-control--removable' : undefined}>
 				<SlSelect
 					size='small'
 					className='pipeline__filters-value-input'
@@ -642,19 +621,7 @@ const PipelineFilterValueControl = ({
 							{option === '' ? '\u00A0' : option}
 						</SlOption>
 					))}
-					{removable && (
-						<SlButton
-							slot='suffix'
-							variant='default'
-							size='small'
-							circle
-							className='pipeline__filters-value-remove'
-							onClick={onRemove}
-							disabled={disabled}
-						>
-							<SlIcon name='x' />
-						</SlButton>
-					)}
+					{removeButton}
 				</SlSelect>
 			</div>
 		);
@@ -669,19 +636,7 @@ const PipelineFilterValueControl = ({
 			name={name}
 			disabled={disabled}
 		>
-			{removable && (
-				<SlButton
-					variant='default'
-					size='small'
-					circle
-					className='pipeline__filters-value-remove'
-					onClick={onRemove}
-					slot='suffix'
-					disabled={disabled}
-				>
-					<SlIcon name='x' />
-				</SlButton>
-			)}
+			{removeButton}
 		</SlInput>
 	);
 };

--- a/admin/src/components/routes/PipelineWrapper/PipelineTransformation.tsx
+++ b/admin/src/components/routes/PipelineWrapper/PipelineTransformation.tsx
@@ -4,6 +4,7 @@ import {
 	updateMappingProperty,
 	getSampleIdentifiers,
 	updateMappingPropertyError,
+	pipelineObjectLabels,
 } from './Pipeline.helpers';
 import {
 	getSchemaComboboxItems,
@@ -17,7 +18,9 @@ import {
 	TransformedProperty,
 	doesUpdatedAtColumnNeedFormat,
 	flattenSchema,
+	getFilterConditions,
 	isRecursiveType,
+	omitEmptyFilterRules,
 	propertyTypesAreEqual,
 	splitPropertyAndPath,
 	transformInPipelineToSet,
@@ -70,7 +73,6 @@ import ConnectionContext from '../../../context/ConnectionContext';
 import Workspace from '../../../lib/api/types/workspace';
 import {
 	PipelineToSet,
-	Filter,
 	RequiredConsents,
 	TransformationFunction,
 	TransformationPurpose,
@@ -80,7 +82,6 @@ import { Combobox } from '../../base/Combobox/Combobox';
 import { ComboboxItem } from '../../base/Combobox/Combobox.types';
 import JSONbig from 'json-bigint';
 import pipelineContext from '../../../context/PipelineContext';
-import TransformedConnection from '../../../lib/core/connection';
 import appContext from '../../../context/AppContext';
 import { mapExpressionArguments, buildMapExpression } from '../../../utils/mapExpression';
 import { isPlainObject } from '../../../utils/isPlainObject';
@@ -809,7 +810,9 @@ const TransformationBox = ({
 
 	const onOpenTransformation = () => {
 		// Validate the filter to prevent Bad Request when loading the samples.
-		let conditions = pipeline.filter?.conditions.filter((condition) => condition.property !== '') || [];
+		const conditions = pipeline.filter
+			? getFilterConditions(pipeline.filter).filter((condition) => condition.property !== '')
+			: [];
 		for (const condition of conditions) {
 			const propertyName = condition.property;
 			const [base, path] = splitPropertyAndPath(propertyName, flatInputSchema);
@@ -1040,7 +1043,7 @@ const TransformationBox = ({
 				);
 			}
 		}
-		const [sourceHeader, destinationHeader] = transformationHeaders(connection, pipeline);
+		const [sourceHeader, destinationHeader] = pipelineObjectLabels(connection, pipeline);
 		body = (
 			<div className='pipeline__transformation-mappings'>
 				{!isCompletelyOpen && (
@@ -1310,15 +1313,7 @@ const FullscreenTransformation = ({
 	}, [outputSchema]);
 
 	const normalizedFilter = useMemo(() => {
-		// Exclude empty conditions from the filter.
-		let f: Filter | null = null;
-		if (pipeline.filter != null) {
-			let conditions = pipeline.filter.conditions.filter((condition) => condition.property !== '');
-			if (conditions.length > 0) {
-				f = { logical: pipeline.filter.logical, conditions: conditions };
-			}
-		}
-		return f;
+		return pipeline.filter == null ? null : omitEmptyFilterRules(pipeline.filter);
 	}, [pipeline.filter]);
 
 	const normalizedConsents = useMemo(() => {
@@ -2322,7 +2317,7 @@ const FullscreenTransformation = ({
 		);
 	}
 
-	const [sourceHeader, destinationHeader] = transformationHeaders(connection, pipeline, 'full');
+	const [sourceHeader, destinationHeader] = pipelineObjectLabels(connection, pipeline, 'full');
 	const outputSchemaTabLabel = isAppEventsExport ? 'Parameters' : 'Schema';
 	return (
 		<div
@@ -3567,63 +3562,4 @@ function removeQuotes(v: any | null) {
 	}
 	return v.replace(/^"|"$/g, '');
 }
-type TransformationHeaderMode = 'compact' | 'full';
-
-const TRANSFORMATION_HEADERS: Record<TransformationHeaderMode, Record<string, [string, string]>> = {
-	compact: {
-		'source:sdk': ['Event schema', 'Profile schema'],
-		'source:webhook': ['Event schema', 'Profile schema'],
-		'source:database': ['Database user schema', 'Profile schema'],
-		'source:file': ['File user schema', 'Profile schema'],
-		'source:application': ['Application user schema', 'Profile schema'],
-		'destination:event': ['Event schema', 'Sending event parameters'],
-		'destination:database': ['Profile schema', 'Database table schema'],
-		'destination:application': ['Profile schema', 'Application user schema'],
-	},
-	full: {
-		'source:sdk': ['Event', 'Profile'],
-		'source:webhook': ['Event', 'Profile'],
-		'source:database': ['Database user', 'Profile'],
-		'source:file': ['File user', 'Profile'],
-		'source:application': ['Application user', 'Profile'],
-		'destination:event': ['Event', 'Sending event'],
-		'destination:database': ['Profile', 'Database table'],
-		'destination:application': ['Profile', 'Application user'],
-	},
-};
-
-// transformationHeaders reports the input and output headers for a transformation.
-// The returned values are fully formatted for the requested mode.
-function transformationHeaders(
-	connection: TransformedConnection,
-	pipeline: TransformedPipeline,
-	mode: TransformationHeaderMode = 'compact',
-): [string, string] {
-	let scenario = 'source:app';
-
-	if (connection.isSource) {
-		if (connection.isSDK) {
-			scenario = 'source:sdk';
-		} else if (connection.isWebhook) {
-			scenario = 'source:webhook';
-		} else if (connection.isDatabase) {
-			scenario = 'source:database';
-		} else if (connection.isFileStorage || connection.isFile) {
-			scenario = 'source:file';
-		} else {
-			scenario = 'source:application';
-		}
-	} else {
-		if (pipeline.target === 'Event') {
-			scenario = 'destination:event';
-		} else if (connection.isDatabase) {
-			scenario = 'destination:database';
-		} else {
-			scenario = 'destination:application';
-		}
-	}
-
-	return TRANSFORMATION_HEADERS[mode][scenario];
-}
-
 export default PipelineTransformation;

--- a/admin/src/lib/api/api.ts
+++ b/admin/src/lib/api/api.ts
@@ -613,8 +613,8 @@ class Profiles {
 		];
 		params.push(['properties', properties.join(',')]);
 		let filter = {
-			logical: 'and',
-			conditions: [
+			operator: 'and',
+			rules: [
 				{
 					property: 'kpid',
 					operator: 'is',

--- a/admin/src/lib/api/types/pipeline.ts
+++ b/admin/src/lib/api/types/pipeline.ts
@@ -84,12 +84,14 @@ type FilterOperator =
 interface FilterCondition {
 	property: string;
 	operator: FilterOperator | '';
-	values: string[] | null;
+	values: string[];
 }
 
+type FilterRule = FilterCondition | Filter;
+
 interface Filter {
-	logical: FilterLogical;
-	conditions: FilterCondition[];
+	operator: FilterLogical;
+	rules: FilterRule[];
 }
 
 interface Pipeline {
@@ -189,6 +191,7 @@ export type {
 	Filter,
 	FilterOperator,
 	FilterLogical,
+	FilterRule,
 	ConsentPurposesOperator,
 	RequiredConsents,
 	FilterCondition,

--- a/admin/src/lib/api/types/pipeline.ts
+++ b/admin/src/lib/api/types/pipeline.ts
@@ -84,7 +84,7 @@ type FilterOperator =
 interface FilterCondition {
 	property: string;
 	operator: FilterOperator | '';
-	values: string[];
+	values?: string[];
 }
 
 type FilterRule = FilterCondition | Filter;

--- a/admin/src/lib/core/pipeline.ts
+++ b/admin/src/lib/core/pipeline.ts
@@ -646,7 +646,7 @@ const transformPipeline = (
 	if (pipeline.filter) {
 		pipeline.filter = mapFilterConditions(pipeline.filter, (condition) => ({
 			...condition,
-			values: condition.values.map((value) => formatString(value)),
+			values: (condition.values ?? []).map((value) => formatString(value)),
 		}));
 	}
 
@@ -1200,7 +1200,7 @@ const computeDefaultPipeline = (
 				operator: 'or',
 				rules: [
 					{ property: 'type', operator: 'is', values: ['identify'] },
-					{ property: 'traits', operator: 'is not empty', values: [] },
+					{ property: 'traits', operator: 'is not empty' },
 				],
 			};
 		}
@@ -1988,13 +1988,14 @@ const validateAndNormalizeFilterCondition = (
 		}
 	}
 
+	const conditionValues = condition.values ?? [];
 	let values: string[] = [];
 	if (isJsonOrText) {
 		const stringType = property.type === 'string' ? (property.full.type as StringType) : null;
 		const propertyValues = stringType?.values ?? null;
 		const allowsEmptySelection = propertyValues != null && propertyValues.includes('');
 
-		for (const [i, v] of condition.values.entries()) {
+		for (const [i, v] of conditionValues.entries()) {
 			const isFirstValueEmpty = i === 0 && v === '';
 			const isSecondBetweenEmpty = i === 1 && v === '' && isBetweenOperator(condition.operator);
 			if ((isFirstValueEmpty || isSecondBetweenEmpty) && !allowsEmptySelection) {
@@ -2016,16 +2017,19 @@ const validateAndNormalizeFilterCondition = (
 			values.push(parsed);
 		}
 	} else {
-		values = condition.values;
+		values = conditionValues;
 	}
 
 	try {
-		validateFilterConditionValues(property.full.type, condition.values, propertyName);
+		validateFilterConditionValues(property.full.type, conditionValues, propertyName);
 	} catch (err) {
 		throw err;
 	}
 
-	const c: FilterCondition = { property: condition.property, operator: condition.operator, values: values };
+	const c: FilterCondition = { property: condition.property, operator: condition.operator };
+	if (!isUnaryOperator(condition.operator)) {
+		c.values = values;
+	}
 	return c;
 };
 

--- a/admin/src/lib/core/pipeline.ts
+++ b/admin/src/lib/core/pipeline.ts
@@ -7,6 +7,7 @@ import {
 	ExpressionToBeExtracted,
 	Filter,
 	FilterCondition,
+	FilterRule,
 	RequiredConsents,
 	FilterOperator,
 	Mapping,
@@ -75,6 +76,43 @@ const FILTER_OPERATORS: FilterOperator[] = [
 	'exists',
 	'does not exist',
 ];
+
+// isFilterGroup reports whether rule is a filter group.
+const isFilterGroup = (rule: FilterRule): rule is Filter => 'rules' in rule;
+
+// getFilterConditions returns every condition in filter in traversal order.
+const getFilterConditions = (filter: Filter): FilterCondition[] => {
+	const conditions: FilterCondition[] = [];
+	for (const rule of filter.rules) {
+		if (isFilterGroup(rule)) {
+			conditions.push(...getFilterConditions(rule));
+		} else {
+			conditions.push(rule);
+		}
+	}
+	return conditions;
+};
+
+// mapFilterConditions applies transform to every condition in filter.
+const mapFilterConditions = (filter: Filter, transform: (condition: FilterCondition) => FilterCondition): Filter => ({
+	operator: filter.operator,
+	rules: filter.rules.map((rule) => (isFilterGroup(rule) ? mapFilterConditions(rule, transform) : transform(rule))),
+});
+
+// omitEmptyFilterRules removes draft conditions and groups that contain no
+// complete rules. It returns null when the root group becomes empty.
+const omitEmptyFilterRules = (filter: Filter): Filter | null => {
+	const rules: FilterRule[] = [];
+	for (const rule of filter.rules) {
+		if (isFilterGroup(rule)) {
+			const group = omitEmptyFilterRules(rule);
+			if (group != null) rules.push(group);
+		} else if (rule.property !== '') {
+			rules.push(rule);
+		}
+	}
+	return rules.length === 0 ? null : { operator: filter.operator, rules };
+};
 
 const UNARY_OPERATORS = new Set<FilterOperator>([
 	'is true',
@@ -601,22 +639,10 @@ const transformPipeline = (
 	}
 
 	if (pipeline.filter) {
-		const conditions: FilterCondition[] = [];
-		for (const condition of pipeline.filter.conditions) {
-			let cond = { ...condition };
-			let values: string[] | null = [];
-			if (condition.values == null) {
-				values = null;
-			} else {
-				for (const v of condition.values) {
-					const formatted = formatString(v);
-					values.push(formatted);
-				}
-			}
-			cond.values = values;
-			conditions.push(cond);
-		}
-		pipeline.filter.conditions = conditions;
+		pipeline.filter = mapFilterConditions(pipeline.filter, (condition) => ({
+			...condition,
+			values: condition.values.map((value) => formatString(value)),
+		}));
 	}
 
 	return {
@@ -945,38 +971,27 @@ const transformInPipelineToSet = async (
 			inSchema = { kind: 'object', properties: [] };
 		}
 
-		let f = { logical: pipeline.filter.logical, conditions: [] };
-
-		// Exclude conditions that have empty properties.
-		let conditions = pipeline.filter.conditions.filter((condition) => condition.property !== '');
-
 		const isEventImport = connection.isSource && pipelineType.target === 'Event';
 		const isEventBasedUserImport = connection.isEventBased && connection.isSource && pipelineType.target === 'User';
 		const isAppEventsExport =
 			connection.isApplication && connection.isDestination && pipelineType.target === 'Event';
-
-		for (const condition of conditions) {
-			const propertyName = condition.property;
-			const [base, path] = splitPropertyAndPath(propertyName, flattenedInputSchema);
-			const property = flattenedInputSchema[base];
-			let c: FilterCondition;
-			try {
-				c = validateAndNormalizeFilterCondition(
+		const draftFilter = omitEmptyFilterRules(pipeline.filter);
+		if (draftFilter != null) {
+			filter = mapFilterConditions(draftFilter, (condition) => {
+				const propertyName = condition.property;
+				const [base, path] = splitPropertyAndPath(propertyName, flattenedInputSchema);
+				const property = flattenedInputSchema[base];
+				const normalized = validateAndNormalizeFilterCondition(
 					condition,
 					property,
 					path,
 					propertyName,
 					isEventBasedUserImport || isAppEventsExport || isEventImport ? ['kpid'] : null,
 				);
-			} catch (err) {
-				throw err;
-			}
-			addPropertyToSchema(base, property.full, inSchema, flattenedInputSchema, property.indentation === 0);
-			f.conditions.push(c);
-		}
+				addPropertyToSchema(base, property.full, inSchema, flattenedInputSchema, property.indentation === 0);
 
-		if (f.conditions.length > 0) {
-			filter = f;
+				return normalized;
+			});
 		}
 	}
 
@@ -1177,10 +1192,10 @@ const computeDefaultPipeline = (
 			pipeline.filter = eventType.defaultFilter;
 		} else if ((connection.isSDK || connection.isWebhook) && pipelineType.target === 'User') {
 			pipeline.filter = {
-				logical: 'or',
-				conditions: [
+				operator: 'or',
+				rules: [
 					{ property: 'type', operator: 'is', values: ['identify'] },
-					{ property: 'traits', operator: 'is not empty', values: null },
+					{ property: 'traits', operator: 'is not empty', values: [] },
 				],
 			};
 		}
@@ -1968,8 +1983,8 @@ const validateAndNormalizeFilterCondition = (
 		}
 	}
 
-	let values: string[] | null = [];
-	if (isJsonOrText && condition.values != null) {
+	let values: string[] = [];
+	if (isJsonOrText) {
 		const stringType = property.type === 'string' ? (property.full.type as StringType) : null;
 		const propertyValues = stringType?.values ?? null;
 		const allowsEmptySelection = propertyValues != null && propertyValues.includes('');
@@ -2009,7 +2024,7 @@ const validateAndNormalizeFilterCondition = (
 	return c;
 };
 
-const validateFilterConditionValues = (type: Type, values: string[] | null, propertyName: string) => {
+const validateFilterConditionValues = (type: Type, values: string[], propertyName: string) => {
 	const throwIfInvalid = (isValid: boolean, typeKind: string, unsigned?: boolean) => {
 		if (!isValid) {
 			throw new Error(
@@ -2017,10 +2032,6 @@ const validateFilterConditionValues = (type: Type, values: string[] | null, prop
 			);
 		}
 	};
-
-	if (values == null) {
-		return;
-	}
 
 	for (const v of values) {
 		if (type.kind === 'int') {
@@ -2117,6 +2128,8 @@ export {
 	checkMapping,
 	checkFunctionPath,
 	getCompatibleFilterOperators,
+	getFilterConditions,
+	isFilterGroup,
 	isUnaryOperator,
 	isBetweenOperator,
 	isOneOfOperator,
@@ -2128,6 +2141,7 @@ export {
 	validateAndNormalizeFilterCondition,
 	validateMatching,
 	propertyTypesAreEqual,
+	omitEmptyFilterRules,
 };
 
 export type {

--- a/admin/src/lib/core/pipeline.ts
+++ b/admin/src/lib/core/pipeline.ts
@@ -77,6 +77,9 @@ const FILTER_OPERATORS: FilterOperator[] = [
 	'does not exist',
 ];
 
+const MAX_FILTER_DEPTH = 4;
+const MAX_FILTER_RULE_COUNT = 100;
+
 // isFilterGroup reports whether rule is a filter group.
 const isFilterGroup = (rule: FilterRule): rule is Filter => 'rules' in rule;
 
@@ -106,7 +109,9 @@ const omitEmptyFilterRules = (filter: Filter): Filter | null => {
 	for (const rule of filter.rules) {
 		if (isFilterGroup(rule)) {
 			const group = omitEmptyFilterRules(rule);
-			if (group != null) rules.push(group);
+			if (group != null) {
+				rules.push(group);
+			}
 		} else if (rule.property !== '') {
 			rules.push(rule);
 		}
@@ -2112,6 +2117,8 @@ const propertyTypesAreEqual = (aType: Type, bType: Type): boolean => {
 export {
 	SCHEDULE_PERIODS,
 	FILTER_OPERATORS,
+	MAX_FILTER_DEPTH,
+	MAX_FILTER_RULE_COUNT,
 	EXPORT_MODE_OPTIONS,
 	flattenSchema,
 	isRecursiveType,

--- a/admin/src/utils/filters.ts
+++ b/admin/src/utils/filters.ts
@@ -298,7 +298,7 @@ const serializeFilter = (filter: Filter, formatted: boolean): string => {
 	// formatCondition builds a single condition string.
 	function formatCondition(condition: FilterCondition): string {
 		const { property, operator, values } = condition;
-		const formattedValues = formatValues(values, operator);
+		const formattedValues = formatValues(values ?? [], operator);
 		return `${property} ${operator}${formattedValues === '' ? '' : ` ${formattedValues}`}`;
 	}
 

--- a/admin/src/utils/filters.ts
+++ b/admin/src/utils/filters.ts
@@ -7,6 +7,11 @@ const MAX_FLOAT32 = 3.4028234663852885981170418348451692544e38;
 const MIN_YEAR = 1;
 const MAX_YEAR = 9999;
 
+// isFilterNumber reports whether value uses the numeric syntax accepted by the
+// filter parser.
+const isFilterNumber = (value: string): boolean =>
+	/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(value) && Number.isFinite(Number(value));
+
 // formatText formats a string value as a string.
 const formatString = (str: string): string => {
 	if (!/^[\s"']/.test(str) && !/[\s"']$/.test(str)) {
@@ -262,21 +267,26 @@ const serializeFilter = (filter: Filter, formatted: boolean): string => {
 	}
 
 	// formatValues formats a list of values as a string.
-	function formatValues(values: string[]): string {
+	function formatValues(values: string[], operator: FilterCondition['operator']): string {
 		if (values.length === 0) {
 			return '';
 		}
 
-		if (values.length === 1) {
+		const usesValueList =
+			operator === 'is one of' ||
+			operator === 'is not one of' ||
+			operator === 'is between' ||
+			operator === 'is not between';
+		if (values.length === 1 && !usesValueList) {
 			const v = values[0];
-			if (v === 'true' || v === 'false' || (v !== '' && !isNaN(Number(v)))) {
+			if ((operator !== 'is' && (v === 'true' || v === 'false')) || isFilterNumber(v)) {
 				return v;
 			}
 			return escapeString(v);
 		}
 
 		const formattedList = values.map((v) => {
-			if (v === 'true' || v === 'false' || (v !== '' && !isNaN(Number(v)))) {
+			if (v === 'true' || v === 'false' || isFilterNumber(v)) {
 				return v;
 			}
 			return escapeString(v);
@@ -288,7 +298,7 @@ const serializeFilter = (filter: Filter, formatted: boolean): string => {
 	// formatCondition builds a single condition string.
 	function formatCondition(condition: FilterCondition): string {
 		const { property, operator, values } = condition;
-		const formattedValues = formatValues(values);
+		const formattedValues = formatValues(values, operator);
 		return `${property} ${operator}${formattedValues === '' ? '' : ` ${formattedValues}`}`;
 	}
 
@@ -322,6 +332,7 @@ export {
 	isDate,
 	isDateTime,
 	isDecimal,
+	isFilterNumber,
 	isFloat,
 	isIP,
 	isInt,

--- a/admin/src/utils/filters.ts
+++ b/admin/src/utils/filters.ts
@@ -1,4 +1,4 @@
-import { Filter, FilterCondition } from '../lib/api/types/pipeline';
+import { Filter, FilterCondition, FilterRule } from '../lib/api/types/pipeline';
 
 const MIN_INT = BigInt('-9223372036854775808');
 const MAX_INT = BigInt('9223372036854775807');
@@ -249,11 +249,8 @@ const parseText = (s: string): string => {
 };
 
 // serializeFilter returns a string representation of the given Filter object.
-// If formatted is true, each condition appears on its own line with indentation
-// based on the logical connector.
+// If formatted is true, each rule appears on its own indented line.
 const serializeFilter = (filter: Filter, formatted: boolean): string => {
-	const { logical, conditions } = filter;
-
 	// escapeString returns the input string escaped and wrapped in double quotes.
 	function escapeString(value: string): string {
 		return `"${value
@@ -265,8 +262,8 @@ const serializeFilter = (filter: Filter, formatted: boolean): string => {
 	}
 
 	// formatValues formats a list of values as a string.
-	function formatValues(values: string[] | null): string {
-		if (!values || values.length === 0) {
+	function formatValues(values: string[]): string {
+		if (values.length === 0) {
 			return '';
 		}
 
@@ -291,32 +288,33 @@ const serializeFilter = (filter: Filter, formatted: boolean): string => {
 	// formatCondition builds a single condition string.
 	function formatCondition(condition: FilterCondition): string {
 		const { property, operator, values } = condition;
-
-		if (!values) {
-			return `${property} ${operator}`;
-		}
-
-		return `${property} ${operator} ${formatValues(values)}`;
+		const formattedValues = formatValues(values);
+		return `${property} ${operator}${formattedValues === '' ? '' : ` ${formattedValues}`}`;
 	}
 
-	// Build the final string from all conditions.
-	const lines: string[] = [];
-
-	for (let i = 0; i < conditions.length; i++) {
-		const condStr = formatCondition(conditions[i]);
-
+	// formatRule formats a condition or nested group.
+	function formatRule(rule: FilterRule, depth: number): string {
+		if (!('rules' in rule)) {
+			return formatCondition(rule);
+		}
 		if (!formatted) {
-			lines.push(condStr);
-		} else {
-			if (i === 0) {
-				lines.push(condStr);
-			} else {
-				lines.push(`${logical} ${condStr}`); // prefix subsequent lines with the connector
-			}
+			return `(${formatGroup(rule, depth + 1)})`;
 		}
+		return `(\n${formatGroup(rule, depth + 1)}\n${'  '.repeat(depth)})`;
 	}
 
-	return formatted ? lines.join('\n') : lines.join(` ${logical} `);
+	// formatGroup formats all rules in a group.
+	function formatGroup(group: Filter, depth: number): string {
+		if (!formatted) {
+			return group.rules.map((rule) => formatRule(rule, depth)).join(` ${group.operator} `);
+		}
+		const indentation = '  '.repeat(depth);
+		return group.rules
+			.map((rule, index) => `${indentation}${index === 0 ? '' : `${group.operator} `}${formatRule(rule, depth)}`)
+			.join('\n');
+	}
+
+	return formatGroup(filter, 0);
 };
 
 export {

--- a/admin/src/utils/filters_parser.ts
+++ b/admin/src/utils/filters_parser.ts
@@ -1,7 +1,9 @@
 import { FILTER_OPERATORS } from '../lib/core/pipeline';
-import { FilterLogical, FilterOperator, Filter, FilterCondition } from '../lib/api/types/pipeline';
+import { FilterLogical, FilterOperator, Filter, FilterCondition, FilterRule } from '../lib/api/types/pipeline';
 
 const SORTED_OPERATORS = [...FILTER_OPERATORS].sort((a, b) => b.length - a.length);
+const MAX_FILTER_DEPTH = 4;
+const MAX_FILTER_RULE_COUNT = 100;
 
 const UNARY_OPERATORS: FilterOperator[] = [
 	'is',
@@ -213,66 +215,124 @@ function parseOperator(s: string, i: number): [FilterOperator, number] {
 	throw new Error('Unknown operator');
 }
 
-// parseFilter parses a user-readable filter expression into a Filter object.
-//
-// It supports property paths, string/number/boolean values, and a rich set of operators.
-// It returns a structured Filter with conditions and a logical connector (and/or).
-// Syntax errors are reported with informative messages.
-export function parseFilter(s: string): Filter {
-	let i = 0;
-	const conditions: FilterCondition[] = [];
-	let logical: FilterLogical | null = null;
-	let conditionCount = 0;
+// isFilterGroup reports whether rule is a filter group.
+const isFilterGroup = (rule: FilterRule): rule is Filter => 'rules' in rule;
 
-	while (i < s.length) {
-		i = skipSpaces(s, i);
+// isOperatorUnary reports whether operator accepts no values.
+const isOperatorUnary = (operator: FilterOperator): boolean =>
+	operator.endsWith('null') ||
+	operator.endsWith('empty') ||
+	operator.endsWith('exist') ||
+	operator === 'is true' ||
+	operator === 'is false';
+
+// parseLogical parses a logical operator at i.
+const parseLogical = (s: string, i: number): FilterLogical | null => {
+	for (const operator of ['and', 'or'] as FilterLogical[]) {
+		const end = i + operator.length;
+		if (s.slice(i, end) === operator && (end === s.length || isWhitespace(s[end]) || s[end] === '(')) {
+			return operator;
+		}
+	}
+
+	return null;
+};
+
+// parseFilter parses a user-readable filter expression into a Filter object.
+// Parentheses delimit nested groups with their own logical operator.
+export function parseFilter(s: string): Filter {
+	let ruleCount = 0;
+
+	const parseCondition = (start: number): [FilterCondition, number] => {
+		let i = start;
 		const [property, ni1] = parseProperty(s, i);
 		i = skipSpaces(s, ni1);
 		const [operator, ni2] = parseOperator(s, i);
 		i = skipSpaces(s, ni2);
 
-		let values: string[] | null = null;
-		if (
-			!operator.endsWith('null') &&
-			!operator.endsWith('empty') &&
-			!operator.endsWith('exist') &&
-			operator !== 'is true' &&
-			operator !== 'is false'
-		) {
+		let values: string[] = [];
+		if (!isOperatorUnary(operator)) {
 			const expectMultiple =
 				operator === 'is one of' ||
 				operator === 'is not one of' ||
 				operator === 'is between' ||
 				operator === 'is not between';
-			const [vals, ni3] = parseValues(s, i, expectMultiple);
-			values = vals;
+			const [parsedValues, ni3] = parseValues(s, i, expectMultiple);
+			values = parsedValues;
 			i = ni3;
 
-			const n = values.length;
-			if ((operator === 'is between' || operator === 'is not between') && n !== 2)
+			if ((operator === 'is between' || operator === 'is not between') && values.length !== 2) {
 				throw new Error(`Operator '${operator}' requires exactly 2 values`);
-			if ((operator === 'is one of' || operator === 'is not one of') && n < 1)
+			}
+			if ((operator === 'is one of' || operator === 'is not one of') && values.length < 1) {
 				throw new Error(`Operator '${operator}' requires at least 1 value`);
-			if (UNARY_OPERATORS.includes(operator) && n !== 1)
+			}
+			if (UNARY_OPERATORS.includes(operator) && values.length !== 1) {
 				throw new Error(`Operator '${operator}' requires exactly 1 value`);
+			}
 		}
 
-		conditions.push({ property, operator, values });
-		conditionCount++;
+		return [{ property, operator, values }, i];
+	};
 
-		i = skipSpaces(s, i);
-		if (i >= s.length) return { logical: logical || 'and', conditions };
+	const parseGroup = (start: number, depth: number, nested: boolean): [Filter, number] => {
+		if (depth > MAX_FILTER_DEPTH) {
+			throw new Error(`Filter exceeds maximum depth of ${MAX_FILTER_DEPTH}`);
+		}
 
-		const next = s.startsWith('and', i) ? 'and' : s.startsWith('or', i) ? 'or' : null;
-		if (!next) throw new Error("Expected logical connector 'and' or 'or'");
-		if (logical && logical !== next) throw new Error('Mixed logical connectors are not allowed');
-		logical = next as FilterLogical;
-		i += next.length;
+		let i = skipSpaces(s, start);
+		const rules: FilterRule[] = [];
+		let operator: FilterLogical | null = null;
+		for (;;) {
+			if (nested && s[i] === ')') {
+				if (rules.length === 0) throw new Error('Filter groups cannot be empty');
+				return [{ operator: operator || 'and', rules }, i + 1];
+			}
+			if (i >= s.length) {
+				if (nested) throw new Error('Unclosed filter group');
+				return [{ operator: operator || 'and', rules }, i];
+			}
 
-		i = skipSpaces(s, i);
-		if (i >= s.length) throw new Error('Trailing logical connector without following condition');
+			let rule: FilterRule;
+			if (s[i] === '(') {
+				[rule, i] = parseGroup(i + 1, depth + 1, true);
+			} else {
+				[rule, i] = parseCondition(i);
+			}
+			rules.push(rule);
+			ruleCount++;
+			if (ruleCount > MAX_FILTER_RULE_COUNT) {
+				throw new Error(`Filter exceeds maximum rule count of ${MAX_FILTER_RULE_COUNT}`);
+			}
+
+			i = skipSpaces(s, i);
+			if (nested && s[i] === ')') {
+				return [{ operator: operator || 'and', rules }, i + 1];
+			}
+			if (i >= s.length) {
+				if (nested) throw new Error('Unclosed filter group');
+				return [{ operator: operator || 'and', rules }, i];
+			}
+			if (s[i] === ')') throw new Error('Unexpected closing parenthesis');
+
+			const next = parseLogical(s, i);
+			if (next == null) throw new Error("Expected logical connector 'and' or 'or'");
+			if (operator != null && operator !== next) {
+				throw new Error('Mixed logical connectors require parentheses');
+			}
+			operator = next;
+			i = skipSpaces(s, i + next.length);
+			if (i >= s.length || (nested && s[i] === ')')) {
+				throw new Error('Trailing logical connector without following rule');
+			}
+		}
+	};
+
+	const [filter, end] = parseGroup(0, 1, false);
+	if (skipSpaces(s, end) !== s.length) throw new Error('Unexpected content after filter');
+	if (filter.rules.length === 1 && isFilterGroup(filter.rules[0])) {
+		return filter.rules[0];
 	}
 
-	if (conditionCount > 1 && !logical) throw new Error('Missing logical connector (and/or) between conditions');
-	return { logical: logical || 'and', conditions };
+	return filter;
 }

--- a/admin/src/utils/filters_parser.ts
+++ b/admin/src/utils/filters_parser.ts
@@ -1,9 +1,14 @@
-import { FILTER_OPERATORS } from '../lib/core/pipeline';
+import {
+	FILTER_OPERATORS,
+	MAX_FILTER_DEPTH,
+	MAX_FILTER_RULE_COUNT,
+	isFilterGroup,
+	isUnaryOperator,
+} from '../lib/core/pipeline';
 import { FilterLogical, FilterOperator, Filter, FilterCondition, FilterRule } from '../lib/api/types/pipeline';
+import { isFilterNumber, isValidPropertyPath } from './filters';
 
 const SORTED_OPERATORS = [...FILTER_OPERATORS].sort((a, b) => b.length - a.length);
-const MAX_FILTER_DEPTH = 4;
-const MAX_FILTER_RULE_COUNT = 100;
 
 const UNARY_OPERATORS: FilterOperator[] = [
 	'is',
@@ -48,8 +53,7 @@ function parseNumber(s: string, i: number): [string, number] {
 	const start = i;
 	while (i < s.length && /[0-9eE.+\-]/.test(s[i])) i++;
 	const str = s.slice(start, i);
-	const num = Number(str);
-	if (!isFinite(num)) throw new Error(`Invalid number: ${str}`);
+	if (!isFilterNumber(str)) throw new Error(`Invalid number: ${str}`);
 	return [str, i];
 }
 
@@ -157,46 +161,27 @@ function parseValues(s: string, i: number, expectMultiple: boolean): [string[], 
 	return [[val], ni];
 }
 
-// parseBracketString parses a map-style property access like ["key"].
-function parseBracketString(s: string, i: number): [string, number] {
-	if (s[i] !== '[') throw new Error('Expected "[" for map access');
-	i++;
-	const quote = s[i];
-	if (quote !== '"' && quote !== "'") throw new Error('Expected quoted string in map access');
-	const [str, end] = parseString(s, i);
-	if (s[end] !== ']') throw new Error('Expected closing bracket ] in map access');
-	return [`[${quote}${str}${quote}]`, end + 1];
-}
-
-// parseProperty parses a property path, including dot notation and brackets.
+// parseProperty parses a filter property path. Unlike transformation
+// expressions, filter property paths support only dot notation; bracket
+// notation for map and JSON keys is intentionally rejected.
 function parseProperty(s: string, i: number): [string, number] {
 	let prop = '';
-	let lastCharDot = false;
 	while (i < s.length) {
-		if (isPropStart(s[i])) {
+		if (isPropChar(s[i])) {
 			const begin = i;
 			while (i < s.length && isPropChar(s[i])) i++;
 			prop += s.slice(begin, i);
-			lastCharDot = false;
 			continue;
 		}
 		if (s[i] === '.') {
-			if (lastCharDot) throw new Error('Invalid property path: consecutive dots');
 			prop += '.';
 			i++;
-			lastCharDot = true;
-			continue;
-		}
-		if (s[i] === '[') {
-			const [bracketed, ni] = parseBracketString(s, i);
-			prop += bracketed;
-			i = ni;
-			lastCharDot = false;
 			continue;
 		}
 		break;
 	}
-	if (!prop || prop.endsWith('.')) throw new Error('Invalid property path');
+	if (!isValidPropertyPath(prop)) throw new Error('Invalid property path');
+	if (s[i] === '[') throw new Error('Bracket notation is not supported in filter property paths');
 	return [prop, i];
 }
 
@@ -208,23 +193,19 @@ function parseOperator(s: string, i: number): [FilterOperator, number] {
 		if (end > len) continue;
 		if (s.slice(i, i + op.length) !== op) continue;
 		const nextChar = s[end];
-		if (end === len || isWhitespace(nextChar) || nextChar === '(' || nextChar === '"' || nextChar === "'") {
+		if (
+			end === len ||
+			isWhitespace(nextChar) ||
+			nextChar === '(' ||
+			nextChar === ')' ||
+			nextChar === '"' ||
+			nextChar === "'"
+		) {
 			return [op as FilterOperator, end];
 		}
 	}
 	throw new Error('Unknown operator');
 }
-
-// isFilterGroup reports whether rule is a filter group.
-const isFilterGroup = (rule: FilterRule): rule is Filter => 'rules' in rule;
-
-// isOperatorUnary reports whether operator accepts no values.
-const isOperatorUnary = (operator: FilterOperator): boolean =>
-	operator.endsWith('null') ||
-	operator.endsWith('empty') ||
-	operator.endsWith('exist') ||
-	operator === 'is true' ||
-	operator === 'is false';
 
 // parseLogical parses a logical operator at i.
 const parseLogical = (s: string, i: number): FilterLogical | null => {
@@ -251,7 +232,7 @@ export function parseFilter(s: string): Filter {
 		i = skipSpaces(s, ni2);
 
 		let values: string[] = [];
-		if (!isOperatorUnary(operator)) {
+		if (!isUnaryOperator(operator)) {
 			const expectMultiple =
 				operator === 'is one of' ||
 				operator === 'is not one of' ||
@@ -276,7 +257,7 @@ export function parseFilter(s: string): Filter {
 	};
 
 	const parseGroup = (start: number, depth: number, nested: boolean): [Filter, number] => {
-		if (depth > MAX_FILTER_DEPTH) {
+		if (depth > MAX_FILTER_DEPTH + 1) {
 			throw new Error(`Filter exceeds maximum depth of ${MAX_FILTER_DEPTH}`);
 		}
 
@@ -290,6 +271,7 @@ export function parseFilter(s: string): Filter {
 			}
 			if (i >= s.length) {
 				if (nested) throw new Error('Unclosed filter group');
+				if (rules.length === 0) throw new Error('Filter groups cannot be empty');
 				return [{ operator: operator || 'and', rules }, i];
 			}
 
@@ -301,7 +283,7 @@ export function parseFilter(s: string): Filter {
 			}
 			rules.push(rule);
 			ruleCount++;
-			if (ruleCount > MAX_FILTER_RULE_COUNT) {
+			if (ruleCount > MAX_FILTER_RULE_COUNT + 1) {
 				throw new Error(`Filter exceeds maximum rule count of ${MAX_FILTER_RULE_COUNT}`);
 			}
 
@@ -330,9 +312,24 @@ export function parseFilter(s: string): Filter {
 
 	const [filter, end] = parseGroup(0, 1, false);
 	if (skipSpaces(s, end) !== s.length) throw new Error('Unexpected content after filter');
-	if (filter.rules.length === 1 && isFilterGroup(filter.rules[0])) {
-		return filter.rules[0];
-	}
+	const result = filter.rules.length === 1 && isFilterGroup(filter.rules[0]) ? filter.rules[0] : filter;
 
-	return filter;
+	let actualRuleCount = 0;
+	const validateGroupLimits = (group: Filter, depth: number) => {
+		if (depth > MAX_FILTER_DEPTH) {
+			throw new Error(`Filter exceeds maximum depth of ${MAX_FILTER_DEPTH}`);
+		}
+		for (const rule of group.rules) {
+			actualRuleCount++;
+			if (actualRuleCount > MAX_FILTER_RULE_COUNT) {
+				throw new Error(`Filter exceeds maximum rule count of ${MAX_FILTER_RULE_COUNT}`);
+			}
+			if (isFilterGroup(rule)) {
+				validateGroupLimits(rule, depth + 1);
+			}
+		}
+	};
+	validateGroupLimits(result, 1);
+
+	return result;
 }

--- a/admin/src/utils/filters_parser_test.ts
+++ b/admin/src/utils/filters_parser_test.ts
@@ -11,6 +11,7 @@
  */
 
 import { parseFilter } from './filters_parser';
+import { serializeFilter } from './filters';
 
 const tests = [
 	// ✅ Valid cases (single values, no parentheses)
@@ -84,6 +85,21 @@ const tests = [
 		expectError: false,
 	},
 	{
+		name: 'Nested AND and OR groups',
+		input: 'status is "active" and (country is "Italy" or country is "Spain")',
+		expectError: false,
+	},
+	{
+		name: 'Nested groups at maximum depth',
+		input: 'a is 1 and (b is 2 or (c is 3 and (d is 4 or e is 5)))',
+		expectError: false,
+	},
+	{
+		name: 'Maximum rule count',
+		input: Array.from({ length: 100 }, (_, i) => `property${i} is ${i}`).join(' and '),
+		expectError: false,
+	},
+	{
 		name: 'Unicode emoji and accents',
 		input: 'comment contains "👍 café \u2764"',
 		expectError: false,
@@ -147,6 +163,21 @@ const tests = [
 	{
 		name: 'Mismatched parentheses',
 		input: 'status is one of ("a", "b"',
+		expectError: true,
+	},
+	{
+		name: 'Unclosed filter group',
+		input: 'a is 1 and (b is 2 or c is 3',
+		expectError: true,
+	},
+	{
+		name: 'Filter nesting exceeds maximum depth',
+		input: 'a is 1 and (b is 2 or (c is 3 and (d is 4 or (e is 5 and f is 6))))',
+		expectError: true,
+	},
+	{
+		name: 'Filter exceeds maximum rule count',
+		input: Array.from({ length: 101 }, (_, i) => `property${i} is ${i}`).join(' and '),
 		expectError: true,
 	},
 	{
@@ -247,4 +278,18 @@ for (const test of tests) {
 	}
 }
 
+const nested = parseFilter('status is "active" and (country is "Italy" or country is "Spain")');
+for (const formatted of [false, true]) {
+	const serialized = serializeFilter(nested, formatted);
+	const parsed = parseFilter(serialized);
+	if (JSON.stringify(parsed) === JSON.stringify(nested)) {
+		console.log(`✅ [PASS] Nested filter ${formatted ? 'formatted' : 'compact'} round trip`);
+		passed++;
+	} else {
+		console.error(`❌ [FAIL] Nested filter round trip → ${serialized}`);
+		failed++;
+	}
+}
+
 console.log(`\nTotal: ${passed} passed, ${failed} failed.`);
+if (failed > 0) process.exitCode = 1;

--- a/admin/src/utils/filters_parser_test.ts
+++ b/admin/src/utils/filters_parser_test.ts
@@ -36,8 +36,8 @@ const tests = [
 		expectError: false,
 	},
 	{
-		name: 'Single quote string',
-		input: "props['key'] is 'value'",
+		name: 'Single-quoted value',
+		input: "props.key is 'value'",
 		expectError: false,
 	},
 
@@ -65,8 +65,8 @@ const tests = [
 		expectError: false,
 	},
 	{
-		name: 'AND with escaped keys and quoted values',
-		input: 'properties["client id"] is "abc" and metadata["referrer"] contains "google"',
+		name: 'AND with nested properties and quoted values',
+		input: 'properties.client_id is "abc" and metadata.referrer contains "google"',
 		expectError: false,
 	},
 	{
@@ -95,8 +95,18 @@ const tests = [
 		expectError: false,
 	},
 	{
+		name: 'Fully parenthesized filter at maximum depth',
+		input: '((((a is 1))))',
+		expectError: false,
+	},
+	{
 		name: 'Maximum rule count',
 		input: Array.from({ length: 100 }, (_, i) => `property${i} is ${i}`).join(' and '),
+		expectError: false,
+	},
+	{
+		name: 'Fully parenthesized filter at maximum rule count',
+		input: `(${Array.from({ length: 100 }, (_, i) => `property${i} is ${i}`).join(' and ')})`,
 		expectError: false,
 	},
 	{
@@ -104,10 +114,16 @@ const tests = [
 		input: 'comment contains "👍 café \u2764"',
 		expectError: false,
 	},
+	// ❌ Invalid: empty filters
 	{
-		name: 'Property key with escaped quotes',
-		input: 'metadata["key with \\"quotes\\""] contains "something"',
-		expectError: false,
+		name: 'Empty filter',
+		input: '',
+		expectError: true,
+	},
+	{
+		name: 'Whitespace-only filter',
+		input: ' \n\t',
+		expectError: true,
 	},
 
 	// ❌ Invalid: single value with parentheses
@@ -176,13 +192,33 @@ const tests = [
 		expectError: true,
 	},
 	{
+		name: 'Fully parenthesized filter exceeds maximum depth',
+		input: '(((((a is 1)))))',
+		expectError: true,
+	},
+	{
 		name: 'Filter exceeds maximum rule count',
 		input: Array.from({ length: 101 }, (_, i) => `property${i} is ${i}`).join(' and '),
 		expectError: true,
 	},
 	{
+		name: 'Fully parenthesized filter exceeds maximum rule count',
+		input: `(${Array.from({ length: 101 }, (_, i) => `property${i} is ${i}`).join(' and ')})`,
+		expectError: true,
+	},
+	{
 		name: 'Consecutive dots in property',
 		input: 'user..name is "Alice"',
+		expectError: true,
+	},
+	{
+		name: 'Bracket notation with single quotes',
+		input: "props['key'] is 'value'",
+		expectError: true,
+	},
+	{
+		name: 'Bracket notation with double quotes',
+		input: 'metadata["key"] contains "something"',
 		expectError: true,
 	},
 	{
@@ -231,11 +267,6 @@ const tests = [
 		expectError: true,
 	},
 	{
-		name: 'Brackets not closed in property key',
-		input: 'meta["client id" is "abc"',
-		expectError: true,
-	},
-	{
 		name: 'Empty parentheses in values',
 		input: 'type is one of ()',
 		expectError: true,
@@ -278,16 +309,46 @@ for (const test of tests) {
 	}
 }
 
-const nested = parseFilter('status is "active" and (country is "Italy" or country is "Spain")');
-for (const formatted of [false, true]) {
-	const serialized = serializeFilter(nested, formatted);
-	const parsed = parseFilter(serialized);
-	if (JSON.stringify(parsed) === JSON.stringify(nested)) {
-		console.log(`✅ [PASS] Nested filter ${formatted ? 'formatted' : 'compact'} round trip`);
-		passed++;
-	} else {
-		console.error(`❌ [FAIL] Nested filter round trip → ${serialized}`);
-		failed++;
+const roundTripExpressions = [
+	{
+		name: 'Nested filter',
+		expression: 'status is "active" and (country is "Italy" or country is "Spain")',
+	},
+	...['true', 'false'].map((value) => ({
+		name: `Filter with "${value}" as a string value`,
+		expression: `status is "${value}"`,
+	})),
+	...['0', '-1', '+.5', '1.', '1.23e+5', '0x10', 'Infinity', ' 1', '1 '].map((value) => ({
+		name: `Filter with ${JSON.stringify(value)} as a value`,
+		expression: `code is ${JSON.stringify(value)}`,
+	})),
+	{
+		name: 'Filter list containing numeric-looking string values',
+		expression: 'code is one of ("0x10", "Infinity", " 1", "1.23e+5")',
+	},
+	...['is one of', 'is not one of'].map((operator) => ({
+		name: `Filter using "${operator}" with one value`,
+		expression: `status ${operator} ("active")`,
+	})),
+	...['is true', 'is false', 'is empty', 'is not empty', 'is null', 'is not null', 'exists', 'does not exist'].map(
+		(operator) => ({
+			name: `Nested filter ending in a condition using "${operator}"`,
+			expression: `status is "active" and (property ${operator})`,
+		}),
+	),
+];
+for (const roundTrip of roundTripExpressions) {
+	const filter = parseFilter(roundTrip.expression);
+	for (const formatted of [false, true]) {
+		const serialized = serializeFilter(filter, formatted);
+		const parsed = parseFilter(serialized);
+		if (JSON.stringify(parsed) === JSON.stringify(filter)) {
+			console.log(`✅ [PASS] ${roundTrip.name} ${formatted ? 'formatted' : 'compact'} round trip`);
+			passed++;
+		} else {
+			console.error(`❌ [FAIL] ${roundTrip.name} round trip → ${serialized}`);
+			failed++;
+		}
 	}
 }
 

--- a/admin/tests/pipelines.spec.ts
+++ b/admin/tests/pipelines.spec.ts
@@ -177,8 +177,8 @@ test(`Add "Export customers" pipeline on Dummy`, async ({ page }) => {
 		"name": "Export customers",
 		"enabled": true,
 		"filter": {
-			"logical": "or",
-			"conditions": [
+			"operator": "or",
+			"rules": [
 				{
 					"property": "email",
 					"operator": "is one of",
@@ -574,8 +574,8 @@ test(`Add "Export users" pipeline on PostgreSQL`, async ({ page }) => {
 		"name": "Export users",
 		"enabled": true,
 		"filter": {
-			"logical": "or",
-			"conditions": [
+			"operator": "or",
+			"rules": [
 				{
 					"property": "email",
 					"operator": "is one of",
@@ -931,8 +931,8 @@ test(`Add "Export users" pipeline on CSV file on File System`, async ({ page }) 
 			"name": "Export users",
 			"enabled": true,
 			"filter": {
-				"logical": "or",
-				"conditions": [
+				"operator": "or",
+				"rules": [
 					{
 						"property": "email",
 						"operator": "is one of",
@@ -1238,7 +1238,7 @@ test(`Add "Import events" pipeline on JavaScript`, async ({ page }) => {
 	await page.locator('.pipeline__filters-add-condition').click();
 	await page.locator('.pipeline__filters-add-condition').click();
 
-	let filters = page.locator('.pipeline__filters-filter');
+	const filters = page.locator('.pipeline__filters-filter');
 
 	await filters.nth(0).locator('.pipeline__filters-property sl-input').click();
 	await filters
@@ -1256,8 +1256,8 @@ test(`Add "Import events" pipeline on JavaScript`, async ({ page }) => {
 		"name": "Import events into warehouse",
 		"enabled": false,
 		"filter": {
-			"logical": "and",
-			"conditions": [
+			"operator": "and",
+			"rules": [
 				{
 					"property": "type",
 					"operator": "is",
@@ -1319,8 +1319,8 @@ test(`Add "Import users" pipeline on JavaScript`, async ({ page }) => {
 		"name": "Import users into warehouse",
 		"enabled": false,
 		"filter": {
-			"logical": "or",
-			"conditions": [
+			"operator": "or",
+			"rules": [
 				{
 					"property": "type",
 					"operator": "is",
@@ -1330,9 +1330,9 @@ test(`Add "Import users" pipeline on JavaScript`, async ({ page }) => {
 				},
 				{
 					"property": "traits",
-         			"operator": "is not empty",
-         			"values": null
-       			}
+					"operator": "is not empty",
+					"values": []
+				}
 			]
 		},
 		"requiredConsents": null,

--- a/admin/tests/pipelines.spec.ts
+++ b/admin/tests/pipelines.spec.ts
@@ -1371,8 +1371,7 @@ test(`Add "Import users" pipeline on JavaScript`, async ({ page }) => {
 				},
 				{
 					"property": "traits",
-					"operator": "is not empty",
-					"values": []
+					"operator": "is not empty"
 				}
 			]
 		},

--- a/admin/tests/pipelines.spec.ts
+++ b/admin/tests/pipelines.spec.ts
@@ -1249,6 +1249,47 @@ test(`Add "Import events" pipeline on JavaScript`, async ({ page }) => {
 
 	await filters.nth(0).locator('.pipeline__filters-value-input sl-option[value="track"]').click(); // value select should open automatically after selecting the operator
 
+	const jsonCondition = filters.nth(1);
+	const jsonPropertyInput = jsonCondition.locator('.pipeline__filters-property sl-input');
+	await jsonPropertyInput.click();
+	await jsonCondition.locator('sl-menu-item .schema-combobox-item__name', { hasText: /^traits$/ }).click();
+	const jsonPathInput = jsonCondition.locator('.pipeline__filters-path >> input');
+	await jsonPathInput.fill('email');
+	const jsonOperatorSelect = jsonCondition.locator('.pipeline__filters-operator');
+	await expect(jsonOperatorSelect).toHaveJSProperty('value', '0');
+	const jsonValueInput = jsonCondition.locator('.pipeline__filters-value-input');
+	await jsonValueInput.locator('input').fill('a@example.com');
+
+	await jsonPropertyInput.click();
+	await jsonCondition.locator('sl-menu-item .schema-combobox-item__name', { hasText: /^properties$/ }).click();
+	await expect(jsonPropertyInput).toHaveJSProperty('value', 'properties');
+	await expect(jsonPathInput).toHaveValue('email');
+	await expect(jsonOperatorSelect).toHaveJSProperty('value', '0');
+	await expect(jsonValueInput).toHaveJSProperty('value', 'a@example.com');
+
+	await jsonPropertyInput.click();
+	await jsonCondition.locator('sl-menu-item .schema-combobox-item__name', { hasText: /^traits$/ }).click();
+
+	for (const operator of [
+		{ name: 'exists', index: 24 },
+		{ name: 'does not exist', index: 25 },
+	]) {
+		const condition = filters.nth(1);
+		await condition.locator('.pipeline__filters-property sl-input').click();
+		await condition.locator('sl-menu-item .schema-combobox-item__name', { hasText: /^traits$/ }).click();
+		const pathInput = condition.locator('.pipeline__filters-path >> input');
+		await pathInput.fill('email');
+		const operatorSelect = condition.locator('.pipeline__filters-operator');
+		const operatorOption = operatorSelect.locator(`sl-option[value="${operator.index}"]`);
+		await expect(operatorOption).toHaveText(operator.name);
+		await operatorSelect.click();
+		await operatorOption.click();
+		await expect(operatorSelect).toHaveJSProperty('value', String(operator.index));
+		await pathInput.fill('');
+		await expect(operatorSelect).toHaveJSProperty('value', '');
+		await condition.locator('.pipeline__filters-remove-condition').click();
+	}
+
 	const expectedBody = `
 	{
 		"target": "Event",

--- a/admin/tests/utils.ts
+++ b/admin/tests/utils.ts
@@ -225,8 +225,12 @@ const fillUserPipelineFilters = async (page: Page): Promise<void> => {
 
 	const rootFilter = page.locator('.pipeline__filters-group--root');
 	const rootRemoveConditionButton = rootFilter.getByRole('button', { name: 'Remove condition' });
-	await expect(rootRemoveConditionButton).toBeEnabled();
-	await expect(rootFilter.locator('sl-tooltip[content="Remove condition"]')).toHaveCount(1);
+	const rootRemoveConditionTooltip = rootFilter.locator(
+		':scope > .pipeline__filters-group-rules > .pipeline__filters-rule:not(.pipeline__filters-rule--group) .pipeline__filters-remove-condition-wrapper > sl-tooltip',
+	);
+	await expect(rootRemoveConditionButton).toHaveJSProperty('disabled', false);
+	await expect(rootRemoveConditionTooltip).toHaveCount(1);
+	await expect(rootRemoveConditionTooltip).toHaveJSProperty('content', 'Remove condition');
 
 	await page.locator('.pipeline__filters-add-condition').click();
 	await page.locator('.pipeline__filters-add-condition').click();
@@ -241,27 +245,62 @@ const fillUserPipelineFilters = async (page: Page): Promise<void> => {
 	const rootActions = rootFilter.locator(':scope > .pipeline__filters-group-actions');
 	await rootActions.locator('.pipeline__filters-add-group').click();
 
-	const nestedGroup = rootFilter.locator('.pipeline__filters-group:not(.pipeline__filters-group--root)');
+	const nestedGroup = rootFilter.locator(
+		':scope > .pipeline__filters-group-rules > .pipeline__filters-rule--group > .pipeline__filters-rule-content > .pipeline__filters-group',
+	);
+	const nestedRemoveGroupTooltip = nestedGroup.locator(
+		':scope > .pipeline__filters-group-header .pipeline__filters-remove-group-wrapper > sl-tooltip',
+	);
+	const nestedRemoveConditionTooltips = nestedGroup.locator(
+		':scope > .pipeline__filters-group-rules > .pipeline__filters-rule:not(.pipeline__filters-rule--group) .pipeline__filters-remove-condition-wrapper > sl-tooltip',
+	);
 	await expect(nestedGroup.locator('.pipeline__filters-logical')).toHaveJSProperty('value', 'or');
-	await expect(nestedGroup.locator('sl-tooltip[content="Remove group"]')).toHaveCount(1);
+	await expect(nestedRemoveGroupTooltip).toHaveCount(1);
+	await expect(nestedRemoveGroupTooltip).toHaveJSProperty('content', 'Remove group');
 
-	const nestedRemoveConditionButtons = nestedGroup.getByRole('button', { name: 'Remove condition' });
+	const nestedRemoveConditionButtons = nestedGroup.locator(
+		':scope > .pipeline__filters-group-rules > .pipeline__filters-rule:not(.pipeline__filters-rule--group) .pipeline__filters-remove-condition',
+	);
 	await expect(nestedRemoveConditionButtons).toHaveCount(1);
-	await expect(nestedRemoveConditionButtons.first()).toBeDisabled();
-	await expect(nestedGroup.locator('sl-tooltip[content="Remove condition"]')).toHaveCount(0);
+	await expect(nestedRemoveConditionButtons.first()).toHaveJSProperty('disabled', true);
+	await expect(nestedRemoveConditionTooltips).toHaveCount(0);
 
 	await nestedGroup.locator('.pipeline__filters-add-condition').click();
 	await expect(nestedRemoveConditionButtons).toHaveCount(2);
-	await expect(nestedRemoveConditionButtons.first()).toBeEnabled();
-	await expect(nestedRemoveConditionButtons.nth(1)).toBeEnabled();
-	await expect(nestedGroup.locator('sl-tooltip[content="Remove condition"]')).toHaveCount(2);
+	await expect(nestedRemoveConditionButtons.first()).toHaveJSProperty('disabled', false);
+	await expect(nestedRemoveConditionButtons.nth(1)).toHaveJSProperty('disabled', false);
+	await expect(nestedRemoveConditionTooltips).toHaveCount(2);
+	await expect(nestedRemoveConditionTooltips.first()).toHaveJSProperty('content', 'Remove condition');
+	await expect(nestedRemoveConditionTooltips.nth(1)).toHaveJSProperty('content', 'Remove condition');
 
 	await nestedRemoveConditionButtons.nth(1).click();
 	await expect(nestedRemoveConditionButtons).toHaveCount(1);
-	await expect(nestedRemoveConditionButtons.first()).toBeDisabled();
+	await expect(nestedRemoveConditionButtons.first()).toHaveJSProperty('disabled', true);
 	await nestedGroup.locator('.pipeline__filters-add-group').click();
-	await expect(nestedGroup.locator('sl-tooltip[content="Remove groups"]')).toHaveCount(1);
-	await nestedGroup.getByRole('button', { name: 'Remove group' }).click();
+	await expect(nestedRemoveGroupTooltip).toHaveJSProperty('content', 'Remove groups');
+	await expect(nestedRemoveConditionButtons.first()).toHaveJSProperty('disabled', false);
+	await nestedRemoveConditionButtons.first().click();
+
+	const childGroup = nestedGroup.locator(
+		':scope > .pipeline__filters-group-rules > .pipeline__filters-rule--group > .pipeline__filters-rule-content > .pipeline__filters-group',
+	);
+	await childGroup
+		.locator(':scope > .pipeline__filters-group-header')
+		.getByRole('button', { name: 'Remove group' })
+		.click();
+	await expect(childGroup).toHaveCount(0);
+	await expect(nestedRemoveConditionButtons).toHaveCount(1);
+	await expect(nestedRemoveConditionButtons.first()).toHaveJSProperty('disabled', true);
+	await expect(nestedGroup.locator('.pipeline__filters-property sl-input')).toHaveJSProperty('value', '');
+	await expect(nestedRemoveGroupTooltip).toHaveJSProperty('content', 'Remove group');
+
+	await nestedGroup.locator('.pipeline__filters-add-group').click();
+	await expect(nestedRemoveGroupTooltip).toHaveJSProperty('content', 'Remove groups');
+	await nestedGroup
+		.first()
+		.locator(':scope > .pipeline__filters-group-header')
+		.getByRole('button', { name: 'Remove group' })
+		.click();
 
 	const filters = page.locator('.pipeline__filters-filter');
 

--- a/admin/tests/utils.ts
+++ b/admin/tests/utils.ts
@@ -222,10 +222,48 @@ const fillUserPipelineFilters = async (page: Page): Promise<void> => {
 	await page.waitForTimeout(1000);
 
 	await page.locator('.pipeline__filters-add-condition').click();
+
+	const rootFilter = page.locator('.pipeline__filters-group--root');
+	const rootRemoveConditionButton = rootFilter.getByRole('button', { name: 'Remove condition' });
+	await expect(rootRemoveConditionButton).toBeEnabled();
+	await expect(rootFilter.locator('sl-tooltip[content="Remove condition"]')).toHaveCount(1);
+
 	await page.locator('.pipeline__filters-add-condition').click();
 	await page.locator('.pipeline__filters-add-condition').click();
 
-	let filters = page.locator('.pipeline__filters-filter');
+	await expect(
+		rootFilter.locator(':scope > .pipeline__filters-group-header .pipeline__filters-group-subject'),
+	).toHaveText('Profiles matching');
+	const connectors = rootFilter.locator(
+		':scope > .pipeline__filters-group-rules > .pipeline__filters-rule > .pipeline__filters-connector',
+	);
+	await expect(connectors).toHaveText(['and', 'and']);
+	const rootActions = rootFilter.locator(':scope > .pipeline__filters-group-actions');
+	await rootActions.locator('.pipeline__filters-add-group').click();
+
+	const nestedGroup = rootFilter.locator('.pipeline__filters-group:not(.pipeline__filters-group--root)');
+	await expect(nestedGroup.locator('.pipeline__filters-logical')).toHaveJSProperty('value', 'or');
+	await expect(nestedGroup.locator('sl-tooltip[content="Remove group"]')).toHaveCount(1);
+
+	const nestedRemoveConditionButtons = nestedGroup.getByRole('button', { name: 'Remove condition' });
+	await expect(nestedRemoveConditionButtons).toHaveCount(1);
+	await expect(nestedRemoveConditionButtons.first()).toBeDisabled();
+	await expect(nestedGroup.locator('sl-tooltip[content="Remove condition"]')).toHaveCount(0);
+
+	await nestedGroup.locator('.pipeline__filters-add-condition').click();
+	await expect(nestedRemoveConditionButtons).toHaveCount(2);
+	await expect(nestedRemoveConditionButtons.first()).toBeEnabled();
+	await expect(nestedRemoveConditionButtons.nth(1)).toBeEnabled();
+	await expect(nestedGroup.locator('sl-tooltip[content="Remove condition"]')).toHaveCount(2);
+
+	await nestedRemoveConditionButtons.nth(1).click();
+	await expect(nestedRemoveConditionButtons).toHaveCount(1);
+	await expect(nestedRemoveConditionButtons.first()).toBeDisabled();
+	await nestedGroup.locator('.pipeline__filters-add-group').click();
+	await expect(nestedGroup.locator('sl-tooltip[content="Remove groups"]')).toHaveCount(1);
+	await nestedGroup.getByRole('button', { name: 'Remove group' }).click();
+
+	const filters = page.locator('.pipeline__filters-filter');
 
 	await filters.nth(0).locator('.pipeline__filters-property sl-input').click();
 	await filters.nth(0).locator('sl-menu-item .schema-combobox-item__name', { hasText: 'email' }).click();
@@ -254,7 +292,9 @@ const fillUserPipelineFilters = async (page: Page): Promise<void> => {
 		)
 		.click(); // remove the last value.
 
-	await page.locator('.pipeline__filters-logical sl-button:nth-child(2)').click(); // set the logical to 'or'.
+	await page.locator('.pipeline__filters-logical').click();
+	await page.locator('.pipeline__filters-logical sl-option[value="or"]').click();
+	await expect(connectors).toHaveText(['or', 'or']);
 
 	await filters.nth(1).locator('.pipeline__filters-property sl-input').click();
 	await filters.nth(1).locator('sl-menu-item .schema-combobox-item__name', { hasText: 'dummy_id' }).click();
@@ -264,6 +304,16 @@ const fillUserPipelineFilters = async (page: Page): Promise<void> => {
 	await filters.nth(1).locator('.pipeline__filters-value-input:nth-child(4) >> input').fill('1800');
 
 	await filters.nth(2).locator('.pipeline__filters-remove-condition').click(); // remove the last filter.
+
+	await expect(rootActions.locator('.pipeline__filters-add-condition')).toContainText('Add a condition');
+	await expect(rootActions.locator('.pipeline__filters-add-group')).toContainText('Add a group');
+	await rootActions.locator('.pipeline__filters-add-group').click();
+
+	await expect(nestedGroup.locator('.pipeline__filters-group-subject')).toHaveText('matching');
+	await expect(nestedGroup.locator('.pipeline__filters-logical')).toHaveJSProperty('value', 'and');
+	const removeGroupButton = nestedGroup.getByRole('button', { name: 'Remove group' });
+	await expect(removeGroupButton).toBeAttached();
+	await removeGroupButton.click();
 };
 
 const deepComparePipelineSchema = (actual: object, expected: object) => {

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -785,9 +785,9 @@ func (workspace workspace) ProfileEvents(_ http.ResponseWriter, r *http.Request)
 	properties := splitQueryParameters(q["properties"])
 
 	filter := &core.Filter{
-		Logical: core.OpAnd,
-		Conditions: []core.FilterCondition{
-			{
+		Operator: core.OpAnd,
+		Rules: []core.FilterRule{
+			&core.FilterCondition{
 				Property: "kpid",
 				Operator: core.OpIs,
 				Values:   []string{kpid},

--- a/core/connection.go
+++ b/core/connection.go
@@ -1043,11 +1043,16 @@ func (this *Connection) Identities(ctx context.Context, first, limit int) ([]Ide
 		store:     this.store,
 		workspace: this.connection.Workspace(),
 	}
-	where := &state.Where{Logical: state.OpAnd, Conditions: []state.WhereCondition{{
-		Property: []string{"_connection"},
-		Operator: state.OpIs,
-		Values:   []any{this.connection.ID},
-	}}}
+	where := &state.Where{
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{
+				Property: []string{"_connection"},
+				Operator: state.OpIs,
+				Values:   []any{this.connection.ID},
+			},
+		},
+	}
 	identities, total, err := ws.identities(ctx, where, first, limit)
 	if err != nil {
 		return nil, 0, err

--- a/core/filters.go
+++ b/core/filters.go
@@ -726,7 +726,7 @@ func validateFilter(filter *Filter, schema types.Type, role state.Role, target s
 
 // validateFilterCondition checks the validity of a filter condition and
 // returns its property path.
-func validateFilterCondition(cond *FilterCondition, validation *filterValidation) ([]string, error) {
+func validateFilterCondition(cond *FilterCondition, validation *filterValidation) (string, error) {
 
 	// disallowJSON indicates whether JSON properties are disallowed.
 	disallowJSON := validation.role == state.Destination && validation.target == state.TargetUser
@@ -736,19 +736,19 @@ func validateFilterCondition(cond *FilterCondition, validation *filterValidation
 	disallowEmptyOnObject := validation.role == state.Destination && validation.target == state.TargetUser || validation.target == state.TargetEvent
 
 	if !types.IsValidPropertyPath(cond.Property) {
-		return nil, errors.New("property path is not valid")
+		return "", errors.New("property path is not valid")
 	}
 
 	p, path, err := resolveFilterProperty(validation.properties, cond.Property)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	op := cond.Operator
 	kind := p.Type.Kind()
 
 	if disallowJSON && kind == types.JSONKind {
-		return nil, fmt.Errorf("property %q has type json, which is not supported in data warehouse exports", path)
+		return "", fmt.Errorf("property %q has type json, which is not supported in data warehouse exports", path)
 	}
 
 	// Validate the operator for the property kind.
@@ -790,32 +790,32 @@ func validateFilterCondition(cond *FilterCondition, validation *filterValidation
 	case OpIs, OpIsNot:
 		switch kind {
 		case types.BooleanKind, types.ArrayKind, types.ObjectKind, types.MapKind:
-			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+			return "", fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
 		}
 	case OpIsBetween, OpIsNotBetween:
 		switch kind {
 		case types.StringKind:
 			if p.Type.Values() != nil {
-				return nil, fmt.Errorf("operator %q cannot be used with string type that has values", op)
+				return "", fmt.Errorf("operator %q cannot be used with string type that has values", op)
 			}
 		case types.BooleanKind, types.UUIDKind, types.IPKind, types.ArrayKind, types.ObjectKind, types.MapKind:
-			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+			return "", fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
 		}
 	case OpIsOneOf, OpIsNotOneOf:
 		switch kind {
 		case types.BooleanKind, types.UUIDKind, types.IPKind, types.ArrayKind, types.ObjectKind, types.MapKind:
-			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+			return "", fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
 		}
 	case OpIsLessThan, OpIsLessThanOrEqualTo, OpIsGreaterThan, OpIsGreaterThanOrEqualTo:
 		switch kind {
 		case types.StringKind:
 			if p.Type.Values() != nil {
-				return nil, fmt.Errorf("operator %q cannot be used with string type that has values", op)
+				return "", fmt.Errorf("operator %q cannot be used with string type that has values", op)
 			}
 		case types.IntKind, types.FloatKind, types.DecimalKind:
 		case types.JSONKind:
 		default:
-			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+			return "", fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
 		}
 	case OpContains, OpDoesNotContain:
 		switch kind {
@@ -823,20 +823,20 @@ func validateFilterCondition(cond *FilterCondition, validation *filterValidation
 		case types.ArrayKind:
 			switch k := p.Type.Elem().Kind(); k {
 			case types.BooleanKind, types.ArrayKind, types.ObjectKind, types.MapKind:
-				return nil, fmt.Errorf("operator %q cannot be used with array(%s) properties", op, k)
+				return "", fmt.Errorf("operator %q cannot be used with array(%s) properties", op, k)
 			}
 		default:
-			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+			return "", fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
 		}
 	case OpStartsWith, OpEndsWith:
 		switch kind {
 		case types.StringKind:
 			if p.Type.Values() != nil {
-				return nil, fmt.Errorf("operator %q cannot be used with string type that has values", op)
+				return "", fmt.Errorf("operator %q cannot be used with string type that has values", op)
 			}
 		case types.JSONKind:
 		default:
-			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+			return "", fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
 		}
 	case OpIsBefore, OpIsAfter, OpIsOnOrBefore, OpIsOnOrAfter:
 		switch kind {
@@ -844,74 +844,74 @@ func validateFilterCondition(cond *FilterCondition, validation *filterValidation
 		case types.YearKind:
 		case types.JSONKind:
 		default:
-			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+			return "", fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
 		}
 	case OpIsTrue, OpIsFalse:
 		if kind != types.BooleanKind && kind != types.JSONKind {
-			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+			return "", fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
 		}
 	case OpIsEmpty, OpIsNotEmpty:
 		switch kind {
 		case types.StringKind:
 			if values := p.Type.Values(); len(values) > 0 {
 				if !slices.Contains(values, "") {
-					return nil, fmt.Errorf("operator %q cannot be used on string properties that exclude the empty string from allowed values", op)
+					return "", fmt.Errorf("operator %q cannot be used on string properties that exclude the empty string from allowed values", op)
 				}
 			}
 		case types.JSONKind, types.ArrayKind, types.MapKind:
 		case types.ObjectKind:
 			if disallowEmptyOnObject {
 				if validation.target == state.TargetEvent {
-					return nil, fmt.Errorf("operator %q cannot be used on object properties for pipelines on events", op)
+					return "", fmt.Errorf("operator %q cannot be used on object properties for pipelines on events", op)
 				}
-				return nil, fmt.Errorf("operator %q cannot be used on object properties for destination pipelines on users", op)
+				return "", fmt.Errorf("operator %q cannot be used on object properties for destination pipelines on users", op)
 			}
 		default:
-			return nil, fmt.Errorf("operator %q can only be used with json, string, object, array, and map properties", op)
+			return "", fmt.Errorf("operator %q can only be used with json, string, object, array, and map properties", op)
 		}
 	case OpIsNull, OpIsNotNull:
 		if !p.Nullable && kind != types.JSONKind {
-			return nil, fmt.Errorf("operator %q can only be used with nullable or json properties", op)
+			return "", fmt.Errorf("operator %q can only be used with nullable or json properties", op)
 		}
 	case OpExists, OpDoesNotExist:
 		if !p.ReadOptional && path == cond.Property {
-			return nil, fmt.Errorf("operator %q can only be used with read-optional properties or with json properties that include a JSON path", op)
+			return "", fmt.Errorf("operator %q can only be used with read-optional properties or with json properties that include a JSON path", op)
 		}
 	default:
-		return nil, fmt.Errorf("operator %q is not valid", op)
+		return "", fmt.Errorf("operator %q is not valid", op)
 	}
 
 	// Validate the values.
 	switch op {
 	case OpIsTrue, OpIsFalse, OpIsEmpty, OpIsNotEmpty, OpIsNull, OpIsNotNull, OpExists, OpDoesNotExist:
 		if cond.Values != nil {
-			return nil, fmt.Errorf("values cannot be used with the operator %q", op)
+			return "", fmt.Errorf("values cannot be used with the operator %q", op)
 		}
 	default:
 		if len(cond.Values) != 1 {
-			return nil, fmt.Errorf("only one value can be used with the operator %q", op)
+			return "", fmt.Errorf("only one value can be used with the operator %q", op)
 		}
 	case OpIsBetween, OpIsNotBetween:
 		if len(cond.Values) != 2 {
-			return nil, fmt.Errorf("two values must be used with the operator %q", op)
+			return "", fmt.Errorf("two values must be used with the operator %q", op)
 		}
 	case OpIsOneOf, OpIsNotOneOf:
 		if len(cond.Values) == 0 {
-			return nil, fmt.Errorf("at least one value must be used with the operator %q", op)
+			return "", fmt.Errorf("at least one value must be used with the operator %q", op)
 		}
 	}
 	if cond.Values == nil {
-		return []string{path}, nil
+		return path, nil
 	}
 	// Handle string properties with allowed values separately.
 	if kind == types.StringKind {
 		if values := p.Type.Values(); values != nil {
 			for _, value := range cond.Values {
 				if !slices.Contains(values, value) {
-					return nil, fmt.Errorf("value of the %q property is not among the allowed values", cond.Property)
+					return "", fmt.Errorf("value of the %q property is not among the allowed values", cond.Property)
 				}
 			}
-			return []string{path}, nil
+			return path, nil
 		}
 	}
 	t := p.Type
@@ -921,7 +921,7 @@ func validateFilterCondition(cond *FilterCondition, validation *filterValidation
 	k := t.Kind()
 	for _, value := range cond.Values {
 		if err := util.ValidateStringField("condition value", value, 60); err != nil {
-			return nil, err
+			return "", err
 		}
 		var valid bool
 		switch k {
@@ -957,14 +957,14 @@ func validateFilterCondition(cond *FilterCondition, validation *filterValidation
 			_, err := netip.ParseAddr(value)
 			valid = err == nil
 		default:
-			return nil, fmt.Errorf("unexpected type for property %q", cond.Property)
+			return "", fmt.Errorf("unexpected type for property %q", cond.Property)
 		}
 		if !valid {
-			return nil, fmt.Errorf("value of the %q property is not a valid %s", cond.Property, k)
+			return "", fmt.Errorf("value of the %q property is not a valid %s", cond.Property, k)
 		}
 	}
 
-	return []string{path}, nil
+	return path, nil
 }
 
 // validateFilterGroup checks the validity of a filter group and its rules.
@@ -997,14 +997,12 @@ func validateFilterGroup(filter *Filter, validation *filterValidation, depth int
 			if rule == nil {
 				return errors.New("filter condition cannot be nil")
 			}
-			paths, err := validateFilterCondition(rule, validation)
+			path, err := validateFilterCondition(rule, validation)
 			if err != nil {
 				return err
 			}
-			for _, path := range paths {
-				if i, ok := slices.BinarySearch(validation.paths, path); !ok {
-					validation.paths = slices.Insert(validation.paths, i, path)
-				}
+			if i, ok := slices.BinarySearch(validation.paths, path); !ok {
+				validation.paths = slices.Insert(validation.paths, i, path)
 			}
 		default:
 			return errors.New("unsupported filter rule")

--- a/core/filters.go
+++ b/core/filters.go
@@ -5,6 +5,7 @@
 package core
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"net/netip"
@@ -43,18 +44,27 @@ type FilterRule interface {
 	filterRule()
 }
 
+// MarshalJSON returns the JSON representation of filter.
+func (filter *Filter) MarshalJSON() ([]byte, error) {
+	if filter == nil {
+		return nil, errors.New("filter cannot be nil")
+	}
+	var b json.Buffer
+	err := marshalFilterJSON(&b, filter)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
 // UnmarshalJSON sets filter to the filter group represented by data.
 func (filter *Filter) UnmarshalJSON(data []byte) error {
-	var value json.Value
-	if err := json.Unmarshal(data, &value); err != nil {
-		return err
-	}
-	ruleCount := 0
-	group, err := unmarshalFilterGroup(value, 1, &ruleCount)
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	group, _, err := unmarshalFilterRule(dec, 1, expectFilterGroup)
 	if err != nil {
 		return err
 	}
-	*filter = *group
+	*filter = *(group.(*Filter))
 	return nil
 }
 
@@ -99,16 +109,20 @@ type FilterCondition struct {
 	// Values.
 	// If the property has a string type with allowed values, each value must be one of the allowed values.
 	// In all other cases, each value must be at most 60 runes and must not contain the NUL byte.
-	Values []string `json:"values"`
+	Values []string `json:"values,omitzero"`
 }
 
 // MarshalJSON returns the JSON representation of condition.
-func (condition FilterCondition) MarshalJSON() ([]byte, error) {
-	if condition.Values == nil {
-		condition.Values = []string{}
+func (condition *FilterCondition) MarshalJSON() ([]byte, error) {
+	if condition == nil {
+		return nil, errors.New("filter condition cannot be nil")
 	}
-	type plainFilterCondition FilterCondition
-	return json.Marshal(plainFilterCondition(condition))
+	var b json.Buffer
+	err := marshalFilterConditionJSON(&b, condition)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 // filterRule marks FilterCondition as a filter rule.
@@ -392,6 +406,75 @@ func isFloatingPoint(s string) bool {
 	return i == len(s)
 }
 
+// marshalFilterConditionJSON appends the JSON representation of condition to
+// b.
+func marshalFilterConditionJSON(b *json.Buffer, condition *FilterCondition) error {
+	b.WriteString(`{"property":`)
+	err := b.Encode(condition.Property)
+	if err != nil {
+		return err
+	}
+	b.WriteString(`,"operator":`)
+	err = b.Encode(condition.Operator)
+	if err != nil {
+		return err
+	}
+	if condition.Values != nil {
+		b.WriteString(`,"values":[`)
+		for i, value := range condition.Values {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			err = b.Encode(value)
+			if err != nil {
+				return err
+			}
+		}
+		b.WriteByte(']')
+	}
+	b.WriteByte('}')
+	return nil
+}
+
+// marshalFilterJSON appends the JSON representation of filter to b.
+func marshalFilterJSON(b *json.Buffer, filter *Filter) error {
+	b.WriteString(`{"operator":`)
+	err := b.Encode(filter.Operator)
+	if err != nil {
+		return err
+	}
+	b.WriteString(`,"rules":[`)
+	for i, rule := range filter.Rules {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		switch rule := rule.(type) {
+		case *Filter:
+			if rule == nil {
+				return errors.New("filter group cannot be nil")
+			}
+			err = marshalFilterJSON(b, rule)
+			if err != nil {
+				return err
+			}
+		case *FilterCondition:
+			if rule == nil {
+				return errors.New("filter condition cannot be nil")
+			}
+			err = marshalFilterConditionJSON(b, rule)
+			if err != nil {
+				return err
+			}
+		case nil:
+			return errors.New("filter rule cannot be nil")
+		default:
+			return fmt.Errorf("unsupported filter rule type %T", rule)
+		}
+	}
+	b.WriteString(`]}`)
+	return nil
+}
+
 // parseInt parses an int(64) from s and returns the int(64) value and true.
 // If s is not a valid int(64), it returns 0 and false.
 func parseInt(s string) (int, bool) {
@@ -491,75 +574,141 @@ func resolveFilterProperty(properties types.Properties, path string) (types.Prop
 	return p, path, nil
 }
 
-// unmarshalFilterGroup unmarshals a filter group and returns it.
-func unmarshalFilterGroup(value json.Value, depth int, ruleCount *int) (*Filter, error) {
+// Filter rule decoding modes.
+const (
+	expectAnyFilterRule = false
+	expectFilterGroup   = true
+)
 
-	if depth > maxFilterDepth {
-		return nil, fmt.Errorf("filter exceeds maximum depth of %d", maxFilterDepth)
+// unmarshalFilterRule unmarshals a filter rule and returns it and its number of
+// descendant rules. If expectGroup is true, it accepts only a filter group.
+func unmarshalFilterRule(dec *json.Decoder, depth int, expectGroup bool) (FilterRule, int, error) {
+
+	tok, err := dec.ReadToken()
+	if err != nil {
+		return nil, 0, err
 	}
-	if !value.IsObject() {
-		return nil, errors.New("filter group must be an object")
-	}
-	if err := validateFilterJSONProperties(value, "operator", "rules"); err != nil {
-		return nil, err
-	}
-	operatorValue, hasOperator := value.Get([]string{"operator"})
-	rulesValue, hasRules := value.Get([]string{"rules"})
-	if !hasOperator || !hasRules {
-		return nil, errors.New("filter group must contain operator and rules")
-	}
-	if !rulesValue.IsArray() {
-		return nil, errors.New("filter rules must be an array")
+	if tok.Kind() != json.Object {
+		return nil, 0, errors.New("filter rule must be an object")
 	}
 
-	var operator FilterLogical
-	if err := operatorValue.Unmarshal(&operator); err != nil {
-		return nil, err
-	}
-	rules := make([]FilterRule, 0, rulesValue.NumElement())
+	var operator string
+	var property string
+	var rules []FilterRule
+	var values []string
+	var descendantRuleCount int
+	var hasOperator, hasProperty, hasRules, hasValues bool
 
-	for _, rawRule := range rulesValue.Elements() {
-		(*ruleCount)++
-		if *ruleCount > maxFilterRuleCount {
-			return nil, fmt.Errorf("filter exceeds maximum rule count of %d", maxFilterRuleCount)
+	for dec.PeekKind() != '}' {
+		tok, err = dec.ReadToken()
+		if err != nil {
+			return nil, 0, err
 		}
-		if !rawRule.IsObject() {
-			return nil, errors.New("filter rule must be an object")
-		}
-		_, isGroup := rawRule.Get([]string{"rules"})
-		_, isCondition := rawRule.Get([]string{"property"})
-		switch {
-		case isGroup && isCondition:
-			return nil, errors.New(`filter rule cannot contain both "rules" and "property"`)
-		case isGroup:
-			group, err := unmarshalFilterGroup(rawRule, depth+1, ruleCount)
-			if err != nil {
-				return nil, err
+		name := tok.String()
+		switch name {
+		case "operator":
+			if hasOperator {
+				return nil, 0, fmt.Errorf("duplicate filter property %q", name)
 			}
-			rules = append(rules, group)
-		case isCondition:
-			if err := validateFilterJSONProperties(rawRule, "property", "operator", "values"); err != nil {
-				return nil, err
+			hasOperator = true
+			err = dec.Decode(&operator)
+		case "property":
+			if hasProperty {
+				return nil, 0, fmt.Errorf("duplicate filter property %q", name)
 			}
-			_, hasConditionOperator := rawRule.Get([]string{"operator"})
-			values, hasValues := rawRule.Get([]string{"values"})
-			if !hasConditionOperator || !hasValues {
-				return nil, errors.New("filter condition must contain property, operator, and values")
+			hasProperty = true
+			if expectGroup {
+				err = dec.SkipValue()
+			} else {
+				err = dec.Decode(&property)
 			}
-			if !values.IsArray() {
-				return nil, errors.New("filter condition values must be an array")
+		case "rules":
+			if hasRules {
+				return nil, 0, fmt.Errorf("duplicate filter property %q", name)
 			}
-			var condition FilterCondition
-			if err := rawRule.Unmarshal(&condition); err != nil {
-				return nil, err
+			if depth > maxFilterDepth {
+				return nil, 0, fmt.Errorf("filter exceeds maximum depth of %d", maxFilterDepth)
 			}
-			rules = append(rules, &condition)
+			hasRules = true
+			rules, descendantRuleCount, err = unmarshalFilterRules(dec, depth)
+		case "values":
+			if hasValues {
+				return nil, 0, fmt.Errorf("duplicate filter property %q", name)
+			}
+			hasValues = true
+			if expectGroup {
+				err = dec.SkipValue()
+			} else {
+				err = dec.Decode(&values)
+			}
 		default:
-			return nil, errors.New(`filter rule must contain either "rules" or "property"`)
+			return nil, 0, fmt.Errorf("unknown filter property %q", name)
+		}
+		if err != nil {
+			return nil, 0, err
 		}
 	}
 
-	return &Filter{Operator: operator, Rules: rules}, nil
+	_ = dec.SkipToken() // skip '}'
+
+	if hasRules && hasProperty {
+		return nil, 0, errors.New(`filter rule cannot contain both "rules" and "property"`)
+	}
+	if hasRules {
+		if hasValues {
+			return nil, 0, errors.New(`unknown filter property "values"`)
+		}
+		if !hasOperator {
+			return nil, 0, errors.New("filter group must contain operator and rules")
+		}
+		return &Filter{Operator: FilterLogical(operator), Rules: rules}, descendantRuleCount, nil
+	}
+	if expectGroup {
+		if hasProperty || hasValues {
+			return nil, 0, errors.New("filter must be a group")
+		}
+		return nil, 0, errors.New("filter group must contain operator and rules")
+	}
+	if hasProperty {
+		if !hasOperator {
+			return nil, 0, errors.New("filter condition must contain property and operator")
+		}
+		return &FilterCondition{Property: property, Operator: FilterOperator(operator), Values: values}, 0, nil
+	}
+
+	return nil, 0, errors.New(`filter rule must contain either "rules" or "property"`)
+}
+
+// unmarshalFilterRules unmarshals the rules of a filter group and returns them
+// and their total rule count.
+func unmarshalFilterRules(dec *json.Decoder, depth int) ([]FilterRule, int, error) {
+
+	tok, err := dec.ReadToken()
+	if err != nil {
+		return nil, 0, err
+	}
+	if tok.Kind() != json.Array {
+		return nil, 0, errors.New("filter rules must be an array")
+	}
+
+	rules := []FilterRule{}
+	ruleCount := 0
+	for dec.PeekKind() != ']' {
+		rule, descendantRuleCount, err := unmarshalFilterRule(dec, depth+1, expectAnyFilterRule)
+		if err != nil {
+			return nil, 0, err
+		}
+		ruleCount += descendantRuleCount + 1
+		if ruleCount > maxFilterRuleCount {
+			return nil, 0, fmt.Errorf("filter exceeds maximum rule count of %d", maxFilterRuleCount)
+		}
+		rules = append(rules, rule)
+	}
+
+	// Consume ']'.
+	_ = dec.SkipToken()
+
+	return rules, ruleCount, nil
 }
 
 // validateFilter checks the validity of a filter and returns the referenced
@@ -735,7 +884,7 @@ func validateFilterCondition(cond *FilterCondition, validation *filterValidation
 	// Validate the values.
 	switch op {
 	case OpIsTrue, OpIsFalse, OpIsEmpty, OpIsNotEmpty, OpIsNull, OpIsNotNull, OpExists, OpDoesNotExist:
-		if len(cond.Values) != 0 {
+		if cond.Values != nil {
 			return nil, fmt.Errorf("values cannot be used with the operator %q", op)
 		}
 	default:
@@ -751,7 +900,7 @@ func validateFilterCondition(cond *FilterCondition, validation *filterValidation
 			return nil, fmt.Errorf("at least one value must be used with the operator %q", op)
 		}
 	}
-	if len(cond.Values) == 0 {
+	if cond.Values == nil {
 		return []string{path}, nil
 	}
 	// Handle string properties with allowed values separately.
@@ -862,16 +1011,5 @@ func validateFilterGroup(filter *Filter, validation *filterValidation, depth int
 		}
 	}
 
-	return nil
-}
-
-// validateFilterJSONProperties checks that value contains only the provided
-// properties.
-func validateFilterJSONProperties(value json.Value, properties ...string) error {
-	for property := range value.Properties() {
-		if !slices.Contains(properties, property) {
-			return fmt.Errorf("unknown filter property %q", property)
-		}
-	}
 	return nil
 }

--- a/core/filters.go
+++ b/core/filters.go
@@ -5,7 +5,6 @@
 package core
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"net/netip"
@@ -18,16 +17,49 @@ import (
 	"github.com/krenalis/krenalis/core/internal/state"
 	"github.com/krenalis/krenalis/core/internal/util"
 	"github.com/krenalis/krenalis/tools/decimal"
+	"github.com/krenalis/krenalis/tools/errors"
+	"github.com/krenalis/krenalis/tools/json"
 	"github.com/krenalis/krenalis/tools/types"
 
 	"github.com/relvacode/iso8601"
 )
 
-// Filter represents a filter.
+// Filter complexity limits.
+const (
+	maxFilterDepth     = 4
+	maxFilterRuleCount = 100
+)
+
+// Filter represents a logical expression whose rules are combined
+// using AND or OR.
 type Filter struct {
-	Logical    FilterLogical     `json:"logical"`    // can be OpAnd or OpOr.
-	Conditions []FilterCondition `json:"conditions"` // cannot be empty.
+	Operator FilterLogical `json:"operator"`
+	Rules    []FilterRule  `json:"rules"`
 }
+
+// FilterRule represents a condition or a nested filter group.
+// It is implemented by *FilterCondition and *Filter.
+type FilterRule interface {
+	filterRule()
+}
+
+// UnmarshalJSON sets filter to the filter group represented by data.
+func (filter *Filter) UnmarshalJSON(data []byte) error {
+	var value json.Value
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	ruleCount := 0
+	group, err := unmarshalFilterGroup(value, 1, &ruleCount)
+	if err != nil {
+		return err
+	}
+	*filter = *group
+	return nil
+}
+
+// filterRule marks Filter as a filter rule.
+func (*Filter) filterRule() {}
 
 // FilterLogical represents the logical operator of a filter.
 // It can be OpAnd or OpOr.
@@ -40,7 +72,7 @@ const (
 
 // convertLogicalToWhere converts a filter logical operator into a where logical
 // operator.
-func convertFilterLogicalToWhere(op FilterLogical) state.WhereLogical {
+func convertLogicalToWhere(op FilterLogical) state.WhereLogical {
 	if op == OpAnd {
 		return state.OpAnd
 	}
@@ -65,12 +97,22 @@ type FilterCondition struct {
 	Operator FilterOperator `json:"operator"`
 
 	// Values.
-	// If the property has a string type with allowed values,
-	// the unique value of values must be one of the allowed values.
-	// In all other cases, each value must be at most 60 runes and must not
-	// contain the NUL byte.
-	Values []string `json:"values,omitzero"`
+	// If the property has a string type with allowed values, each value must be one of the allowed values.
+	// In all other cases, each value must be at most 60 runes and must not contain the NUL byte.
+	Values []string `json:"values"`
 }
+
+// MarshalJSON returns the JSON representation of condition.
+func (condition FilterCondition) MarshalJSON() ([]byte, error) {
+	if condition.Values == nil {
+		condition.Values = []string{}
+	}
+	type plainFilterCondition FilterCondition
+	return json.Marshal(plainFilterCondition(condition))
+}
+
+// filterRule marks FilterCondition as a filter rule.
+func (*FilterCondition) filterRule() {}
 
 // FilterOperator represents a filter condition operator.
 type FilterOperator string
@@ -112,30 +154,45 @@ var operators = [...]FilterOperator{
 	OpExists, OpDoesNotExist,
 }
 
+// filterValidation contains the state shared while validating a filter tree.
+type filterValidation struct {
+	paths      []string
+	properties types.Properties
+	role       state.Role
+	ruleCount  int
+	target     state.Target
+}
+
 // convertOperatorFromWhere converts a where operator into a filter operator.
 func convertOperatorFromWhere(op state.WhereOperator) FilterOperator {
 	return operators[op]
 }
 
-// convertOperatorFromWhere converts a filter operator into a where operator.
+// convertOperatorToWhere converts a filter operator into a where operator.
 func convertOperatorToWhere(op FilterOperator) state.WhereOperator {
 	return state.WhereOperator(slices.Index(operators[:], op))
 }
 
 // convertFilterToWhere converts the provided filter into a where.
 // The filter must have been validated using the validateFilter function with
-// the same schema.
-// Panics if the filter is nil or the schema is not valid.
+// the same schema. Panics if the filter is nil or the schema is not valid.
 func convertFilterToWhere(filter *Filter, schema types.Type) *state.Where {
+
 	where := &state.Where{
-		Logical:    convertFilterLogicalToWhere(filter.Logical),
-		Conditions: make([]state.WhereCondition, len(filter.Conditions)),
+		Operator: convertLogicalToWhere(filter.Operator),
+		Rules:    make([]state.WhereRule, len(filter.Rules)),
 	}
 	properties := schema.Properties()
-	for i, cond := range filter.Conditions {
-		p, _, _ := retrieveFilterProperty(properties, cond.Property)
+
+	for i, rule := range filter.Rules {
+		if group, ok := rule.(*Filter); ok {
+			where.Rules[i] = convertFilterToWhere(group, schema)
+			continue
+		}
+		cond := rule.(*FilterCondition)
+		p, _, _ := resolveFilterProperty(properties, cond.Property)
 		var values []any
-		if cond.Values != nil {
+		if len(cond.Values) > 0 {
 			values = make([]any, len(cond.Values))
 		}
 		t := p.Type
@@ -184,26 +241,34 @@ func convertFilterToWhere(filter *Filter, schema types.Type) *state.Where {
 			}
 			values[i] = v
 		}
-		where.Conditions[i] = state.WhereCondition{
+		where.Rules[i] = &state.WhereCondition{
 			Property: strings.Split(cond.Property, "."),
 			Operator: convertOperatorToWhere(cond.Operator),
 			Values:   values,
 		}
 	}
+
 	return where
 }
 
 // convertWhereToFilter converts the provided where into a filter.
 // Panics if where is nil or the schema is not valid.
 func convertWhereToFilter(where *state.Where, schema types.Type) *Filter {
+
 	filter := &Filter{
-		Logical:    convertLogicalFromWhere(where.Logical),
-		Conditions: make([]FilterCondition, len(where.Conditions)),
+		Operator: convertLogicalFromWhere(where.Operator),
+		Rules:    make([]FilterRule, len(where.Rules)),
 	}
 	properties := schema.Properties()
-	for i, cond := range where.Conditions {
+
+	for i, rule := range where.Rules {
+		if group, ok := rule.(*state.Where); ok {
+			filter.Rules[i] = convertWhereToFilter(group, schema)
+			continue
+		}
+		cond := rule.(*state.WhereCondition)
 		var values []string
-		if cond.Values != nil {
+		if len(cond.Values) > 0 {
 			values = make([]string, len(cond.Values))
 		}
 		for i, value := range cond.Values {
@@ -237,12 +302,13 @@ func convertWhereToFilter(where *state.Where, schema types.Type) *Filter {
 			}
 			values[i] = v
 		}
-		filter.Conditions[i] = FilterCondition{
+		filter.Rules[i] = &FilterCondition{
 			Property: strings.Join(cond.Property, "."),
 			Operator: convertOperatorFromWhere(cond.Operator),
 			Values:   values,
 		}
 	}
+
 	return filter
 }
 
@@ -404,11 +470,12 @@ func parseYear(s string) (int, bool) {
 	return year, true
 }
 
-// retrieveFilterProperty retrieves a property in properties, located at a
-// specific path and returns the property along with its path. If the path
-// points to a json property, it returns the path to that json property.
-// path must be a valid property path.
-func retrieveFilterProperty(properties types.Properties, path string) (types.Property, string, error) {
+// resolveFilterProperty resolves path against properties.
+//
+// It returns the property at path and its schema path or, if path extends into
+// a JSON property, that JSON property and its schema path. path must be a valid
+// property path.
+func resolveFilterProperty(properties types.Properties, path string) (types.Property, string, error) {
 	p, err := properties.ByPath(path)
 	if err != nil {
 		if p.Type.Kind() != types.JSONKind {
@@ -424,263 +491,387 @@ func retrieveFilterProperty(properties types.Properties, path string) (types.Pro
 	return p, path, nil
 }
 
-// validateFilter checks the validity of a filter and returns its properties.
+// unmarshalFilterGroup unmarshals a filter group and returns it.
+func unmarshalFilterGroup(value json.Value, depth int, ruleCount *int) (*Filter, error) {
+
+	if depth > maxFilterDepth {
+		return nil, fmt.Errorf("filter exceeds maximum depth of %d", maxFilterDepth)
+	}
+	if !value.IsObject() {
+		return nil, errors.New("filter group must be an object")
+	}
+	if err := validateFilterJSONProperties(value, "operator", "rules"); err != nil {
+		return nil, err
+	}
+	operatorValue, hasOperator := value.Get([]string{"operator"})
+	rulesValue, hasRules := value.Get([]string{"rules"})
+	if !hasOperator || !hasRules {
+		return nil, errors.New("filter group must contain operator and rules")
+	}
+	if !rulesValue.IsArray() {
+		return nil, errors.New("filter rules must be an array")
+	}
+
+	var operator FilterLogical
+	if err := operatorValue.Unmarshal(&operator); err != nil {
+		return nil, err
+	}
+	rules := make([]FilterRule, 0, rulesValue.NumElement())
+
+	for _, rawRule := range rulesValue.Elements() {
+		(*ruleCount)++
+		if *ruleCount > maxFilterRuleCount {
+			return nil, fmt.Errorf("filter exceeds maximum rule count of %d", maxFilterRuleCount)
+		}
+		if !rawRule.IsObject() {
+			return nil, errors.New("filter rule must be an object")
+		}
+		_, isGroup := rawRule.Get([]string{"rules"})
+		_, isCondition := rawRule.Get([]string{"property"})
+		switch {
+		case isGroup && isCondition:
+			return nil, errors.New(`filter rule cannot contain both "rules" and "property"`)
+		case isGroup:
+			group, err := unmarshalFilterGroup(rawRule, depth+1, ruleCount)
+			if err != nil {
+				return nil, err
+			}
+			rules = append(rules, group)
+		case isCondition:
+			if err := validateFilterJSONProperties(rawRule, "property", "operator", "values"); err != nil {
+				return nil, err
+			}
+			_, hasConditionOperator := rawRule.Get([]string{"operator"})
+			values, hasValues := rawRule.Get([]string{"values"})
+			if !hasConditionOperator || !hasValues {
+				return nil, errors.New("filter condition must contain property, operator, and values")
+			}
+			if !values.IsArray() {
+				return nil, errors.New("filter condition values must be an array")
+			}
+			var condition FilterCondition
+			if err := rawRule.Unmarshal(&condition); err != nil {
+				return nil, err
+			}
+			rules = append(rules, &condition)
+		default:
+			return nil, errors.New(`filter rule must contain either "rules" or "property"`)
+		}
+	}
+
+	return &Filter{Operator: operator, Rules: rules}, nil
+}
+
+// validateFilter checks the validity of a filter and returns the referenced
+// property paths.
 // Returns an error if the filter is not valid. Specifically, it returns a
 // types.PathNotExistError if a path does not exist.
 // Panics if the filter is nil or the schema is not valid.
 func validateFilter(filter *Filter, schema types.Type, role state.Role, target state.Target) ([]string, error) {
-
-	// disallowJSON indicates if "json" properties are disallowed.
-	disallowJSON := role == state.Destination && target == state.TargetUser
-
-	// disallowEmptyOnObject indicates if "is empty" and "is not empty" operators are disallowed on object properties.
-	disallowEmptyOnObject := role == state.Destination && target == state.TargetUser || target == state.TargetEvent
-
-	if op := filter.Logical; op != OpAnd && op != OpOr {
-		return nil, fmt.Errorf("invalid logical operator %q", op)
+	validation := filterValidation{properties: schema.Properties(), role: role, target: target}
+	if err := validateFilterGroup(filter, &validation, 1); err != nil {
+		return nil, err
 	}
-	if len(filter.Conditions) == 0 {
-		return nil, errors.New("conditions are missing")
+	return validation.paths, nil
+}
+
+// validateFilterCondition checks the validity of a filter condition and
+// returns its property path.
+func validateFilterCondition(cond *FilterCondition, validation *filterValidation) ([]string, error) {
+
+	// disallowJSON indicates whether JSON properties are disallowed.
+	disallowJSON := validation.role == state.Destination && validation.target == state.TargetUser
+
+	// disallowEmptyOnObject indicates whether the "is empty" and "is not empty"
+	// operators are disallowed on object properties.
+	disallowEmptyOnObject := validation.role == state.Destination && validation.target == state.TargetUser || validation.target == state.TargetEvent
+
+	if !types.IsValidPropertyPath(cond.Property) {
+		return nil, errors.New("property path is not valid")
 	}
 
-	var pp []string
-	properties := schema.Properties()
+	p, path, err := resolveFilterProperty(validation.properties, cond.Property)
+	if err != nil {
+		return nil, err
+	}
 
-	for _, cond := range filter.Conditions {
+	op := cond.Operator
+	kind := p.Type.Kind()
 
-		if !types.IsValidPropertyPath(cond.Property) {
-			return nil, errors.New("property path is not valid")
+	if disallowJSON && kind == types.JSONKind {
+		return nil, fmt.Errorf("property %q has type json, which is not supported in data warehouse exports", path)
+	}
+
+	// Validate the operator for the property kind.
+	//
+	// is                          : int, float, decimal, datetime, date, time, year, uuid, json, ip, string
+	// is not                      : int, float, decimal, datetime, date, time, year, uuid, json, ip, string
+	// is less than                : int, float, decimal, json, string [^1]
+	// is less than or equal to    : int, float, decimal, json, string [^1]
+	// is greater than             : int, float, decimal, json, string [^1]
+	// is greater than or equal to : int, float, decimal, json, string [^1]
+	// is between                  : int, float, decimal, year, datetime, date, time, json, string [^1]
+	// is not between              : int, float, decimal, year, datetime, date, time, json, string [^1]
+	// contains                    : json, string, array [^2]
+	// does not contain            : json, string, array [^2]
+	// is one of                   : int, float, decimal, year, datetime, date, time, json, string
+	// is not one of               : int, float, decimal, year, datetime, date, time, json, string
+	// starts with                 : json, string [^1]
+	// ends with                   : json, string [^1]
+	// is before                   : datetime, date, time, year
+	// is on or before             : datetime, date, time, year
+	// is after                    : datetime, date, time, year
+	// is on or after              : datetime, date, time, year
+	// is true                     : boolean, json
+	// is false                    : boolean, json
+	// is empty                    : json, string, object, array, map [^3]
+	// is not empty                : json, string, object, array, map [^3]
+	// is null                     : All types [^4]
+	// is not null                 : All types [^4]
+	// exists                      : All types [^5]
+	// does not exist              : All types [^5]
+	//
+	// [1]: Strings with allowed values are not supported.
+	// [2]: array(T) is supported if T is supported by the "is" operator.
+	// [3]: Object properties are not supported for destination pipelines on users or for pipelines on events.
+	// [4]: Only if the property is nullable or has type JSON.
+	// [5]: Only if the property is read-optional or the path continues inside a JSON property.
+	//
+	switch op {
+	case OpIs, OpIsNot:
+		switch kind {
+		case types.BooleanKind, types.ArrayKind, types.ObjectKind, types.MapKind:
+			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
 		}
+	case OpIsBetween, OpIsNotBetween:
+		switch kind {
+		case types.StringKind:
+			if p.Type.Values() != nil {
+				return nil, fmt.Errorf("operator %q cannot be used with string type that has values", op)
+			}
+		case types.BooleanKind, types.UUIDKind, types.IPKind, types.ArrayKind, types.ObjectKind, types.MapKind:
+			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+		}
+	case OpIsOneOf, OpIsNotOneOf:
+		switch kind {
+		case types.BooleanKind, types.UUIDKind, types.IPKind, types.ArrayKind, types.ObjectKind, types.MapKind:
+			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+		}
+	case OpIsLessThan, OpIsLessThanOrEqualTo, OpIsGreaterThan, OpIsGreaterThanOrEqualTo:
+		switch kind {
+		case types.StringKind:
+			if p.Type.Values() != nil {
+				return nil, fmt.Errorf("operator %q cannot be used with string type that has values", op)
+			}
+		case types.IntKind, types.FloatKind, types.DecimalKind:
+		case types.JSONKind:
+		default:
+			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+		}
+	case OpContains, OpDoesNotContain:
+		switch kind {
+		case types.StringKind, types.JSONKind:
+		case types.ArrayKind:
+			switch k := p.Type.Elem().Kind(); k {
+			case types.BooleanKind, types.ArrayKind, types.ObjectKind, types.MapKind:
+				return nil, fmt.Errorf("operator %q cannot be used with array(%s) properties", op, k)
+			}
+		default:
+			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+		}
+	case OpStartsWith, OpEndsWith:
+		switch kind {
+		case types.StringKind:
+			if p.Type.Values() != nil {
+				return nil, fmt.Errorf("operator %q cannot be used with string type that has values", op)
+			}
+		case types.JSONKind:
+		default:
+			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+		}
+	case OpIsBefore, OpIsAfter, OpIsOnOrBefore, OpIsOnOrAfter:
+		switch kind {
+		case types.DateTimeKind, types.DateKind, types.TimeKind:
+		case types.YearKind:
+		case types.JSONKind:
+		default:
+			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+		}
+	case OpIsTrue, OpIsFalse:
+		if kind != types.BooleanKind && kind != types.JSONKind {
+			return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+		}
+	case OpIsEmpty, OpIsNotEmpty:
+		switch kind {
+		case types.StringKind:
+			if values := p.Type.Values(); len(values) > 0 {
+				if !slices.Contains(values, "") {
+					return nil, fmt.Errorf("operator %q cannot be used on string properties that exclude the empty string from allowed values", op)
+				}
+			}
+		case types.JSONKind, types.ArrayKind, types.MapKind:
+		case types.ObjectKind:
+			if disallowEmptyOnObject {
+				if validation.target == state.TargetEvent {
+					return nil, fmt.Errorf("operator %q cannot be used on object properties for pipelines on events", op)
+				}
+				return nil, fmt.Errorf("operator %q cannot be used on object properties for destination pipelines on users", op)
+			}
+		default:
+			return nil, fmt.Errorf("operator %q can only be used with json, string, object, array, and map properties", op)
+		}
+	case OpIsNull, OpIsNotNull:
+		if !p.Nullable && kind != types.JSONKind {
+			return nil, fmt.Errorf("operator %q can only be used with nullable or json properties", op)
+		}
+	case OpExists, OpDoesNotExist:
+		if !p.ReadOptional && path == cond.Property {
+			return nil, fmt.Errorf("operator %q can only be used with read-optional properties or with json properties that include a JSON path", op)
+		}
+	default:
+		return nil, fmt.Errorf("operator %q is not valid", op)
+	}
 
-		p, path, err := retrieveFilterProperty(properties, cond.Property)
-		if err != nil {
+	// Validate the values.
+	switch op {
+	case OpIsTrue, OpIsFalse, OpIsEmpty, OpIsNotEmpty, OpIsNull, OpIsNotNull, OpExists, OpDoesNotExist:
+		if len(cond.Values) != 0 {
+			return nil, fmt.Errorf("values cannot be used with the operator %q", op)
+		}
+	default:
+		if len(cond.Values) != 1 {
+			return nil, fmt.Errorf("only one value can be used with the operator %q", op)
+		}
+	case OpIsBetween, OpIsNotBetween:
+		if len(cond.Values) != 2 {
+			return nil, fmt.Errorf("two values must be used with the operator %q", op)
+		}
+	case OpIsOneOf, OpIsNotOneOf:
+		if len(cond.Values) == 0 {
+			return nil, fmt.Errorf("at least one value must be used with the operator %q", op)
+		}
+	}
+	if len(cond.Values) == 0 {
+		return []string{path}, nil
+	}
+	// Handle string properties with allowed values separately.
+	if kind == types.StringKind {
+		if values := p.Type.Values(); values != nil {
+			for _, value := range cond.Values {
+				if !slices.Contains(values, value) {
+					return nil, fmt.Errorf("value of the %q property is not among the allowed values", cond.Property)
+				}
+			}
+			return []string{path}, nil
+		}
+	}
+	t := p.Type
+	if t.Kind() == types.ArrayKind {
+		t = t.Elem()
+	}
+	k := t.Kind()
+	for _, value := range cond.Values {
+		if err := util.ValidateStringField("condition value", value, 60); err != nil {
 			return nil, err
 		}
-
-		if i, ok := slices.BinarySearch(pp, path); !ok {
-			pp = slices.Insert(pp, i, path)
-		}
-
-		op := cond.Operator
-		kind := p.Type.Kind()
-
-		if disallowJSON && kind == types.JSONKind {
-			return nil, fmt.Errorf("property %q has type json, which is not supported in data warehouse exports", path)
-		}
-
-		// Validate the operator and its kind.
-		//
-		// is                          : int, float, decimal, datetime, date, time, year, uuid, json, ip, string
-		// is not                      : int, float, decimal, datetime, date, time, year, uuid, json, ip, string
-		// is less than                : int, float, decimal, json, string [^1]
-		// is less than or equal to    : int, float, decimal, json, string [^1]
-		// is greater than             : int, float, decimal, json, string [^1]
-		// is greater than or equal to : int, float, decimal, json, string [^1]
-		// is between                  : int, float, decimal, year, datetime, date, time, json, string [^1]
-		// is not between              : int, float, decimal, year, datetime, date, time, json, string [^1]
-		// contains                    : json, string, array [^2]
-		// does not contain            : json, string, array [^2]
-		// is one of                   : int, float, decimal, year, datetime, date, time, json, string
-		// is not one of               : int, float, decimal, year, datetime, date, time, json, string
-		// starts with                 : json, string [^1]
-		// ends with                   : json, string [^1]
-		// is before                   : datetime, date, time, year
-		// is on or before             : datetime, date, time, year
-		// is after                    : datetime, date, time, year
-		// is on or after              : datetime, date, time, year
-		// is true                     : boolean, json
-		// is false                    : boolean, json
-		// is empty                    : json, string, object, array, map [^3]
-		// is not empty                : json, string, object, array, map [^3]
-		// is null                     : All types [^4]
-		// is not null                 : All types [^4]
-		// exists                      : All types [^5]
-		// does not exist              : All types [^5]
-		//
-		// [1]: string with values is not supported.
-		// [2]: array(T) is supported if T is a type that is supported by the 'is' operator.
-		// [3]: object is disallowed on users when role is destination and on events.
-		// [4]: only if the property is nullable or 'json'.
-		// [5]: only if the property is read-optional or 'json' with a non-empty path.
-		//
-		switch op {
-		case OpIs, OpIsNot:
-			switch kind {
-			case types.BooleanKind, types.ArrayKind, types.ObjectKind, types.MapKind:
-				return nil, fmt.Errorf("operator %q cannot be used with boolean properties", op)
+		var valid bool
+		switch k {
+		case types.StringKind, types.JSONKind:
+			valid = utf8.ValidString(value)
+		case types.IntKind:
+			if t.IsUnsigned() {
+				_, valid = parseUnsigned(value)
+			} else {
+				_, valid = parseInt(value)
 			}
-		case OpIsBetween, OpIsNotBetween:
-			switch kind {
-			case types.StringKind:
-				if p.Type.Values() != nil {
-					return nil, fmt.Errorf("operator %q cannot be used with string type that has values", op)
-				}
-			case types.BooleanKind, types.UUIDKind, types.IPKind, types.ArrayKind, types.ObjectKind, types.MapKind:
-				return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+		case types.FloatKind:
+			_, valid = parseFloat(value, t.BitSize())
+		case types.DecimalKind:
+			_, valid = parseDecimal(value)
+		case types.DateTimeKind:
+			if t, err := iso8601.ParseString(value); err == nil {
+				y := t.UTC().Year()
+				valid = types.MinYear <= y && y <= types.MaxYear
 			}
-		case OpIsOneOf, OpIsNotOneOf:
-			switch kind {
-			case types.BooleanKind, types.UUIDKind, types.IPKind, types.ArrayKind, types.ObjectKind, types.MapKind:
-				return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
+		case types.DateKind:
+			if t, err := time.Parse(time.DateOnly, value); err == nil {
+				y := t.UTC().Year()
+				valid = types.MinYear <= y && y <= types.MaxYear
 			}
-		case OpIsLessThan, OpIsLessThanOrEqualTo, OpIsGreaterThan, OpIsGreaterThanOrEqualTo:
-			switch kind {
-			case types.StringKind:
-				if p.Type.Values() != nil {
-					return nil, fmt.Errorf("operator %q cannot be used with string type that has values", op)
-				}
-			case types.IntKind, types.FloatKind, types.DecimalKind:
-			case types.JSONKind:
-			default:
-				return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
-			}
-		case OpContains, OpDoesNotContain:
-			switch kind {
-			case types.StringKind, types.JSONKind:
-			case types.ArrayKind:
-				switch k := p.Type.Elem().Kind(); k {
-				case types.BooleanKind, types.ArrayKind, types.ObjectKind, types.MapKind:
-					return nil, fmt.Errorf("operator %q cannot be used with array(%s) properties", op, k)
-				}
-			default:
-				return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
-			}
-		case OpStartsWith, OpEndsWith:
-			switch kind {
-			case types.StringKind:
-				if p.Type.Values() != nil {
-					return nil, fmt.Errorf("operator %q cannot be used with string type that has values", op)
-				}
-			case types.JSONKind:
-			default:
-				return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
-			}
-		case OpIsBefore, OpIsAfter, OpIsOnOrBefore, OpIsOnOrAfter:
-			switch kind {
-			case types.DateTimeKind, types.DateKind, types.TimeKind:
-			case types.YearKind:
-			case types.JSONKind:
-			default:
-				return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
-			}
-		case OpIsTrue, OpIsFalse:
-			if kind != types.BooleanKind && kind != types.JSONKind {
-				return nil, fmt.Errorf("operator %q cannot be used with %s properties", op, kind)
-			}
-		case OpIsEmpty, OpIsNotEmpty:
-			switch kind {
-			case types.StringKind:
-				if values := p.Type.Values(); len(values) > 0 {
-					if !slices.Contains(values, "") {
-						return nil, fmt.Errorf("operator %q cannot be used on string properties that exclude the empty string from allowed values", op)
-					}
-				}
-			case types.JSONKind, types.ArrayKind, types.MapKind:
-			case types.ObjectKind:
-				if disallowEmptyOnObject {
-					if target == state.TargetEvent {
-						return nil, fmt.Errorf("operator %q cannot be used on object properties for pipelines on events", op)
-					}
-					return nil, fmt.Errorf("operator %q cannot be used on object properties for destination pipelines on users", op)
-				}
-			default:
-				return nil, fmt.Errorf("operator %q can only be used with json, string, object, array, and map properties", op)
-			}
-		case OpIsNull, OpIsNotNull:
-			if !p.Nullable && kind != types.JSONKind {
-				return nil, fmt.Errorf("operator %q can only be used with nullable or json properties", op)
-			}
-		case OpExists, OpDoesNotExist:
-			if !p.ReadOptional && path == cond.Property {
-				return nil, fmt.Errorf("operator %q can only be used with read-optional properties or with json properties that include a JSON path", op)
-			}
+		case types.TimeKind:
+			_, valid = util.ParseTime(value)
+		case types.YearKind:
+			_, valid = parseYear(value)
+		case types.UUIDKind:
+			_, valid = types.ParseUUID(value)
+		case types.IPKind:
+			_, err := netip.ParseAddr(value)
+			valid = err == nil
 		default:
-			return nil, fmt.Errorf("operator %q is not valid", op)
+			return nil, fmt.Errorf("unexpected type for property %q", cond.Property)
 		}
-
-		// Validate the values.
-		switch op {
-		case OpIsTrue, OpIsFalse, OpIsEmpty, OpIsNotEmpty, OpIsNull, OpIsNotNull, OpExists, OpDoesNotExist:
-			if cond.Values != nil {
-				return nil, fmt.Errorf("values cannot be used with the operator %q", op)
-			}
-		default:
-			if len(cond.Values) != 1 {
-				return nil, fmt.Errorf("only one value can be used with the operator %q", op)
-			}
-		case OpIsBetween, OpIsNotBetween:
-			if len(cond.Values) != 2 {
-				return nil, fmt.Errorf("two values must be used with the operator %q", op)
-			}
-		case OpIsOneOf, OpIsNotOneOf:
-			if len(cond.Values) == 0 {
-				return nil, fmt.Errorf("at least one value must be used with the operator %q", op)
-			}
-		}
-		if cond.Values == nil {
-			continue
-		}
-		// Handles separately the string type case with allowed values.
-		if kind == types.StringKind {
-			if values := p.Type.Values(); values != nil {
-				for _, value := range cond.Values {
-					if !slices.Contains(values, value) {
-						return nil, fmt.Errorf("value of the %q property is not among the allowed values", cond.Property)
-					}
-				}
-				continue
-			}
-		}
-		t := p.Type
-		if t.Kind() == types.ArrayKind {
-			t = t.Elem()
-		}
-		k := t.Kind()
-		for _, value := range cond.Values {
-			if err := util.ValidateStringField("condition value", value, 60); err != nil {
-				return nil, err
-			}
-			var valid bool
-			switch k {
-			case types.StringKind, types.JSONKind:
-				valid = utf8.ValidString(value)
-			case types.IntKind:
-				if t.IsUnsigned() {
-					_, valid = parseUnsigned(value)
-				} else {
-					_, valid = parseInt(value)
-				}
-			case types.FloatKind:
-				_, valid = parseFloat(value, t.BitSize())
-			case types.DecimalKind:
-				_, valid = parseDecimal(value)
-			case types.DateTimeKind:
-				if t, err := iso8601.ParseString(value); err == nil {
-					y := t.UTC().Year()
-					valid = types.MinYear <= y && y <= types.MaxYear
-				}
-			case types.DateKind:
-				if t, err := time.Parse(time.DateOnly, value); err == nil {
-					y := t.UTC().Year()
-					valid = types.MinYear <= y && y <= types.MaxYear
-				}
-			case types.TimeKind:
-				_, valid = util.ParseTime(value)
-			case types.YearKind:
-				_, valid = parseYear(value)
-			case types.UUIDKind:
-				_, valid = types.ParseUUID(value)
-			case types.IPKind:
-				_, err := netip.ParseAddr(value)
-				valid = err == nil
-			default:
-				return nil, fmt.Errorf("unexpected type for property %q", cond.Property)
-			}
-			if !valid {
-				return nil, fmt.Errorf("value of the %q property is not a valid %s", cond.Property, k)
-			}
+		if !valid {
+			return nil, fmt.Errorf("value of the %q property is not a valid %s", cond.Property, k)
 		}
 	}
 
-	return pp, nil
+	return []string{path}, nil
+}
+
+// validateFilterGroup checks the validity of a filter group and its rules.
+func validateFilterGroup(filter *Filter, validation *filterValidation, depth int) error {
+
+	if depth > maxFilterDepth {
+		return fmt.Errorf("filter exceeds maximum depth of %d", maxFilterDepth)
+	}
+	if op := filter.Operator; op != OpAnd && op != OpOr {
+		return fmt.Errorf("invalid logical operator %q", op)
+	}
+	if len(filter.Rules) == 0 {
+		return errors.New("rules are missing")
+	}
+
+	for _, rule := range filter.Rules {
+		validation.ruleCount++
+		if validation.ruleCount > maxFilterRuleCount {
+			return fmt.Errorf("filter exceeds maximum rule count of %d", maxFilterRuleCount)
+		}
+		switch rule := rule.(type) {
+		case *Filter:
+			if rule == nil {
+				return errors.New("filter group cannot be nil")
+			}
+			if err := validateFilterGroup(rule, validation, depth+1); err != nil {
+				return err
+			}
+		case *FilterCondition:
+			if rule == nil {
+				return errors.New("filter condition cannot be nil")
+			}
+			paths, err := validateFilterCondition(rule, validation)
+			if err != nil {
+				return err
+			}
+			for _, path := range paths {
+				if i, ok := slices.BinarySearch(validation.paths, path); !ok {
+					validation.paths = slices.Insert(validation.paths, i, path)
+				}
+			}
+		default:
+			return errors.New("unsupported filter rule")
+		}
+	}
+
+	return nil
+}
+
+// validateFilterJSONProperties checks that value contains only the provided
+// properties.
+func validateFilterJSONProperties(value json.Value, properties ...string) error {
+	for property := range value.Properties() {
+		if !slices.Contains(properties, property) {
+			return fmt.Errorf("unknown filter property %q", property)
+		}
+	}
+	return nil
 }

--- a/core/filters_test.go
+++ b/core/filters_test.go
@@ -5,7 +5,7 @@
 package core
 
 import (
-	"errors"
+	"bytes"
 	"fmt"
 	"math"
 	"reflect"
@@ -15,11 +15,144 @@ import (
 
 	"github.com/krenalis/krenalis/core/internal/state"
 	"github.com/krenalis/krenalis/tools/decimal"
+	"github.com/krenalis/krenalis/tools/errors"
+	"github.com/krenalis/krenalis/tools/json"
 	"github.com/krenalis/krenalis/tools/types"
 
 	"github.com/google/go-cmp/cmp"
 )
 
+// Test_Filter_JSON verifies the recursive filter JSON representation.
+func Test_Filter_JSON(t *testing.T) {
+
+	data := []byte(`{"operator":"and","rules":[` +
+		`{"property":"a","operator":"is","values":["5"]},` +
+		`{"operator":"or","rules":[` +
+		`{"property":"b","operator":"is null","values":[]},` +
+		`{"property":"c","operator":"is one of","values":["x","y"]}` +
+		`]}` +
+		`]}`)
+	var filter Filter
+	if err := json.Unmarshal(data, &filter); err != nil {
+		t.Fatalf("unexpected error %q", err)
+	}
+	expected := Filter{
+		Operator: OpAnd,
+		Rules: []FilterRule{
+			&FilterCondition{Property: "a", Operator: OpIs, Values: []string{"5"}},
+			&Filter{
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpIsNull, Values: []string{}},
+					&FilterCondition{Property: "c", Operator: OpIsOneOf, Values: []string{"x", "y"}},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(&expected, &filter); diff != "" {
+		t.Fatalf("unexpected filter (-want +got):\n%s", diff)
+	}
+	got, err := json.Marshal(&filter)
+	if err != nil {
+		t.Fatalf("unexpected error %q", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("expected %s, got %s", data, got)
+	}
+
+	var encoded bytes.Buffer
+	err = json.Encode(&encoded, &Filter{
+		Operator: OpAnd,
+		Rules: []FilterRule{
+			&FilterCondition{Property: "a", Operator: OpIsNull},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error %q", err)
+	}
+	const unary = `{"operator":"and","rules":[{"property":"a","operator":"is null","values":[]}]}`
+	if encoded.String() != unary {
+		t.Fatalf("expected %s, got %s", unary, encoded.String())
+	}
+
+}
+
+// Test_Filter_UnmarshalJSONRejectsInvalidStructure verifies structural
+// validation while decoding filters.
+func Test_Filter_UnmarshalJSONRejectsInvalidStructure(t *testing.T) {
+
+	tests := []string{
+		`[]`,
+		`{"operator":"and","rules":"invalid"}`,
+		`{"operator":"and","rules":[true]}`,
+		`{"operator":"and","rules":[{"rules":[]}]}`,
+		`{"operator":"and","rules":[{"operator":"or","rules":[],"property":"a"}]}`,
+		`{"operator":"and","rules":[{}]}`,
+		`{"operator":"and","rules":[{"property":"a","operator":"is"}]}`,
+		`{"operator":"and","rules":[{"property":"a","operator":"is","values":null}]}`,
+		`{"operator":"and","rules":[{"property":"a","operator":"is","values":["1"],"extra":true}]}`,
+		`{"operator":"and","rules":[],"logical":"and"}`,
+	}
+	for _, data := range tests {
+		t.Run(data, func(t *testing.T) {
+			var filter Filter
+			if err := json.Unmarshal([]byte(data), &filter); err == nil {
+				t.Fatal("expected error, got no error")
+			}
+		})
+	}
+}
+
+// Test_Filter_UnmarshalJSONLimits verifies filter complexity limits while
+// decoding JSON.
+func Test_Filter_UnmarshalJSONLimits(t *testing.T) {
+
+	filterWithDepth := func(depth int) *Filter {
+		var rule FilterRule = &FilterCondition{Property: "a", Operator: OpIs, Values: []string{"1"}}
+		for range depth {
+			rule = &Filter{Operator: OpAnd, Rules: []FilterRule{rule}}
+		}
+		return rule.(*Filter)
+	}
+	filterWithRuleCount := func(ruleCount int) *Filter {
+		rules := make([]FilterRule, ruleCount)
+		for i := range rules {
+			rules[i] = &FilterCondition{Property: "a", Operator: OpIs, Values: []string{"1"}}
+		}
+		return &Filter{Operator: OpAnd, Rules: rules}
+	}
+
+	tests := []struct {
+		name     string
+		filter   *Filter
+		expected error
+	}{
+		{"maximum depth", filterWithDepth(maxFilterDepth), nil},
+		{"excessive depth", filterWithDepth(maxFilterDepth + 1), fmt.Errorf("filter exceeds maximum depth of %d", maxFilterDepth)},
+		{"maximum rule count", filterWithRuleCount(maxFilterRuleCount), nil},
+		{"excessive rule count", filterWithRuleCount(maxFilterRuleCount + 1), fmt.Errorf("filter exceeds maximum rule count of %d", maxFilterRuleCount)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := json.Marshal(test.filter)
+			if err != nil {
+				t.Fatalf("unexpected marshal error %q", err)
+			}
+			var filter Filter
+			err = json.Unmarshal(data, &filter)
+			if cause := errors.Unwrap(err); cause != nil {
+				err = cause
+			}
+			if !reflect.DeepEqual(test.expected, err) {
+				t.Fatalf("expected error %q (type %T), got error %q (type %T)", test.expected, test.expected, err, err)
+			}
+		})
+	}
+
+}
+
+// Test_convertFilterToWhere verifies conversion from filters to where
+// expressions.
 func Test_convertFilterToWhere(t *testing.T) {
 
 	schema := types.Object([]types.Property{
@@ -45,97 +178,102 @@ func Test_convertFilterToWhere(t *testing.T) {
 	d := decimal.MustParse("56.19")
 
 	tests := []struct {
+		name     string
 		filter   Filter
 		expected state.Where
 	}{
 		{
+			name: "all property types",
 			filter: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpIsTrue},
-					{Property: "b", Operator: OpIs, Values: []string{"-105"}},
-					{Property: "c", Operator: OpIsNot, Values: []string{"197"}},
-					{Property: "d", Operator: OpIsGreaterThan, Values: []string{"3.802"}},
-					{Property: "e", Operator: OpIsGreaterThan, Values: []string{"60526.8020184552091647"}},
-					{Property: "e", Operator: OpIsLessThan, Values: []string{"1.7976931348623157e+308"}},
-					{Property: "f", Operator: OpIsLessThanOrEqualTo, Values: []string{"12.956"}},
-					{Property: "g", Operator: OpIsAfter, Values: []string{"2024-09-19T14:36:57.264699103"}},
-					{Property: "h", Operator: OpIsBetween, Values: []string{"2024-09-19", "2025-09-19"}},
-					{Property: "i", Operator: OpIsBefore, Values: []string{"14:36:57.264699103"}},
-					{Property: "j", Operator: OpIsOnOrAfter, Values: []string{"2024"}},
-					{Property: "k", Operator: OpIs, Values: []string{"38d065ab-ca46-4812-a83c-a9712e09c153"}},
-					{Property: "l", Operator: OpIs, Values: []string{"foo"}},
-					{Property: "l", Operator: OpIsOneOf, Values: []string{"foo", "56.19", "boo"}},
-					{Property: "l.x", Operator: OpExists},
-					{Property: "m", Operator: OpIsNot, Values: []string{"192.168.1.1"}},
-					{Property: "n", Operator: OpIs, Values: []string{"boo"}},
-					{Property: "o", Operator: OpIsNull},
-					{Property: "o", Operator: OpContains, Values: []string{"boo"}},
-					{Property: "p", Operator: OpIsNot},
-					{Property: "p.x", Operator: OpIs, Values: []string{"foo"}},
-					{Property: "p.x.y", Operator: OpExists},
-					{Property: "q", Operator: OpIsNull},
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpIsTrue},
+					&FilterCondition{Property: "b", Operator: OpIs, Values: []string{"-105"}},
+					&FilterCondition{Property: "c", Operator: OpIsNot, Values: []string{"197"}},
+					&FilterCondition{Property: "d", Operator: OpIsGreaterThan, Values: []string{"3.802"}},
+					&FilterCondition{Property: "e", Operator: OpIsGreaterThan, Values: []string{"60526.8020184552091647"}},
+					&FilterCondition{Property: "e", Operator: OpIsLessThan, Values: []string{"1.7976931348623157e+308"}},
+					&FilterCondition{Property: "f", Operator: OpIsLessThanOrEqualTo, Values: []string{"12.956"}},
+					&FilterCondition{Property: "g", Operator: OpIsAfter, Values: []string{"2024-09-19T14:36:57.264699103"}},
+					&FilterCondition{Property: "h", Operator: OpIsBetween, Values: []string{"2024-09-19", "2025-09-19"}},
+					&FilterCondition{Property: "i", Operator: OpIsBefore, Values: []string{"14:36:57.264699103"}},
+					&FilterCondition{Property: "j", Operator: OpIsOnOrAfter, Values: []string{"2024"}},
+					&FilterCondition{Property: "k", Operator: OpIs, Values: []string{"38d065ab-ca46-4812-a83c-a9712e09c153"}},
+					&FilterCondition{Property: "l", Operator: OpIs, Values: []string{"foo"}},
+					&FilterCondition{Property: "l", Operator: OpIsOneOf, Values: []string{"foo", "56.19", "boo"}},
+					&FilterCondition{Property: "l.x", Operator: OpExists},
+					&FilterCondition{Property: "m", Operator: OpIsNot, Values: []string{"192.168.1.1"}},
+					&FilterCondition{Property: "n", Operator: OpIs, Values: []string{"boo"}},
+					&FilterCondition{Property: "o", Operator: OpIsNull},
+					&FilterCondition{Property: "o", Operator: OpContains, Values: []string{"boo"}},
+					&FilterCondition{Property: "p", Operator: OpIsEmpty},
+					&FilterCondition{Property: "p.x", Operator: OpIs, Values: []string{"foo"}},
+					&FilterCondition{Property: "l.x.y", Operator: OpExists},
+					&FilterCondition{Property: "q", Operator: OpIsNull},
 				},
 			},
 			expected: state.Where{
-				Logical: state.OpOr,
-				Conditions: []state.WhereCondition{
-					{Property: []string{"a"}, Operator: state.OpIsTrue},
-					{Property: []string{"b"}, Operator: state.OpIs, Values: []any{-105}},
-					{Property: []string{"c"}, Operator: state.OpIsNot, Values: []any{uint(197)}},
-					{Property: []string{"d"}, Operator: state.OpIsGreaterThan, Values: []any{float64(float32(3.802))}},
-					{Property: []string{"e"}, Operator: state.OpIsGreaterThan, Values: []any{60526.80201845521}},
-					{Property: []string{"e"}, Operator: state.OpIsLessThan, Values: []any{1.7976931348623157e+308}},
-					{Property: []string{"f"}, Operator: state.OpIsLessThanOrEqualTo, Values: []any{decimal.MustParse("12.956")}},
-					{Property: []string{"g"}, Operator: state.OpIsAfter, Values: []any{time.Date(2024, 9, 19, 14, 36, 57, 264699103, time.UTC)}},
-					{Property: []string{"h"}, Operator: state.OpIsBetween, Values: []any{time.Date(2024, 9, 19, 0, 0, 0, 0, time.UTC), time.Date(2025, 9, 19, 0, 0, 0, 0, time.UTC)}},
-					{Property: []string{"i"}, Operator: state.OpIsBefore, Values: []any{time.Date(1970, 1, 1, 14, 36, 57, 264699103, time.UTC)}},
-					{Property: []string{"j"}, Operator: state.OpIsOnOrAfter, Values: []any{2024}},
-					{Property: []string{"k"}, Operator: state.OpIs, Values: []any{"38d065ab-ca46-4812-a83c-a9712e09c153"}},
-					{Property: []string{"l"}, Operator: state.OpIs, Values: []any{state.JSONConditionValue{String: "foo"}}},
-					{Property: []string{"l"}, Operator: state.OpIsOneOf, Values: []any{
+				Operator: state.OpOr,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIsTrue},
+					&state.WhereCondition{Property: []string{"b"}, Operator: state.OpIs, Values: []any{-105}},
+					&state.WhereCondition{Property: []string{"c"}, Operator: state.OpIsNot, Values: []any{uint(197)}},
+					&state.WhereCondition{Property: []string{"d"}, Operator: state.OpIsGreaterThan, Values: []any{float64(float32(3.802))}},
+					&state.WhereCondition{Property: []string{"e"}, Operator: state.OpIsGreaterThan, Values: []any{60526.80201845521}},
+					&state.WhereCondition{Property: []string{"e"}, Operator: state.OpIsLessThan, Values: []any{1.7976931348623157e+308}},
+					&state.WhereCondition{Property: []string{"f"}, Operator: state.OpIsLessThanOrEqualTo, Values: []any{decimal.MustParse("12.956")}},
+					&state.WhereCondition{Property: []string{"g"}, Operator: state.OpIsAfter, Values: []any{time.Date(2024, 9, 19, 14, 36, 57, 264699103, time.UTC)}},
+					&state.WhereCondition{Property: []string{"h"}, Operator: state.OpIsBetween, Values: []any{time.Date(2024, 9, 19, 0, 0, 0, 0, time.UTC), time.Date(2025, 9, 19, 0, 0, 0, 0, time.UTC)}},
+					&state.WhereCondition{Property: []string{"i"}, Operator: state.OpIsBefore, Values: []any{time.Date(1970, 1, 1, 14, 36, 57, 264699103, time.UTC)}},
+					&state.WhereCondition{Property: []string{"j"}, Operator: state.OpIsOnOrAfter, Values: []any{2024}},
+					&state.WhereCondition{Property: []string{"k"}, Operator: state.OpIs, Values: []any{"38d065ab-ca46-4812-a83c-a9712e09c153"}},
+					&state.WhereCondition{Property: []string{"l"}, Operator: state.OpIs, Values: []any{state.JSONConditionValue{String: "foo"}}},
+					&state.WhereCondition{Property: []string{"l"}, Operator: state.OpIsOneOf, Values: []any{
 						state.JSONConditionValue{String: "foo"},
 						state.JSONConditionValue{String: "56.19", Number: &d},
 						state.JSONConditionValue{String: "boo"},
 					}},
-					{Property: []string{"l", "x"}, Operator: state.OpExists},
-					{Property: []string{"m"}, Operator: state.OpIsNot, Values: []any{"192.168.1.1"}},
-					{Property: []string{"n"}, Operator: state.OpIs, Values: []any{"boo"}},
-					{Property: []string{"o"}, Operator: state.OpIsNull},
-					{Property: []string{"o"}, Operator: state.OpContains, Values: []any{"boo"}},
-					{Property: []string{"p"}, Operator: state.OpIsNot},
-					{Property: []string{"p", "x"}, Operator: state.OpIs, Values: []any{"foo"}},
-					{Property: []string{"p", "x", "y"}, Operator: state.OpExists},
-					{Property: []string{"q"}, Operator: state.OpIsNull},
+					&state.WhereCondition{Property: []string{"l", "x"}, Operator: state.OpExists},
+					&state.WhereCondition{Property: []string{"m"}, Operator: state.OpIsNot, Values: []any{"192.168.1.1"}},
+					&state.WhereCondition{Property: []string{"n"}, Operator: state.OpIs, Values: []any{"boo"}},
+					&state.WhereCondition{Property: []string{"o"}, Operator: state.OpIsNull},
+					&state.WhereCondition{Property: []string{"o"}, Operator: state.OpContains, Values: []any{"boo"}},
+					&state.WhereCondition{Property: []string{"p"}, Operator: state.OpIsEmpty},
+					&state.WhereCondition{Property: []string{"p", "x"}, Operator: state.OpIs, Values: []any{"foo"}},
+					&state.WhereCondition{Property: []string{"l", "x", "y"}, Operator: state.OpExists},
+					&state.WhereCondition{Property: []string{"q"}, Operator: state.OpIsNull},
 				},
 			},
 		},
 		{
+			name: "and",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpIsTrue},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpIsTrue},
 				},
 			},
 			expected: state.Where{
-				Logical: state.OpAnd,
-				Conditions: []state.WhereCondition{
-					{Property: []string{"a"}, Operator: state.OpIsTrue},
+				Operator: state.OpAnd,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIsTrue},
 				},
 			},
 		},
 	}
 
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			got := convertFilterToWhere(&test.filter, schema)
-			if !reflect.DeepEqual(&test.expected, got) {
-				t.Fatalf("unexpected value:\n%s", cmp.Diff(&test.expected, got))
+			if diff := cmp.Diff(&test.expected, got); diff != "" {
+				t.Fatalf("unexpected value (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
+// Test_convertWhereToFilter verifies conversion from where expressions to
+// filters.
 func Test_convertWhereToFilter(t *testing.T) {
 
 	schema := types.Object([]types.Property{
@@ -161,94 +299,141 @@ func Test_convertWhereToFilter(t *testing.T) {
 	d := decimal.MustParse("56.19")
 
 	tests := []struct {
+		name     string
 		where    state.Where
 		expected Filter
 	}{
 		{
+			name: "all property types",
 			where: state.Where{
-				Logical: state.OpOr,
-				Conditions: []state.WhereCondition{
-					{Property: []string{"a"}, Operator: state.OpIsTrue},
-					{Property: []string{"b"}, Operator: state.OpIs, Values: []any{-105}},
-					{Property: []string{"c"}, Operator: state.OpIsNot, Values: []any{uint(197)}},
-					{Property: []string{"d"}, Operator: state.OpIsGreaterThan, Values: []any{float64(float32(3.802))}},
-					{Property: []string{"e"}, Operator: state.OpIsGreaterThan, Values: []any{60526.80201845521}},
-					{Property: []string{"e"}, Operator: state.OpIsLessThan, Values: []any{1.7976931348623157e+308}},
-					{Property: []string{"f"}, Operator: state.OpIsLessThanOrEqualTo, Values: []any{decimal.MustParse("12.956")}},
-					{Property: []string{"g"}, Operator: state.OpIsAfter, Values: []any{time.Date(2024, 9, 19, 14, 36, 57, 264699103, time.UTC)}},
-					{Property: []string{"h"}, Operator: state.OpIsBetween, Values: []any{time.Date(2024, 9, 19, 0, 0, 0, 0, time.UTC), time.Date(2025, 9, 19, 0, 0, 0, 0, time.UTC)}},
-					{Property: []string{"i"}, Operator: state.OpIsBefore, Values: []any{time.Date(1970, 1, 1, 14, 36, 57, 264699103, time.UTC)}},
-					{Property: []string{"j"}, Operator: state.OpIsOnOrAfter, Values: []any{2024}},
-					{Property: []string{"k"}, Operator: state.OpIs, Values: []any{"38d065ab-ca46-4812-a83c-a9712e09c153"}},
-					{Property: []string{"l"}, Operator: state.OpIs, Values: []any{state.JSONConditionValue{String: "foo"}}},
-					{Property: []string{"l"}, Operator: state.OpIsOneOf, Values: []any{
+				Operator: state.OpOr,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIsTrue},
+					&state.WhereCondition{Property: []string{"b"}, Operator: state.OpIs, Values: []any{-105}},
+					&state.WhereCondition{Property: []string{"c"}, Operator: state.OpIsNot, Values: []any{uint(197)}},
+					&state.WhereCondition{Property: []string{"d"}, Operator: state.OpIsGreaterThan, Values: []any{float64(float32(3.802))}},
+					&state.WhereCondition{Property: []string{"e"}, Operator: state.OpIsGreaterThan, Values: []any{60526.80201845521}},
+					&state.WhereCondition{Property: []string{"e"}, Operator: state.OpIsLessThan, Values: []any{1.7976931348623157e+308}},
+					&state.WhereCondition{Property: []string{"f"}, Operator: state.OpIsLessThanOrEqualTo, Values: []any{decimal.MustParse("12.956")}},
+					&state.WhereCondition{Property: []string{"g"}, Operator: state.OpIsAfter, Values: []any{time.Date(2024, 9, 19, 14, 36, 57, 264699103, time.UTC)}},
+					&state.WhereCondition{Property: []string{"h"}, Operator: state.OpIsBetween, Values: []any{time.Date(2024, 9, 19, 0, 0, 0, 0, time.UTC), time.Date(2025, 9, 19, 0, 0, 0, 0, time.UTC)}},
+					&state.WhereCondition{Property: []string{"i"}, Operator: state.OpIsBefore, Values: []any{time.Date(1970, 1, 1, 14, 36, 57, 264699103, time.UTC)}},
+					&state.WhereCondition{Property: []string{"j"}, Operator: state.OpIsOnOrAfter, Values: []any{2024}},
+					&state.WhereCondition{Property: []string{"k"}, Operator: state.OpIs, Values: []any{"38d065ab-ca46-4812-a83c-a9712e09c153"}},
+					&state.WhereCondition{Property: []string{"l"}, Operator: state.OpIs, Values: []any{state.JSONConditionValue{String: "foo"}}},
+					&state.WhereCondition{Property: []string{"l"}, Operator: state.OpIsOneOf, Values: []any{
 						state.JSONConditionValue{String: "foo"},
 						state.JSONConditionValue{String: "56.19", Number: &d},
 						state.JSONConditionValue{String: "boo"},
 					}},
-					{Property: []string{"l.x"}, Operator: state.OpExists},
-					{Property: []string{"m"}, Operator: state.OpIsNot, Values: []any{"192.168.1.1"}},
-					{Property: []string{"n"}, Operator: state.OpIs, Values: []any{"boo"}},
-					{Property: []string{"o"}, Operator: state.OpIsNull},
-					{Property: []string{"o"}, Operator: state.OpContains, Values: []any{"boo"}},
-					{Property: []string{"p"}, Operator: state.OpIsNot},
-					{Property: []string{"p.x"}, Operator: state.OpIs, Values: []any{"foo"}},
-					{Property: []string{"p.x.y"}, Operator: state.OpExists},
-					{Property: []string{"q"}, Operator: state.OpIsNull},
+					&state.WhereCondition{Property: []string{"l", "x"}, Operator: state.OpExists},
+					&state.WhereCondition{Property: []string{"m"}, Operator: state.OpIsNot, Values: []any{"192.168.1.1"}},
+					&state.WhereCondition{Property: []string{"n"}, Operator: state.OpIs, Values: []any{"boo"}},
+					&state.WhereCondition{Property: []string{"o"}, Operator: state.OpIsNull},
+					&state.WhereCondition{Property: []string{"o"}, Operator: state.OpContains, Values: []any{"boo"}},
+					&state.WhereCondition{Property: []string{"p"}, Operator: state.OpIsEmpty},
+					&state.WhereCondition{Property: []string{"p", "x"}, Operator: state.OpIs, Values: []any{"foo"}},
+					&state.WhereCondition{Property: []string{"l", "x", "y"}, Operator: state.OpExists},
+					&state.WhereCondition{Property: []string{"q"}, Operator: state.OpIsNull},
 				},
 			},
 			expected: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpIsTrue},
-					{Property: "b", Operator: OpIs, Values: []string{"-105"}},
-					{Property: "c", Operator: OpIsNot, Values: []string{"197"}},
-					{Property: "d", Operator: OpIsGreaterThan, Values: []string{"3.802"}},
-					{Property: "e", Operator: OpIsGreaterThan, Values: []string{"60526.80201845521"}},
-					{Property: "e", Operator: OpIsLessThan, Values: []string{"1.7976931348623157e+308"}},
-					{Property: "f", Operator: OpIsLessThanOrEqualTo, Values: []string{"12.956"}},
-					{Property: "g", Operator: OpIsAfter, Values: []string{"2024-09-19T14:36:57.264699103"}},
-					{Property: "h", Operator: OpIsBetween, Values: []string{"2024-09-19", "2025-09-19"}},
-					{Property: "i", Operator: OpIsBefore, Values: []string{"14:36:57.264699103"}},
-					{Property: "j", Operator: OpIsOnOrAfter, Values: []string{"2024"}},
-					{Property: "k", Operator: OpIs, Values: []string{"38d065ab-ca46-4812-a83c-a9712e09c153"}},
-					{Property: "l", Operator: OpIs, Values: []string{"foo"}},
-					{Property: "l", Operator: OpIsOneOf, Values: []string{"foo", "56.19", "boo"}},
-					{Property: "l.x", Operator: OpExists},
-					{Property: "m", Operator: OpIsNot, Values: []string{"192.168.1.1"}},
-					{Property: "n", Operator: OpIs, Values: []string{"boo"}},
-					{Property: "o", Operator: OpIsNull},
-					{Property: "o", Operator: OpContains, Values: []string{"boo"}},
-					{Property: "p", Operator: OpIsNot},
-					{Property: "p.x", Operator: OpIs, Values: []string{"foo"}},
-					{Property: "p.x.y", Operator: OpExists},
-					{Property: "q", Operator: OpIsNull},
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpIsTrue},
+					&FilterCondition{Property: "b", Operator: OpIs, Values: []string{"-105"}},
+					&FilterCondition{Property: "c", Operator: OpIsNot, Values: []string{"197"}},
+					&FilterCondition{Property: "d", Operator: OpIsGreaterThan, Values: []string{"3.802"}},
+					&FilterCondition{Property: "e", Operator: OpIsGreaterThan, Values: []string{"60526.80201845521"}},
+					&FilterCondition{Property: "e", Operator: OpIsLessThan, Values: []string{"1.7976931348623157e+308"}},
+					&FilterCondition{Property: "f", Operator: OpIsLessThanOrEqualTo, Values: []string{"12.956"}},
+					&FilterCondition{Property: "g", Operator: OpIsAfter, Values: []string{"2024-09-19T14:36:57.264699103"}},
+					&FilterCondition{Property: "h", Operator: OpIsBetween, Values: []string{"2024-09-19", "2025-09-19"}},
+					&FilterCondition{Property: "i", Operator: OpIsBefore, Values: []string{"14:36:57.264699103"}},
+					&FilterCondition{Property: "j", Operator: OpIsOnOrAfter, Values: []string{"2024"}},
+					&FilterCondition{Property: "k", Operator: OpIs, Values: []string{"38d065ab-ca46-4812-a83c-a9712e09c153"}},
+					&FilterCondition{Property: "l", Operator: OpIs, Values: []string{"foo"}},
+					&FilterCondition{Property: "l", Operator: OpIsOneOf, Values: []string{"foo", "56.19", "boo"}},
+					&FilterCondition{Property: "l.x", Operator: OpExists},
+					&FilterCondition{Property: "m", Operator: OpIsNot, Values: []string{"192.168.1.1"}},
+					&FilterCondition{Property: "n", Operator: OpIs, Values: []string{"boo"}},
+					&FilterCondition{Property: "o", Operator: OpIsNull},
+					&FilterCondition{Property: "o", Operator: OpContains, Values: []string{"boo"}},
+					&FilterCondition{Property: "p", Operator: OpIsEmpty},
+					&FilterCondition{Property: "p.x", Operator: OpIs, Values: []string{"foo"}},
+					&FilterCondition{Property: "l.x.y", Operator: OpExists},
+					&FilterCondition{Property: "q", Operator: OpIsNull},
 				},
 			},
 		},
 		{
+			name: "and",
 			where: state.Where{
-				Logical: state.OpAnd,
-				Conditions: []state.WhereCondition{
-					{Property: []string{"a"}, Operator: state.OpIsTrue},
+				Operator: state.OpAnd,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIsTrue},
 				},
 			},
 			expected: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpIsTrue},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpIsTrue},
 				},
 			},
 		},
 	}
 
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			got := convertWhereToFilter(&test.where, schema)
-			if !reflect.DeepEqual(&test.expected, got) {
-				t.Fatalf("unexpected value:\n%s", cmp.Diff(&test.expected, got))
+			if diff := cmp.Diff(&test.expected, got); diff != "" {
+				t.Fatalf("unexpected value (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// Test_convertFilterWhereNested verifies conversion between nested filters and
+// where expressions.
+func Test_convertFilterWhereNested(t *testing.T) {
+
+	schema := types.Object([]types.Property{
+		{Name: "a", Type: types.Int(32)},
+		{Name: "b", Type: types.String()},
+		{Name: "c", Type: types.Boolean()},
+	})
+	filter := &Filter{
+		Operator: OpAnd,
+		Rules: []FilterRule{
+			&FilterCondition{Property: "a", Operator: OpIs, Values: []string{"5"}},
+			&Filter{
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpContains, Values: []string{"foo"}},
+					&FilterCondition{Property: "c", Operator: OpIsTrue},
+				},
+			},
+		},
+	}
+	where := convertFilterToWhere(filter, schema)
+	expected := &state.Where{
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIs, Values: []any{5}},
+			&state.Where{
+				Operator: state.OpOr,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{Property: []string{"b"}, Operator: state.OpContains, Values: []any{"foo"}},
+					&state.WhereCondition{Property: []string{"c"}, Operator: state.OpIsTrue},
+				},
+			},
+		},
+	}
+	if !expected.Equal(where) {
+		t.Fatalf("expected %#v, got %#v", expected, where)
+	}
+	if diff := cmp.Diff(filter, convertWhereToFilter(where, schema)); diff != "" {
+		t.Fatalf("unexpected filter after round trip (-want +got):\n%s", diff)
 	}
 }
 
@@ -297,6 +482,7 @@ func Test_parseDecimal(t *testing.T) {
 	}
 }
 
+// Test_parseFloat verifies parsing floating-point filter values.
 func Test_parseFloat(t *testing.T) {
 	tests := []struct {
 		n        string
@@ -310,7 +496,7 @@ func Test_parseFloat(t *testing.T) {
 		{"-1.23e-4", 64, -1.23e-4, true},
 		{"67.0597e+183", 64, 67.0597e+183, true},
 		{"123", 32, float64(float32(123)), true},
-		{"1.23", 32, float64(float32(1.23)), true},
+		{"1.23", 64, 1.23, true},
 		{"1.23", 32, float64(float32(1.23)), true},
 		{"01.23", 64, 1.23, true},
 		{"-01.23", 64, -1.23, true},
@@ -332,7 +518,7 @@ func Test_parseFloat(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.n, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%q/%d", test.n, test.bitSize), func(t *testing.T) {
 			got, valid := parseFloat(test.n, test.bitSize)
 			if !valid {
 				if test.valid {
@@ -344,7 +530,7 @@ func Test_parseFloat(t *testing.T) {
 				t.Fatalf("expected invalid, got valid")
 			}
 			if test.expected != got {
-				t.Fatalf("expected %f, got %f", test.expected, got)
+				t.Fatalf("expected %g, got %g", test.expected, got)
 			}
 		})
 	}
@@ -360,15 +546,15 @@ func Test_parseInt(t *testing.T) {
 		{"123", 123, true},
 		{"-123", -123, true},
 		{"+123", 123, true},
-		{"000", 0, false}, // invalid due to leading zeros.
+		{"000", 0, false}, // leading zeros are not allowed.
 		{"00123", 0, false},
 		{"+0", 0, true},
 		{"-0", 0, true},
-		{"-00123", 0, false},                          // invalid due to leading zeros.
-		{"-9223372036854775809", 0, false},            // overflow negative.
+		{"-00123", 0, false},                          // leading zeros are not allowed.
+		{"-9223372036854775809", 0, false},            // negative overflow.
 		{"-9223372036854775808", math.MinInt64, true}, // minimum int64.
 		{"9223372036854775807", math.MaxInt64, true},  // maximum int64.
-		{"9223372036854775808", 0, false},             // overflow positive.
+		{"9223372036854775808", 0, false},             // positive overflow.
 		{"abc", 0, false},
 		{"", 0, false},
 	}
@@ -392,6 +578,7 @@ func Test_parseInt(t *testing.T) {
 	}
 }
 
+// Test_parseYear verifies parsing year filter values.
 func Test_parseYear(t *testing.T) {
 	tests := []struct {
 		year     string
@@ -401,10 +588,10 @@ func Test_parseYear(t *testing.T) {
 		{"2023", 2023, true},
 		{"1999", 1999, true},
 		{"99", 99, true},
-		{"0", 0, false},               // overflow.
+		{"0", 0, false},               // below the minimum year.
 		{"1", types.MinYear, true},    // minimum year.
 		{"9999", types.MaxYear, true}, // maximum year.
-		{"10000", 0, false},           // overflow.
+		{"10000", 0, false},           // above the maximum year.
 		{"0000", 0, false},
 		{"12345", 0, false},
 		{"12a4", 0, false},
@@ -433,7 +620,8 @@ func Test_parseYear(t *testing.T) {
 	}
 }
 
-func Test_parseUint(t *testing.T) {
+// Test_parseUnsigned verifies parsing unsigned integer filter values.
+func Test_parseUnsigned(t *testing.T) {
 	tests := []struct {
 		n        string
 		expected uint
@@ -441,7 +629,7 @@ func Test_parseUint(t *testing.T) {
 	}{
 		{"0", 0, true},
 		{"123", 123, true},
-		{"000", 0, false}, // leading zeros should be invalid.
+		{"000", 0, false}, // leading zeros are not allowed.
 		{"00123", 0, false},
 		{"4294967295", 4294967295, true}, // maximum uint32 value.
 		{"18446744073709551615", 18446744073709551615, true}, // maximum uint64 value.
@@ -471,45 +659,7 @@ func Test_parseUint(t *testing.T) {
 	}
 }
 
-func Test_parseUUID(t *testing.T) {
-	tests := []struct {
-		s    string
-		uuid string
-		ok   bool
-	}{
-
-		// Supported UUID formats.
-		{"2a9b8326-aadb-416a-adc1-71761f3ff4b9", "2a9b8326-aadb-416a-adc1-71761f3ff4b9", true},
-		{"2a9b8326-aadb-416a-ADC1-71761F3FF4B9", "2a9b8326-aadb-416a-adc1-71761f3ff4b9", true},
-		{"2A9B8326-AADB-416A-ADC1-71761F3FF4B9", "2a9b8326-aadb-416a-adc1-71761f3ff4b9", true},
-
-		// Unsupported UUID formats.
-		{"60af802184814c8389153f9055d57e6c", "", false},
-		{"60AF802184814C8389153F9055D57E6C", "", false},
-		{"{60af8021-8481-4c83-8915-3f9055d57e6c}", "", false},
-		{"{60AF8021-8481-4C83-8915-3F9055D57E6C}", "", false},
-		{"urn:uuid:60af8021-8481-4c83-8915-3f9055d57e6c", "", false},
-		{"urn:uuid:60AF8021-8481-4C83-8915-3F9055D57E6C", "", false},
-
-		// Strings that do not represent UUIDs.
-		{"", "", false},
-		{"12345", "", false},
-		{"abcdef0123456789", "", false},
-		{"2a9b8326-aadb-416a-adc1-71761f3ff4b92a9b8326-aadb-416a-adc1-71761f3ff4b9", "", false},
-	}
-	for _, test := range tests {
-		t.Run(test.s, func(t *testing.T) {
-			gotUUID, gotOk := types.ParseUUID(test.s)
-			if gotUUID != test.uuid {
-				t.Fatalf("expected UUID %s, got %s", test.uuid, gotUUID)
-			}
-			if gotOk != test.ok {
-				t.Fatalf("expected ok = %t, got %t", test.ok, gotOk)
-			}
-		})
-	}
-}
-
+// Test_resolveFilterProperty verifies resolution of filter property paths.
 func Test_resolveFilterProperty(t *testing.T) {
 
 	schema := types.Object([]types.Property{
@@ -540,11 +690,11 @@ func Test_resolveFilterProperty(t *testing.T) {
 	properties := schema.Properties()
 
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			gotProperty, gotPath, err := retrieveFilterProperty(properties, test.path)
+		t.Run(test.path, func(t *testing.T) {
+			gotProperty, gotPath, err := resolveFilterProperty(properties, test.path)
 			if err != nil {
 				if test.err == nil {
-					t.Fatalf("expected no error, got error %q  (type %T)", err, err)
+					t.Fatalf("expected no error, got error %q (type %T)", err, err)
 				}
 				if !reflect.DeepEqual(test.err, err) {
 					t.Fatalf("expected error %q (type %T), got error %q (type %T)", test.err, test.err, err, err)
@@ -552,7 +702,7 @@ func Test_resolveFilterProperty(t *testing.T) {
 				return
 			}
 			if test.err != nil {
-				t.Fatalf("expected error %q, got no errors", test.err)
+				t.Fatalf("expected error %q, got no error", test.err)
 			}
 			if !types.Equal(types.Object([]types.Property{test.expectedProperty}), types.Object([]types.Property{gotProperty})) {
 				t.Fatalf("expected property %#v, got %#v", test.expectedProperty, gotProperty)
@@ -565,6 +715,8 @@ func Test_resolveFilterProperty(t *testing.T) {
 
 }
 
+// Test_validateFilter verifies validation of filter structure, operators, and
+// values.
 func Test_validateFilter(t *testing.T) {
 
 	schema := types.Object([]types.Property{
@@ -586,320 +738,386 @@ func Test_validateFilter(t *testing.T) {
 		{Name: "p", Type: types.String().WithValues("foo"), Nullable: true},
 		{Name: "q", Type: types.Array(types.Float(64)), Nullable: true},
 	})
+	destinationRole := state.Destination
+	eventTarget := state.TargetEvent
 
 	tests := []struct {
+		name     string
 		filter   Filter
-		role     state.Role
-		target   state.Target
+		role     *state.Role
+		target   *state.Target
 		expected []string
 		err      error
 	}{
 		{
+			name: "invalid logical operator",
 			filter: Filter{
-				Logical: "foo",
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpIs, Values: []string{"5"}},
+				Operator: "foo",
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpIs, Values: []string{"5"}},
 				},
 			},
 			err: errors.New(`invalid logical operator "foo"`),
 		},
 		{
+			name: "missing rules",
 			filter: Filter{
-				Logical: OpOr,
+				Operator: OpOr,
 			},
-			err: errors.New("conditions are missing"),
+			err: errors.New("rules are missing"),
 		},
 		{
+			name: "nested filter",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "a c", Operator: OpIs, Values: []string{"5"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpIs, Values: []string{"foo"}},
+					&Filter{
+						Operator: OpOr,
+						Rules: []FilterRule{
+							&FilterCondition{Property: "c", Operator: OpIs, Values: []string{"5"}},
+							&FilterCondition{Property: "d.s", Operator: OpExists},
+						},
+					},
+				},
+			},
+			expected: []string{"b", "c", "d"},
+		},
+		{
+			name: "invalid property path",
+			filter: Filter{
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a c", Operator: OpIs, Values: []string{"5"}},
 				},
 			},
 			err: errors.New("property path is not valid"),
 		},
 		{
+			name: "unknown property path",
 			filter: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "z", Operator: OpIs, Values: []string{"5"}},
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "z", Operator: OpIs, Values: []string{"5"}},
 				},
 			},
 			err: types.PathNotExistError{Path: "z"},
 		},
 		{
+			name: "is on boolean",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpIs, Values: []string{"true"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpIs, Values: []string{"true"}},
 				},
 			},
 			err: errors.New(`operator "is" cannot be used with boolean properties`),
 		},
 		{
+			name: "is on object",
 			filter: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpIsLessThan, Values: []string{"true"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "m", Operator: OpIs, Values: []string{"value"}},
+				},
+			},
+			err: errors.New(`operator "is" cannot be used with object properties`),
+		},
+		{
+			name: "is less than on boolean",
+			filter: Filter{
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpIsLessThan, Values: []string{"true"}},
 				},
 			},
 			err: errors.New(`operator "is less than" cannot be used with boolean properties`),
 		},
 		{
+			name: "contains on unsupported array element",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "l", Operator: OpContains, Values: []string{"true"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "l", Operator: OpContains, Values: []string{"true"}},
 				},
 			},
 			err: errors.New(`operator "contains" cannot be used with array(map) properties`),
 		},
 		{
+			name: "does not contain on boolean",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpDoesNotContain, Values: []string{"true"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpDoesNotContain, Values: []string{"true"}},
 				},
 			},
 			err: errors.New(`operator "does not contain" cannot be used with boolean properties`),
 		},
 		{
+			name: "is before on boolean",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpIsBefore, Values: []string{"true"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpIsBefore, Values: []string{"true"}},
 				},
 			},
 			err: errors.New(`operator "is before" cannot be used with boolean properties`),
 		},
 		{
+			name: "is true on string",
 			filter: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "b", Operator: OpIsTrue},
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpIsTrue},
 				},
 			},
 			err: errors.New(`operator "is true" cannot be used with string properties`),
 		},
 		{
+			name: "is null on non-nullable property",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: OpIsNull},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: OpIsNull},
 				},
 			},
 			err: errors.New(`operator "is null" can only be used with nullable or json properties`),
 		},
 		{
+			name: "exists on required property",
 			filter: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "b", Operator: OpExists},
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpExists},
 				},
 			},
 			err: errors.New(`operator "exists" can only be used with read-optional properties or with json properties that include a JSON path`),
 		},
 		{
+			name: "does not exist on JSON root",
 			filter: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "d", Operator: OpDoesNotExist},
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "d", Operator: OpDoesNotExist},
 				},
 			},
 			err: errors.New(`operator "does not exist" can only be used with read-optional properties or with json properties that include a JSON path`),
 		},
 		{
+			name: "invalid condition operator",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "a", Operator: "boo", Values: []string{"5"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "a", Operator: "boo", Values: []string{"5"}},
 				},
 			},
 			err: errors.New(`operator "boo" is not valid`),
 		},
 		{
+			name: "value with unary operator",
 			filter: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "b", Operator: OpIsNull, Values: []string{"5"}},
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpIsNull, Values: []string{"5"}},
 				},
 			},
 			err: errors.New(`values cannot be used with the operator "is null"`),
 		},
 		{
+			name: "one value with binary operator",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "b", Operator: OpIsBetween, Values: []string{"5"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpIsBetween, Values: []string{"5"}},
 				},
 			},
 			err: errors.New(`two values must be used with the operator "is between"`),
 		},
 		{
+			name: "missing value",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "b", Operator: OpContains},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpContains},
 				},
 			},
 			err: errors.New(`only one value can be used with the operator "contains"`),
 		},
 		{
+			name: "NUL byte in value",
 			filter: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "b", Operator: OpContains, Values: []string{"foo \x00"}},
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpContains, Values: []string{"foo \x00"}},
 				},
 			},
 			err: errors.New("condition value contains the NUL byte"),
 		},
 		{
+			name: "invalid int value",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "c", Operator: OpIs, Values: []string{"75.0"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "c", Operator: OpIs, Values: []string{"75.0"}},
 				},
 			},
-			err: fmt.Errorf(`value of the "c" property is not a valid int`),
+			err: errors.New(`value of the "c" property is not a valid int`),
 		},
 		{
+			name: "invalid UUID value",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "o", Operator: OpIsLessThan, Values: []string{"none"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "h", Operator: OpIs, Values: []string{"invalid"}},
 				},
 			},
-			err: fmt.Errorf(`operator "is less than" cannot be used with string type that has values`),
+			err: errors.New(`value of the "h" property is not a valid uuid`),
 		},
 		{
+			name: "comparison on string with allowed values",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "o", Operator: OpIsOneOf, Values: []string{"foo", "moo"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "o", Operator: OpIsLessThan, Values: []string{"none"}},
 				},
 			},
-			err: fmt.Errorf(`value of the "o" property is not among the allowed values`),
+			err: errors.New(`operator "is less than" cannot be used with string type that has values`),
 		},
 		{
+			name: "value outside allowed values",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "p", Operator: OpIsEmpty},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "o", Operator: OpIsOneOf, Values: []string{"foo", "moo"}},
 				},
 			},
-			err: fmt.Errorf(`operator "is empty" cannot be used on string properties that exclude the empty string from allowed values`),
+			err: errors.New(`value of the "o" property is not among the allowed values`),
 		},
 		{
+			name: "is empty when empty string is not allowed",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "p", Operator: OpIsNotEmpty},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "p", Operator: OpIsEmpty},
 				},
 			},
-			err: fmt.Errorf(`operator "is not empty" cannot be used on string properties that exclude the empty string from allowed values`),
+			err: errors.New(`operator "is empty" cannot be used on string properties that exclude the empty string from allowed values`),
 		},
 		{
+			name: "is not empty when empty string is not allowed",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "g", Operator: OpIsEmpty},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "p", Operator: OpIsNotEmpty},
 				},
 			},
-			err: fmt.Errorf(`operator "is empty" can only be used with json, string, object, array, and map properties`),
+			err: errors.New(`operator "is not empty" cannot be used on string properties that exclude the empty string from allowed values`),
 		},
 		{
+			name: "is empty on time",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "g", Operator: OpIsEmpty},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "g", Operator: OpIsEmpty},
 				},
 			},
-			err: fmt.Errorf(`operator "is empty" can only be used with json, string, object, array, and map properties`),
+			err: errors.New(`operator "is empty" can only be used with json, string, object, array, and map properties`),
 		},
 		{
+			name: "is not empty on time",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "m", Operator: OpIsEmpty},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "g", Operator: OpIsNotEmpty},
 				},
 			},
-			target: state.TargetUser,
-			role:   state.Destination,
-			err:    fmt.Errorf(`operator "is empty" cannot be used on object properties for destination pipelines on users`),
+			err: errors.New(`operator "is not empty" can only be used with json, string, object, array, and map properties`),
 		},
 		{
+			name: "is empty on destination user object",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "m", Operator: OpIsNotEmpty},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "m", Operator: OpIsEmpty},
 				},
 			},
-			target: state.TargetEvent,
-			role:   state.Source,
-			err:    fmt.Errorf(`operator "is not empty" cannot be used on object properties for pipelines on events`),
+			role: &destinationRole,
+			err:  errors.New(`operator "is empty" cannot be used on object properties for destination pipelines on users`),
 		},
 		{
+			name: "is not empty on event object",
 			filter: Filter{
-				Logical: OpAnd,
-				Conditions: []FilterCondition{
-					{Property: "d.p", Operator: OpIsNotEmpty},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "m", Operator: OpIsNotEmpty},
 				},
 			},
-			target: state.TargetUser,
-			role:   state.Destination,
-			err:    fmt.Errorf(`property "d" has type json, which is not supported in data warehouse exports`),
+			target: &eventTarget,
+			err:    errors.New(`operator "is not empty" cannot be used on object properties for pipelines on events`),
 		},
 		{
+			name: "JSON in destination user filter",
 			filter: Filter{
-				Logical: OpOr,
-				Conditions: []FilterCondition{
-					{Property: "b", Operator: OpIs, Values: []string{"5"}},
-					{Property: "b", Operator: OpIsNot, Values: []string{"foo"}},
-					{Property: "c", Operator: OpIsLessThan, Values: []string{"12"}},
-					{Property: "c", Operator: OpIsLessThanOrEqualTo, Values: []string{"5"}},
-					{Property: "b", Operator: OpIsGreaterThan, Values: []string{"boo"}},
-					{Property: "b", Operator: OpIsEmpty},
-					{Property: "c", Operator: OpIsGreaterThanOrEqualTo, Values: []string{"23"}},
-					{Property: "c", Operator: OpIsBetween, Values: []string{"10", "20"}},
-					{Property: "c", Operator: OpIsNotBetween, Values: []string{"20", "30"}},
-					{Property: "b", Operator: OpContains, Values: []string{"abc"}},
-					{Property: "b", Operator: OpDoesNotContain, Values: []string{"abc"}},
-					{Property: "c", Operator: OpIsOneOf, Values: []string{"5", "8", "-3"}},
-					{Property: "b", Operator: OpIsNotOneOf, Values: []string{"a", "b", "c"}},
-					{Property: "b", Operator: OpStartsWith, Values: []string{"abc"}},
-					{Property: "b", Operator: OpEndsWith, Values: []string{"abc"}},
-					{Property: "e", Operator: OpIsBefore, Values: []string{"2024-09-10T15:34:31"}},
-					{Property: "f", Operator: OpIsOnOrBefore, Values: []string{"2024-09-10"}},
-					{Property: "g", Operator: OpIsAfter, Values: []string{"15:34:31"}},
-					{Property: "h", Operator: OpIs, Values: []string{"dbfa8339-0d12-4c94-a3fb-569199ae5c8e"}},
-					{Property: "h", Operator: OpExists},
-					{Property: "h", Operator: OpDoesNotExist},
-					{Property: "i", Operator: OpIsBefore, Values: []string{"2024"}},
-					{Property: "j", Operator: OpIs, Values: []string{"192.168.1.1"}},
-					{Property: "d", Operator: OpIsNotEmpty},
-					{Property: "e", Operator: OpIsOnOrAfter, Values: []string{"2024-09-10T15:34:31"}},
-					{Property: "a", Operator: OpIsTrue},
-					{Property: "a", Operator: OpIsFalse},
-					{Property: "b", Operator: OpIsNull},
-					{Property: "b", Operator: OpIsNotNull},
-					{Property: "d", Operator: OpIsEmpty},
-					{Property: "d.s", Operator: OpIsEmpty},
-					{Property: "d.s", Operator: OpExists},
-					{Property: "d.s", Operator: OpDoesNotExist},
-					{Property: "k", Operator: OpIsNull},
-					{Property: "k", Operator: OpContains, Values: []string{"boo"}},
-					{Property: "m", Operator: OpIsNull},
-					{Property: "m", Operator: OpIsEmpty},
-					{Property: "m.x", Operator: OpContains, Values: []string{"abc"}},
-					{Property: "n", Operator: OpIsNotNull},
-					{Property: "n", Operator: OpIsNotEmpty},
-					{Property: "o", Operator: OpIs, Values: []string{"foo"}},
-					{Property: "o", Operator: OpIs, Values: []string{""}},
-					{Property: "o", Operator: OpIsOneOf, Values: []string{"foo", "boo"}},
-					{Property: "o", Operator: OpIsNotNull},
-					{Property: "o", Operator: OpIsEmpty},
-					{Property: "o", Operator: OpIsNotEmpty},
-					{Property: "q", Operator: OpContains, Values: []string{"1.34"}},
+				Operator: OpAnd,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "d.p", Operator: OpIsNotEmpty},
+				},
+			},
+			role: &destinationRole,
+			err:  errors.New(`property "d" has type json, which is not supported in data warehouse exports`),
+		},
+		{
+			name: "all valid operators",
+			filter: Filter{
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpIs, Values: []string{"5"}},
+					&FilterCondition{Property: "b", Operator: OpIsNot, Values: []string{"foo"}},
+					&FilterCondition{Property: "c", Operator: OpIsLessThan, Values: []string{"12"}},
+					&FilterCondition{Property: "c", Operator: OpIsLessThanOrEqualTo, Values: []string{"5"}},
+					&FilterCondition{Property: "b", Operator: OpIsGreaterThan, Values: []string{"boo"}},
+					&FilterCondition{Property: "b", Operator: OpIsEmpty},
+					&FilterCondition{Property: "c", Operator: OpIsGreaterThanOrEqualTo, Values: []string{"23"}},
+					&FilterCondition{Property: "c", Operator: OpIsBetween, Values: []string{"10", "20"}},
+					&FilterCondition{Property: "c", Operator: OpIsNotBetween, Values: []string{"20", "30"}},
+					&FilterCondition{Property: "b", Operator: OpContains, Values: []string{"abc"}},
+					&FilterCondition{Property: "b", Operator: OpDoesNotContain, Values: []string{"abc"}},
+					&FilterCondition{Property: "c", Operator: OpIsOneOf, Values: []string{"5", "8", "-3"}},
+					&FilterCondition{Property: "b", Operator: OpIsNotOneOf, Values: []string{"a", "b", "c"}},
+					&FilterCondition{Property: "b", Operator: OpStartsWith, Values: []string{"abc"}},
+					&FilterCondition{Property: "b", Operator: OpEndsWith, Values: []string{"abc"}},
+					&FilterCondition{Property: "e", Operator: OpIsBefore, Values: []string{"2024-09-10T15:34:31"}},
+					&FilterCondition{Property: "f", Operator: OpIsOnOrBefore, Values: []string{"2024-09-10"}},
+					&FilterCondition{Property: "g", Operator: OpIsAfter, Values: []string{"15:34:31"}},
+					&FilterCondition{Property: "h", Operator: OpIs, Values: []string{"dbfa8339-0d12-4c94-a3fb-569199ae5c8e"}},
+					&FilterCondition{Property: "h", Operator: OpExists},
+					&FilterCondition{Property: "h", Operator: OpDoesNotExist},
+					&FilterCondition{Property: "i", Operator: OpIsBefore, Values: []string{"2024"}},
+					&FilterCondition{Property: "j", Operator: OpIs, Values: []string{"192.168.1.1"}},
+					&FilterCondition{Property: "d", Operator: OpIsNotEmpty},
+					&FilterCondition{Property: "e", Operator: OpIsOnOrAfter, Values: []string{"2024-09-10T15:34:31"}},
+					&FilterCondition{Property: "a", Operator: OpIsTrue},
+					&FilterCondition{Property: "a", Operator: OpIsFalse},
+					&FilterCondition{Property: "b", Operator: OpIsNull},
+					&FilterCondition{Property: "b", Operator: OpIsNotNull},
+					&FilterCondition{Property: "d", Operator: OpIsEmpty},
+					&FilterCondition{Property: "d.s", Operator: OpIsEmpty},
+					&FilterCondition{Property: "d.s", Operator: OpExists},
+					&FilterCondition{Property: "d.s", Operator: OpDoesNotExist},
+					&FilterCondition{Property: "k", Operator: OpIsNull},
+					&FilterCondition{Property: "k", Operator: OpContains, Values: []string{"boo"}},
+					&FilterCondition{Property: "m", Operator: OpIsNull},
+					&FilterCondition{Property: "m", Operator: OpIsEmpty},
+					&FilterCondition{Property: "m.x", Operator: OpContains, Values: []string{"abc"}},
+					&FilterCondition{Property: "n", Operator: OpIsNotNull},
+					&FilterCondition{Property: "n", Operator: OpIsNotEmpty},
+					&FilterCondition{Property: "o", Operator: OpIs, Values: []string{"foo"}},
+					&FilterCondition{Property: "o", Operator: OpIs, Values: []string{""}},
+					&FilterCondition{Property: "o", Operator: OpIsOneOf, Values: []string{"foo", "boo"}},
+					&FilterCondition{Property: "o", Operator: OpIsNotNull},
+					&FilterCondition{Property: "o", Operator: OpIsEmpty},
+					&FilterCondition{Property: "o", Operator: OpIsNotEmpty},
+					&FilterCondition{Property: "q", Operator: OpContains, Values: []string{"1.34"}},
 				},
 			},
 			expected: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "m", "m.x", "n", "o", "q"},
@@ -907,19 +1125,19 @@ func Test_validateFilter(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			role := test.role
-			if role == state.Both {
-				role = state.Source
+		t.Run(test.name, func(t *testing.T) {
+			role := state.Source
+			if test.role != nil {
+				role = *test.role
 			}
 			target := state.TargetUser
-			if test.target == state.TargetEvent {
-				target = state.TargetEvent
+			if test.target != nil {
+				target = *test.target
 			}
 			got, err := validateFilter(&test.filter, schema, role, target)
 			if err != nil {
 				if test.err == nil {
-					t.Fatalf("expected no error, got error %q  (type %T)", err, err)
+					t.Fatalf("expected no error, got error %q (type %T)", err, err)
 				}
 				if !reflect.DeepEqual(test.err, err) {
 					t.Fatalf("expected error %q (type %T), got error %q (type %T)", test.err, test.err, err, err)
@@ -927,10 +1145,77 @@ func Test_validateFilter(t *testing.T) {
 				return
 			}
 			if test.err != nil {
-				t.Fatalf("expected error %q, got no errors", test.err)
+				t.Fatalf("expected error %q, got no error", test.err)
 			}
 			if !slices.Equal(test.expected, got) {
 				t.Fatalf("expected %q, got %q", test.expected, got)
+			}
+		})
+	}
+
+}
+
+// Test_validateFilterLimits verifies filter complexity limits for values built
+// directly in Go.
+func Test_validateFilterLimits(t *testing.T) {
+
+	schema := types.Object([]types.Property{{Name: "a", Type: types.Int(32)}})
+	filterWithDepth := func(depth int) *Filter {
+		var rule FilterRule = &FilterCondition{Property: "a", Operator: OpIs, Values: []string{"1"}}
+		for range depth {
+			rule = &Filter{Operator: OpAnd, Rules: []FilterRule{rule}}
+		}
+		return rule.(*Filter)
+	}
+	filterWithRuleCount := func(ruleCount int) *Filter {
+		rules := make([]FilterRule, ruleCount)
+		for i := range rules {
+			rules[i] = &FilterCondition{Property: "a", Operator: OpIs, Values: []string{"1"}}
+		}
+		return &Filter{Operator: OpAnd, Rules: rules}
+	}
+
+	tests := []struct {
+		name     string
+		filter   *Filter
+		expected error
+	}{
+		{"maximum depth", filterWithDepth(maxFilterDepth), nil},
+		{"excessive depth", filterWithDepth(maxFilterDepth + 1), fmt.Errorf("filter exceeds maximum depth of %d", maxFilterDepth)},
+		{"maximum rule count", filterWithRuleCount(maxFilterRuleCount), nil},
+		{"excessive rule count", filterWithRuleCount(maxFilterRuleCount + 1), fmt.Errorf("filter exceeds maximum rule count of %d", maxFilterRuleCount)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := validateFilter(test.filter, schema, state.Source, state.TargetUser)
+			if !reflect.DeepEqual(test.expected, err) {
+				t.Fatalf("expected error %q (type %T), got error %q (type %T)", test.expected, test.expected, err, err)
+			}
+		})
+	}
+
+}
+
+// Test_validateFilterRejectsNilRules verifies that filter validation rejects
+// nil rules, including interfaces containing typed nil pointers.
+func Test_validateFilterRejectsNilRules(t *testing.T) {
+
+	schema := types.Object([]types.Property{{Name: "a", Type: types.Int(32)}})
+	tests := []struct {
+		name string
+		rule FilterRule
+		err  error
+	}{
+		{"nil interface", nil, errors.New("unsupported filter rule")},
+		{"nil group", (*Filter)(nil), errors.New("filter group cannot be nil")},
+		{"nil condition", (*FilterCondition)(nil), errors.New("filter condition cannot be nil")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filter := &Filter{Operator: OpAnd, Rules: []FilterRule{test.rule}}
+			_, err := validateFilter(filter, schema, state.Source, state.TargetUser)
+			if !reflect.DeepEqual(test.err, err) {
+				t.Fatalf("expected error %q (type %T), got error %q (type %T)", test.err, test.err, err, err)
 			}
 		})
 	}

--- a/core/filters_test.go
+++ b/core/filters_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,12 +29,13 @@ func Test_Filter_JSON(t *testing.T) {
 	data := []byte(`{"operator":"and","rules":[` +
 		`{"property":"a","operator":"is","values":["5"]},` +
 		`{"operator":"or","rules":[` +
-		`{"property":"b","operator":"is null","values":[]},` +
+		`{"property":"b","operator":"is null"},` +
 		`{"property":"c","operator":"is one of","values":["x","y"]}` +
 		`]}` +
 		`]}`)
 	var filter Filter
-	if err := json.Unmarshal(data, &filter); err != nil {
+	err := json.Unmarshal(data, &filter)
+	if err != nil {
 		t.Fatalf("unexpected error %q", err)
 	}
 	expected := Filter{
@@ -43,7 +45,7 @@ func Test_Filter_JSON(t *testing.T) {
 			&Filter{
 				Operator: OpOr,
 				Rules: []FilterRule{
-					&FilterCondition{Property: "b", Operator: OpIsNull, Values: []string{}},
+					&FilterCondition{Property: "b", Operator: OpIsNull},
 					&FilterCondition{Property: "c", Operator: OpIsOneOf, Values: []string{"x", "y"}},
 				},
 			},
@@ -60,19 +62,212 @@ func Test_Filter_JSON(t *testing.T) {
 		t.Fatalf("expected %s, got %s", data, got)
 	}
 
-	var encoded bytes.Buffer
-	err = json.Encode(&encoded, &Filter{
-		Operator: OpAnd,
+}
+
+// Test_Filter_MarshalJSONDoesNotValidateSemantics verifies that JSON encoding
+// does not reject filters solely because they are semantically invalid.
+func Test_Filter_MarshalJSONDoesNotValidateSemantics(t *testing.T) {
+
+	filter := Filter{
+		Operator: "invalid",
 		Rules: []FilterRule{
-			&FilterCondition{Property: "a", Operator: OpIsNull},
+			&Filter{Operator: "invalid"},
+			&FilterCondition{Operator: "invalid", Values: []string{}},
 		},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error %q", err)
 	}
-	const unary = `{"operator":"and","rules":[{"property":"a","operator":"is null","values":[]}]}`
-	if encoded.String() != unary {
-		t.Fatalf("expected %s, got %s", unary, encoded.String())
+	got, err := json.Marshal(filter)
+	if err != nil {
+		t.Fatalf("unexpected marshal error %q", err)
+	}
+	expected := `{"operator":"invalid","rules":[{"operator":"invalid","rules":[]},` +
+		`{"property":"","operator":"invalid","values":[]}]}`
+	if string(got) != expected {
+		t.Fatalf("expected %s, got %s", expected, got)
+	}
+
+}
+
+// Test_Filter_MarshalJSONRejectsInvalidStrings verifies that JSON encoding
+// returns an error for invalid UTF-8 in filter strings.
+func Test_Filter_MarshalJSONRejectsInvalidStrings(t *testing.T) {
+
+	invalid := string([]byte{0xff})
+	tests := []struct {
+		name   string
+		filter Filter
+	}{
+		{
+			name:   "logical operator",
+			filter: Filter{Operator: FilterLogical(invalid)},
+		},
+		{
+			name: "property",
+			filter: Filter{Rules: []FilterRule{
+				&FilterCondition{Property: invalid},
+			}},
+		},
+		{
+			name: "condition operator",
+			filter: Filter{Rules: []FilterRule{
+				&FilterCondition{Operator: FilterOperator(invalid)},
+			}},
+		},
+		{
+			name: "condition value",
+			filter: Filter{Rules: []FilterRule{
+				&FilterCondition{Values: []string{invalid}},
+			}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := json.Marshal(&test.filter)
+			if err != nil {
+				return
+			}
+			t.Fatal("expected error, got no error")
+		})
+	}
+
+}
+
+// Test_Filter_MarshalJSONRejectsNilReceivers verifies that MarshalJSON returns
+// an error when called directly on a nil receiver.
+func Test_Filter_MarshalJSONRejectsNilReceivers(t *testing.T) {
+
+	var filter *Filter
+	_, err := filter.MarshalJSON()
+	if err != nil {
+		if err.Error() != "filter cannot be nil" {
+			t.Fatalf("expected filter error %q, got %q", "filter cannot be nil", err)
+		}
+	}
+	if err == nil {
+		t.Fatal("expected filter error, got no error")
+	}
+
+	var condition *FilterCondition
+	_, err = condition.MarshalJSON()
+	if err != nil {
+		if err.Error() != "filter condition cannot be nil" {
+			t.Fatalf("expected condition error %q, got %q", "filter condition cannot be nil", err)
+		}
+	}
+	if err == nil {
+		t.Fatal("expected condition error, got no error")
+	}
+
+}
+
+// Test_Filter_MarshalJSONRejectsNilRules verifies that JSON encoding returns
+// an error for nil rules.
+func Test_Filter_MarshalJSONRejectsNilRules(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		rule     FilterRule
+		expected string
+	}{
+		{"interface", nil, "filter rule cannot be nil"},
+		{"group", (*Filter)(nil), "filter group cannot be nil"},
+		{"condition", (*FilterCondition)(nil), "filter condition cannot be nil"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filter := Filter{Operator: OpAnd, Rules: []FilterRule{test.rule}}
+			_, err := json.Marshal(&filter)
+			if err != nil {
+				if !strings.Contains(err.Error(), test.expected) {
+					t.Fatalf("expected error %q, got %q", test.expected, err)
+				}
+				return
+			}
+			t.Fatal("expected error, got no error")
+		})
+	}
+
+}
+
+// Test_Filter_MarshalJSONValues verifies the JSON representation of nil,
+// empty, and non-empty condition values.
+func Test_Filter_MarshalJSONValues(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		condition *FilterCondition
+		expected  string
+	}{
+		{
+			name:      "nil",
+			condition: &FilterCondition{Property: "a", Operator: OpIsNull},
+			expected:  `{"property":"a","operator":"is null"}`,
+		},
+		{
+			name:      "empty",
+			condition: &FilterCondition{Property: "a", Operator: OpIsNull, Values: []string{}},
+			expected:  `{"property":"a","operator":"is null","values":[]}`,
+		},
+		{
+			name:      "non-empty",
+			condition: &FilterCondition{Property: "a", Operator: OpIs, Values: []string{"5"}},
+			expected:  `{"property":"a","operator":"is","values":["5"]}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := json.Marshal(test.condition)
+			if err != nil {
+				t.Fatalf("unexpected condition marshal error %q", err)
+			}
+			if string(got) != test.expected {
+				t.Fatalf("expected %s, got %s", test.expected, got)
+			}
+
+			filter := &Filter{Operator: OpAnd, Rules: []FilterRule{test.condition}}
+			got, err = json.Marshal(filter)
+			if err != nil {
+				t.Fatalf("unexpected filter marshal error %q", err)
+			}
+			expectedFilter := `{"operator":"and","rules":[` + test.expected + `]}`
+			if string(got) != expectedFilter {
+				t.Fatalf("expected %s, got %s", expectedFilter, got)
+			}
+
+			var encoded bytes.Buffer
+			err = json.Encode(&encoded, filter)
+			if err != nil {
+				t.Fatalf("unexpected encode error %q", err)
+			}
+			if encoded.String() != expectedFilter {
+				t.Fatalf("expected %s, got %s", expectedFilter, encoded.String())
+			}
+		})
+	}
+
+}
+
+// Test_Filter_UnmarshalJSONDoesNotValidateSemantics verifies that JSON
+// decoding does not reject filters solely because they are semantically
+// invalid.
+func Test_Filter_UnmarshalJSONDoesNotValidateSemantics(t *testing.T) {
+
+	data := []byte(`{"operator":"invalid","rules":[` +
+		`{"operator":"invalid","rules":[]},` +
+		`{"property":"","operator":"invalid","values":[]}]}`)
+	var filter Filter
+	err := json.Unmarshal(data, &filter)
+	if err != nil {
+		t.Fatalf("unexpected unmarshal error %q", err)
+	}
+	expected := Filter{
+		Operator: "invalid",
+		Rules: []FilterRule{
+			&Filter{Operator: "invalid", Rules: []FilterRule{}},
+			&FilterCondition{Operator: "invalid", Values: []string{}},
+		},
+	}
+	if diff := cmp.Diff(&expected, &filter); diff != "" {
+		t.Fatalf("unexpected filter (-want +got):\n%s", diff)
 	}
 
 }
@@ -82,25 +277,62 @@ func Test_Filter_JSON(t *testing.T) {
 func Test_Filter_UnmarshalJSONRejectsInvalidStructure(t *testing.T) {
 
 	tests := []string{
+		`null`,
 		`[]`,
+		`{"operator":"and"}`,
+		`{"rules":[]}`,
+		`{"operator":1,"rules":[]}`,
+		`{"operator":"and","operator":"or","rules":[]}`,
+		`{"operator":"and","rules":[],"rules":[]}`,
 		`{"operator":"and","rules":"invalid"}`,
+		`{"operator":"and","rules":null}`,
+		`{"operator":"and","rules":[],"values":[]}`,
 		`{"operator":"and","rules":[true]}`,
 		`{"operator":"and","rules":[{"rules":[]}]}`,
 		`{"operator":"and","rules":[{"operator":"or","rules":[],"property":"a"}]}`,
 		`{"operator":"and","rules":[{}]}`,
-		`{"operator":"and","rules":[{"property":"a","operator":"is"}]}`,
-		`{"operator":"and","rules":[{"property":"a","operator":"is","values":null}]}`,
+		`{"operator":"and","rules":[{"property":"a","values":[]}]}`,
+		`{"operator":"and","rules":[{"property":1,"operator":"is"}]}`,
+		`{"operator":"and","rules":[{"property":"a","operator":1}]}`,
+		`{"operator":"and","rules":[{"property":"a","operator":"is","values":true}]}`,
+		`{"operator":"and","rules":[{"property":"a","operator":"is","values":[1]}]}`,
+		`{"operator":"and","rules":[{"property":"a","operator":"is","values":[],"values":[]}]}`,
 		`{"operator":"and","rules":[{"property":"a","operator":"is","values":["1"],"extra":true}]}`,
 		`{"operator":"and","rules":[],"logical":"and"}`,
 	}
 	for _, data := range tests {
 		t.Run(data, func(t *testing.T) {
 			var filter Filter
-			if err := json.Unmarshal([]byte(data), &filter); err == nil {
+			err := json.Unmarshal([]byte(data), &filter)
+			if err == nil {
 				t.Fatal("expected error, got no error")
 			}
 		})
 	}
+}
+
+// Test_Filter_UnmarshalJSONRejectsRootConditions verifies that decoding a
+// condition as a Filter reports that the top-level value must be a group.
+func Test_Filter_UnmarshalJSONRejectsRootConditions(t *testing.T) {
+
+	tests := []string{
+		`{"property":"a","operator":"is","values":["1"]}`,
+		`{"values":true,"property":"a","operator":"is"}`,
+	}
+	for _, data := range tests {
+		t.Run(data, func(t *testing.T) {
+			var filter Filter
+			err := json.Unmarshal([]byte(data), &filter)
+			if err != nil {
+				if !strings.Contains(err.Error(), "filter must be a group") {
+					t.Fatalf("expected group error, got %q", err)
+				}
+				return
+			}
+			t.Fatal("expected error, got no error")
+		})
+	}
+
 }
 
 // Test_Filter_UnmarshalJSONLimits verifies filter complexity limits while
@@ -121,6 +353,12 @@ func Test_Filter_UnmarshalJSONLimits(t *testing.T) {
 		}
 		return &Filter{Operator: OpAnd, Rules: rules}
 	}
+	filterWithNestedRuleCount := func(ruleCount int) *Filter {
+		nestedRuleCount := ruleCount / 2
+		filter := filterWithRuleCount(ruleCount - nestedRuleCount - 1)
+		filter.Rules = append(filter.Rules, filterWithRuleCount(nestedRuleCount))
+		return filter
+	}
 
 	tests := []struct {
 		name     string
@@ -131,6 +369,8 @@ func Test_Filter_UnmarshalJSONLimits(t *testing.T) {
 		{"excessive depth", filterWithDepth(maxFilterDepth + 1), fmt.Errorf("filter exceeds maximum depth of %d", maxFilterDepth)},
 		{"maximum rule count", filterWithRuleCount(maxFilterRuleCount), nil},
 		{"excessive rule count", filterWithRuleCount(maxFilterRuleCount + 1), fmt.Errorf("filter exceeds maximum rule count of %d", maxFilterRuleCount)},
+		{"maximum nested rule count", filterWithNestedRuleCount(maxFilterRuleCount), nil},
+		{"excessive nested rule count", filterWithNestedRuleCount(maxFilterRuleCount + 1), fmt.Errorf("filter exceeds maximum rule count of %d", maxFilterRuleCount)},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -145,6 +385,81 @@ func Test_Filter_UnmarshalJSONLimits(t *testing.T) {
 			}
 			if !reflect.DeepEqual(test.expected, err) {
 				t.Fatalf("expected error %q (type %T), got error %q (type %T)", test.expected, test.expected, err, err)
+			}
+		})
+	}
+
+}
+
+// Test_Filter_UnmarshalJSONValues verifies that absent and null condition
+// values decode as nil while an empty array remains non-nil.
+func Test_Filter_UnmarshalJSONValues(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		data     string
+		expected []string
+	}{
+		{
+			name: "absent",
+			data: `{"operator":"and","rules":[` +
+				`{"property":"a","operator":"is null"}]}`,
+		},
+		{
+			name: "null",
+			data: `{"operator":"and","rules":[` +
+				`{"property":"a","operator":"is null","values":null}]}`,
+		},
+		{
+			name: "absent with valued operator",
+			data: `{"operator":"and","rules":[` +
+				`{"property":"a","operator":"is"}]}`,
+		},
+		{
+			name: "null with valued operator",
+			data: `{"operator":"and","rules":[` +
+				`{"property":"a","operator":"is","values":null}]}`,
+		},
+		{
+			name: "empty",
+			data: `{"operator":"and","rules":[` +
+				`{"property":"a","operator":"is null","values":[]}]}`,
+			expected: []string{},
+		},
+		{
+			name: "non-empty",
+			data: `{"operator":"and","rules":[` +
+				`{"property":"a","operator":"is","values":["5"]}]}`,
+			expected: []string{"5"},
+		},
+		{
+			name: "null element",
+			data: `{"operator":"and","rules":[` +
+				`{"property":"a","operator":"is","values":[null]}]}`,
+			expected: []string{""},
+		},
+		{
+			name:     "members in a different order",
+			data:     `{"rules":[{"values":["5"],"operator":"is","property":"a"}],"operator":"and"}`,
+			expected: []string{"5"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var filter Filter
+			err := json.Unmarshal([]byte(test.data), &filter)
+			if err != nil {
+				t.Fatalf("unexpected unmarshal error %q", err)
+			}
+			if len(filter.Rules) != 1 {
+				t.Fatalf("expected one rule, got %d", len(filter.Rules))
+			}
+			condition, ok := filter.Rules[0].(*FilterCondition)
+			if !ok {
+				t.Fatalf("expected a filter condition, got %T", filter.Rules[0])
+			}
+			if diff := cmp.Diff(test.expected, condition.Values); diff != "" {
+				t.Fatalf("unexpected values (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -912,6 +1227,26 @@ func Test_validateFilter(t *testing.T) {
 				},
 			},
 			err: errors.New(`operator "boo" is not valid`),
+		},
+		{
+			name: "no values with unary operator",
+			filter: Filter{
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpIsNull},
+				},
+			},
+			expected: []string{"b"},
+		},
+		{
+			name: "empty values with unary operator",
+			filter: Filter{
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "b", Operator: OpIsNull, Values: []string{}},
+				},
+			},
+			err: errors.New(`values cannot be used with the operator "is null"`),
 		},
 		{
 			name: "value with unary operator",

--- a/core/internal/datastore/query.go
+++ b/core/internal/datastore/query.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/krenalis/krenalis/core/internal/state"
+	"github.com/krenalis/krenalis/tools/errors"
 	"github.com/krenalis/krenalis/warehouses"
 )
 
@@ -50,51 +51,103 @@ type Query struct {
 }
 
 // convertWhere converts a state.Where expression into a warehouses.Expr.
-// "exists" and "does not exist" operators are mapped to OpIsNotNull and
-// OpIsNull, respectively.
-func convertWhere(where *state.Where, columnFromProperty map[string]warehouses.Column) (warehouses.Expr, error) {
-	exp := warehouses.NewMultiExpr(warehouses.LogicalOperator(where.Logical), make([]warehouses.Expr, len(where.Conditions)))
-	for i, cond := range where.Conditions {
-		path := strings.Join(cond.Property, ".") // TODO(marco): How can I avoid this allocation?
-		if column, ok := columnFromProperty[path]; ok {
+// "exists" and "does not exist" operators are mapped to warehouses.OpIsNotNull
+// and warehouses.OpIsNull, respectively. For object properties, "exists"
+// matches if any descendant column is non-null, while "does not exist" matches
+// if all descendant columns are null.
+func convertWhere(where *state.Where, columnByProperty map[string]warehouses.Column) (warehouses.Expr, error) {
+
+	if where == nil {
+		return nil, errors.New("where expression cannot be nil")
+	}
+	if where.Operator != state.OpAnd && where.Operator != state.OpOr {
+		return nil, fmt.Errorf("invalid logical operator %d in where expression", int(where.Operator))
+	}
+
+	// state.WhereLogical values match the corresponding
+	// warehouses.LogicalOperator values.
+	expr := warehouses.NewMultiExpr(
+		warehouses.LogicalOperator(where.Operator),
+		make([]warehouses.Expr, len(where.Rules)),
+	)
+
+	for i, rule := range where.Rules {
+
+		switch rule := rule.(type) {
+
+		case *state.Where:
+			if rule == nil {
+				return nil, errors.New("where group cannot be nil")
+			}
+			operand, err := convertWhere(rule, columnByProperty)
+			if err != nil {
+				return nil, err
+			}
+			expr.Operands[i] = operand
+
+		case *state.WhereCondition:
+			if rule == nil {
+				return nil, errors.New("where condition cannot be nil")
+			}
+			path := strings.Join(rule.Property, ".")
+			if rule.Operator < state.OpIs || rule.Operator > state.OpDoesNotExist {
+				return nil, fmt.Errorf("invalid operator %d for property %q in where expression",
+					int(rule.Operator), path)
+			}
+			if column, ok := columnByProperty[path]; ok {
+				var op warehouses.Operator
+				switch rule.Operator {
+				case state.OpExists:
+					op = warehouses.OpIsNotNull
+				case state.OpDoesNotExist:
+					op = warehouses.OpIsNull
+				default:
+					// state.WhereOperator values through state.OpIsNotNull match the
+					// corresponding warehouses.Operator values.
+					op = warehouses.Operator(rule.Operator)
+				}
+				expr.Operands[i] = warehouses.NewBaseExpr(column, op, rule.Values...)
+				continue
+			}
+			var descendantColumns []warehouses.Column
+			n := len(path)
+			for name, column := range columnByProperty {
+				if len(name) > n && name[n] == '.' && name[:n] == path {
+					descendantColumns = append(descendantColumns, column)
+				}
+			}
+			if len(descendantColumns) == 0 {
+				return nil, fmt.Errorf("property %q does not map to any warehouse columns", path)
+			}
+			// The property is an object; apply the condition to all descendant columns.
+			var logicalOp warehouses.LogicalOperator
 			var op warehouses.Operator
-			switch cond.Operator {
+			switch rule.Operator {
 			case state.OpExists:
+				logicalOp = warehouses.OpOr
 				op = warehouses.OpIsNotNull
 			case state.OpDoesNotExist:
+				logicalOp = warehouses.OpAnd
 				op = warehouses.OpIsNull
 			default:
-				op = warehouses.Operator(cond.Operator)
+				return nil, fmt.Errorf("operator %q cannot be used with object property %q in where expression",
+					rule.Operator, path)
 			}
-			exp.Operands[i] = warehouses.NewBaseExpr(column, op, cond.Values...)
-			continue
-		}
-		// The property is an object; apply it to all sub-property columns.
-		var logical warehouses.LogicalOperator
-		var op warehouses.Operator
-		switch cond.Operator {
-		case state.OpExists:
-			logical = warehouses.OpOr
-			op = warehouses.OpIsNotNull
-		case state.OpDoesNotExist:
-			logical = warehouses.OpAnd
-			op = warehouses.OpIsNull
+			slices.SortFunc(descendantColumns, func(a, b warehouses.Column) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+			operands := make([]warehouses.Expr, len(descendantColumns))
+			for j, column := range descendantColumns {
+				operands[j] = warehouses.NewBaseExpr(column, op)
+			}
+			expr.Operands[i] = warehouses.NewMultiExpr(logicalOp, operands)
+
 		default:
-			return nil, fmt.Errorf("invalid operator %q for property %q in where expression", cond.Operator, path)
+			return nil, errors.New("unsupported where rule")
+
 		}
-		var operands []warehouses.Expr
-		for name, column := range columnFromProperty {
-			if strings.HasPrefix(name, path) && name[len(path)] == '.' {
-				operands = append(operands, warehouses.NewBaseExpr(column, op))
-			}
-		}
-		if operands == nil {
-			return nil, fmt.Errorf("property %q does not exist in where expression", path)
-		}
-		slices.SortFunc(operands, func(a, b warehouses.Expr) int {
-			return cmp.Compare(a.(*warehouses.BaseExpr).Column.Name, b.(*warehouses.BaseExpr).Column.Name)
-		})
-		exp.Operands[i] = warehouses.NewMultiExpr(logical, operands)
+
 	}
-	return exp, nil
+
+	return expr, nil
 }

--- a/core/internal/datastore/query.go
+++ b/core/internal/datastore/query.go
@@ -63,9 +63,11 @@ func convertWhere(where *state.Where, columnByProperty map[string]warehouses.Col
 	if where.Operator != state.OpAnd && where.Operator != state.OpOr {
 		return nil, fmt.Errorf("invalid logical operator %d in where expression", int(where.Operator))
 	}
+	if len(where.Rules) == 0 {
+		return nil, errors.New("where rules are missing")
+	}
 
-	// state.WhereLogical values match the corresponding
-	// warehouses.LogicalOperator values.
+	// state.WhereLogical values match the corresponding warehouses.LogicalOperator values.
 	expr := warehouses.NewMultiExpr(
 		warehouses.LogicalOperator(where.Operator),
 		make([]warehouses.Expr, len(where.Rules)),
@@ -89,7 +91,7 @@ func convertWhere(where *state.Where, columnByProperty map[string]warehouses.Col
 			if rule == nil {
 				return nil, errors.New("where condition cannot be nil")
 			}
-			path := strings.Join(rule.Property, ".")
+			path := strings.Join(rule.Property, ".") // TODO(marco): How can I avoid this allocation?
 			if rule.Operator < state.OpIs || rule.Operator > state.OpDoesNotExist {
 				return nil, fmt.Errorf("invalid operator %d for property %q in where expression",
 					int(rule.Operator), path)
@@ -102,8 +104,6 @@ func convertWhere(where *state.Where, columnByProperty map[string]warehouses.Col
 				case state.OpDoesNotExist:
 					op = warehouses.OpIsNull
 				default:
-					// state.WhereOperator values through state.OpIsNotNull match the
-					// corresponding warehouses.Operator values.
 					op = warehouses.Operator(rule.Operator)
 				}
 				expr.Operands[i] = warehouses.NewBaseExpr(column, op, rule.Values...)

--- a/core/internal/datastore/query_test.go
+++ b/core/internal/datastore/query_test.go
@@ -285,6 +285,38 @@ func TestConvertWhereRejectsInvalidOperators(t *testing.T) {
 	}
 }
 
+// TestConvertWhereRejectsMissingRules tests convertWhere with empty top-level
+// and nested groups.
+func TestConvertWhereRejectsMissingRules(t *testing.T) {
+	tests := []struct {
+		name  string
+		where *state.Where
+	}{
+		{
+			name:  "top-level group",
+			where: &state.Where{Operator: state.OpAnd},
+		},
+		{
+			name: "nested group",
+			where: &state.Where{
+				Operator: state.OpAnd,
+				Rules: []state.WhereRule{
+					&state.Where{Operator: state.OpOr},
+				},
+			},
+		},
+	}
+	expected := errors.New("where rules are missing")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := convertWhere(test.where, nil)
+			if !reflect.DeepEqual(expected, err) {
+				t.Fatalf("expected error %q (type %T), got error %q (type %T)", expected, expected, err, err)
+			}
+		})
+	}
+}
+
 // TestConvertWhereRejectsUnsupportedObjectOperator tests convertWhere with an
 // operator that cannot be translated for an object property.
 func TestConvertWhereRejectsUnsupportedObjectOperator(t *testing.T) {

--- a/core/internal/datastore/query_test.go
+++ b/core/internal/datastore/query_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/krenalis/krenalis/core/internal/state"
+	"github.com/krenalis/krenalis/tools/errors"
 	"github.com/krenalis/krenalis/tools/types"
 	"github.com/krenalis/krenalis/warehouses"
 )
@@ -20,9 +21,9 @@ func TestConvertWhereSimple(t *testing.T) {
 		"a": column,
 	}
 	where := &state.Where{
-		Logical: state.OpAnd,
-		Conditions: []state.WhereCondition{
-			{Property: []string{"a"}, Operator: state.OpIs, Values: []any{1}},
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIs, Values: []any{1}},
 		},
 	}
 	got, err := convertWhere(where, columns)
@@ -46,10 +47,10 @@ func TestConvertWhereMultiple(t *testing.T) {
 		"b.c": colBC,
 	}
 	where := &state.Where{
-		Logical: state.OpOr,
-		Conditions: []state.WhereCondition{
-			{Property: []string{"a"}, Operator: state.OpIsGreaterThan, Values: []any{5}},
-			{Property: []string{"b", "c"}, Operator: state.OpIsLessThanOrEqualTo, Values: []any{10}},
+		Operator: state.OpOr,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIsGreaterThan, Values: []any{5}},
+			&state.WhereCondition{Property: []string{"b", "c"}, Operator: state.OpIsLessThanOrEqualTo, Values: []any{10}},
 		},
 	}
 	got, err := convertWhere(where, columns)
@@ -65,26 +66,94 @@ func TestConvertWhereMultiple(t *testing.T) {
 	}
 }
 
-// TestConvertWhereExistsOperators tests convertWhere with exists operators.
+// TestConvertWhereMultipleValues tests convertWhere with a condition containing
+// multiple values.
+func TestConvertWhereMultipleValues(t *testing.T) {
+	column := warehouses.Column{Name: "a", Type: types.Int(32)}
+	where := &state.Where{
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{
+				Property: []string{"a"},
+				Operator: state.OpIsBetween,
+				Values:   []any{5, 10},
+			},
+		},
+	}
+	got, err := convertWhere(where, map[string]warehouses.Column{"a": column})
+	if err != nil {
+		t.Fatalf("convertWhere returned error: %v", err)
+	}
+	want := warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
+		warehouses.NewBaseExpr(column, warehouses.OpIsBetween, 5, 10),
+	})
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("expected %#v, got %#v", want, got)
+	}
+}
+
+// TestConvertWhereNested tests convertWhere with a nested logical group.
+func TestConvertWhereNested(t *testing.T) {
+	colA := warehouses.Column{Name: "a", Type: types.Int(32)}
+	colB := warehouses.Column{Name: "b", Type: types.Int(32)}
+	colC := warehouses.Column{Name: "c", Type: types.Int(32)}
+	columns := map[string]warehouses.Column{"a": colA, "b": colB, "c": colC}
+	where := &state.Where{
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIs, Values: []any{1}},
+			&state.Where{
+				Operator: state.OpOr,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{Property: []string{"b"}, Operator: state.OpIsGreaterThan, Values: []any{2}},
+					&state.WhereCondition{Property: []string{"c"}, Operator: state.OpIsLessThan, Values: []any{3}},
+				},
+			},
+		},
+	}
+	got, err := convertWhere(where, columns)
+	if err != nil {
+		t.Fatalf("convertWhere returned error: %v", err)
+	}
+	want := warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
+		warehouses.NewBaseExpr(colA, warehouses.OpIs, 1),
+		warehouses.NewMultiExpr(warehouses.OpOr, []warehouses.Expr{
+			warehouses.NewBaseExpr(colB, warehouses.OpIsGreaterThan, 2),
+			warehouses.NewBaseExpr(colC, warehouses.OpIsLessThan, 3),
+		}),
+	})
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("expected %#v, got %#v", want, got)
+	}
+}
+
+// TestConvertWhereExistsOperators tests convertWhere with "exists" and
+// "does not exist" operators.
 func TestConvertWhereExistsOperators(t *testing.T) {
 	colA := warehouses.Column{Name: "a", Type: types.Int(32)}
 	colBC := warehouses.Column{Name: "b_c", Type: types.Int(32)}
 	colBD := warehouses.Column{Name: "b_d", Type: types.String()}
+	colBEF := warehouses.Column{Name: "b_e_f", Type: types.String()}
 	colEF := warehouses.Column{Name: "e_f", Type: types.Boolean()}
 	colEG := warehouses.Column{Name: "e_g", Type: types.String()}
+	colH := warehouses.Column{Name: "h", Type: types.String()}
 	columns := map[string]warehouses.Column{
-		"a":   colA,
-		"b.c": colBC,
-		"b.d": colBD,
-		"e.f": colEF,
-		"e.g": colEG,
+		"a":     colA,
+		"b.c":   colBC,
+		"b.d":   colBD,
+		"b.e.f": colBEF,
+		"b2.c":  {Name: "b2_c", Type: types.String()},
+		"e.f":   colEF,
+		"e.g":   colEG,
+		"h":     colH,
 	}
 	where := &state.Where{
-		Logical: state.OpAnd,
-		Conditions: []state.WhereCondition{
-			{Property: []string{"a"}, Operator: state.OpExists},
-			{Property: []string{"b"}, Operator: state.OpDoesNotExist},
-			{Property: []string{"e"}, Operator: state.OpExists},
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{Property: []string{"a"}, Operator: state.OpExists},
+			&state.WhereCondition{Property: []string{"h"}, Operator: state.OpDoesNotExist},
+			&state.WhereCondition{Property: []string{"b"}, Operator: state.OpDoesNotExist},
+			&state.WhereCondition{Property: []string{"e"}, Operator: state.OpExists},
 		},
 	}
 	got, err := convertWhere(where, columns)
@@ -93,9 +162,11 @@ func TestConvertWhereExistsOperators(t *testing.T) {
 	}
 	want := warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
 		warehouses.NewBaseExpr(colA, warehouses.OpIsNotNull),
+		warehouses.NewBaseExpr(colH, warehouses.OpIsNull),
 		warehouses.NewMultiExpr(warehouses.OpAnd, []warehouses.Expr{
 			warehouses.NewBaseExpr(colBC, warehouses.OpIsNull),
 			warehouses.NewBaseExpr(colBD, warehouses.OpIsNull),
+			warehouses.NewBaseExpr(colBEF, warehouses.OpIsNull),
 		}),
 		warehouses.NewMultiExpr(warehouses.OpOr, []warehouses.Expr{
 			warehouses.NewBaseExpr(colEF, warehouses.OpIsNotNull),
@@ -107,17 +178,224 @@ func TestConvertWhereExistsOperators(t *testing.T) {
 	}
 }
 
+// TestConvertWhereRejectsNilValues tests convertWhere with nil expressions and
+// rules.
+func TestConvertWhereRejectsNilValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		where    *state.Where
+		expected error
+	}{
+		{
+			name:     "nil expression",
+			expected: errors.New("where expression cannot be nil"),
+		},
+		{
+			name: "nil rule",
+			where: &state.Where{
+				Operator: state.OpAnd,
+				Rules:    []state.WhereRule{nil},
+			},
+			expected: errors.New("unsupported where rule"),
+		},
+		{
+			name: "nil group",
+			where: &state.Where{
+				Operator: state.OpAnd,
+				Rules:    []state.WhereRule{(*state.Where)(nil)},
+			},
+			expected: errors.New("where group cannot be nil"),
+		},
+		{
+			name: "nil condition",
+			where: &state.Where{
+				Operator: state.OpAnd,
+				Rules:    []state.WhereRule{(*state.WhereCondition)(nil)},
+			},
+			expected: errors.New("where condition cannot be nil"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			_, err := convertWhere(test.where, nil)
+			if !reflect.DeepEqual(test.expected, err) {
+				t.Fatalf("expected error %q (type %T), got error %q (type %T)", test.expected, test.expected, err, err)
+			}
+
+		})
+	}
+}
+
+// TestConvertWhereRejectsInvalidOperators tests convertWhere with logical and
+// condition operators outside their valid ranges.
+func TestConvertWhereRejectsInvalidOperators(t *testing.T) {
+	tests := []struct {
+		name     string
+		where    *state.Where
+		expected error
+	}{
+		{
+			name: "logical operator below range",
+			where: &state.Where{
+				Operator: state.WhereLogical(-1),
+			},
+			expected: errors.New("invalid logical operator -1 in where expression"),
+		},
+		{
+			name: "logical operator above range",
+			where: &state.Where{
+				Operator: state.WhereLogical(state.OpOr + 1),
+			},
+			expected: errors.New("invalid logical operator 2 in where expression"),
+		},
+		{
+			name: "condition operator below range",
+			where: &state.Where{
+				Operator: state.OpAnd,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{Property: []string{"a"}, Operator: state.WhereOperator(-1)},
+				},
+			},
+			expected: errors.New(`invalid operator -1 for property "a" in where expression`),
+		},
+		{
+			name: "condition operator above range",
+			where: &state.Where{
+				Operator: state.OpAnd,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{
+						Property: []string{"a"},
+						Operator: state.WhereOperator(state.OpDoesNotExist + 1),
+					},
+				},
+			},
+			expected: errors.New(`invalid operator 26 for property "a" in where expression`),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			_, err := convertWhere(test.where, nil)
+			if !reflect.DeepEqual(test.expected, err) {
+				t.Fatalf("expected error %q (type %T), got error %q (type %T)", test.expected, test.expected, err, err)
+			}
+
+		})
+	}
+}
+
+// TestConvertWhereRejectsUnsupportedObjectOperator tests convertWhere with an
+// operator that cannot be translated for an object property.
+func TestConvertWhereRejectsUnsupportedObjectOperator(t *testing.T) {
+	where := &state.Where{
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIs, Values: []any{1}},
+		},
+	}
+	columns := map[string]warehouses.Column{
+		"a.b": {Name: "a_b", Type: types.Int(32)},
+	}
+	_, err := convertWhere(where, columns)
+	expected := errors.New(`operator "Is" cannot be used with object property "a" in where expression`)
+	if !reflect.DeepEqual(expected, err) {
+		t.Fatalf("expected error %q (type %T), got error %q (type %T)", expected, expected, err, err)
+	}
+}
+
 // TestConvertWhereUnknownProperty tests convertWhere with an unknown property
 // path.
 func TestConvertWhereUnknownProperty(t *testing.T) {
-	where := &state.Where{
-		Logical: state.OpAnd,
-		Conditions: []state.WhereCondition{
-			{Property: []string{"a"}, Operator: state.OpIs, Values: []any{1}},
-		},
+	tests := []struct {
+		name     string
+		operator state.WhereOperator
+	}{
+		{"exists", state.OpExists},
+		{"is", state.OpIs},
 	}
-	_, err := convertWhere(where, map[string]warehouses.Column{})
-	if err == nil {
-		t.Fatalf("expected error, got no error")
+	expected := errors.New(`property "a" does not map to any warehouse columns`)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			where := &state.Where{
+				Operator: state.OpAnd,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{Property: []string{"a"}, Operator: test.operator},
+				},
+			}
+			_, err := convertWhere(where, map[string]warehouses.Column{})
+			if !reflect.DeepEqual(expected, err) {
+				t.Fatalf("expected error %q (type %T), got error %q (type %T)", expected, expected, err, err)
+			}
+
+		})
 	}
+}
+
+// TestConvertWhereOperatorValues verifies that state.WhereLogical values and
+// state.WhereOperator values through state.OpIsNotNull match their warehouse
+// counterparts.
+func TestConvertWhereOperatorValues(t *testing.T) {
+
+	logicalOperators := []struct {
+		name      string
+		state     state.WhereLogical
+		warehouse warehouses.LogicalOperator
+	}{
+		{"and", state.OpAnd, warehouses.OpAnd},
+		{"or", state.OpOr, warehouses.OpOr},
+	}
+
+	for _, operator := range logicalOperators {
+		t.Run("logical/"+operator.name, func(t *testing.T) {
+
+			if got := warehouses.LogicalOperator(operator.state); got != operator.warehouse {
+				t.Fatalf("expected warehouse operator %d, got %d", operator.warehouse, got)
+			}
+
+		})
+	}
+
+	conditionOperators := []struct {
+		name      string
+		state     state.WhereOperator
+		warehouse warehouses.Operator
+	}{
+		{"is", state.OpIs, warehouses.OpIs},
+		{"is not", state.OpIsNot, warehouses.OpIsNot},
+		{"is less than", state.OpIsLessThan, warehouses.OpIsLessThan},
+		{"is less than or equal to", state.OpIsLessThanOrEqualTo, warehouses.OpIsLessThanOrEqualTo},
+		{"is greater than", state.OpIsGreaterThan, warehouses.OpIsGreaterThan},
+		{"is greater than or equal to", state.OpIsGreaterThanOrEqualTo, warehouses.OpIsGreaterThanOrEqualTo},
+		{"is between", state.OpIsBetween, warehouses.OpIsBetween},
+		{"is not between", state.OpIsNotBetween, warehouses.OpIsNotBetween},
+		{"contains", state.OpContains, warehouses.OpContains},
+		{"does not contain", state.OpDoesNotContain, warehouses.OpDoesNotContain},
+		{"is one of", state.OpIsOneOf, warehouses.OpIsOneOf},
+		{"is not one of", state.OpIsNotOneOf, warehouses.OpIsNotOneOf},
+		{"starts with", state.OpStartsWith, warehouses.OpStartsWith},
+		{"ends with", state.OpEndsWith, warehouses.OpEndsWith},
+		{"is before", state.OpIsBefore, warehouses.OpIsBefore},
+		{"is on or before", state.OpIsOnOrBefore, warehouses.OpIsOnOrBefore},
+		{"is after", state.OpIsAfter, warehouses.OpIsAfter},
+		{"is on or after", state.OpIsOnOrAfter, warehouses.OpIsOnOrAfter},
+		{"is true", state.OpIsTrue, warehouses.OpIsTrue},
+		{"is false", state.OpIsFalse, warehouses.OpIsFalse},
+		{"is empty", state.OpIsEmpty, warehouses.OpIsEmpty},
+		{"is not empty", state.OpIsNotEmpty, warehouses.OpIsNotEmpty},
+		{"is null", state.OpIsNull, warehouses.OpIsNull},
+		{"is not null", state.OpIsNotNull, warehouses.OpIsNotNull},
+	}
+
+	for _, operator := range conditionOperators {
+		t.Run("condition/"+operator.name, func(t *testing.T) {
+
+			if got := warehouses.Operator(operator.state); got != operator.warehouse {
+				t.Fatalf("expected warehouse operator %d, got %d", operator.warehouse, got)
+			}
+
+		})
+	}
+
 }

--- a/core/internal/filters/applies.go
+++ b/core/internal/filters/applies.go
@@ -18,76 +18,89 @@ func Applies(where *state.Where, attributes map[string]any) bool {
 	if where == nil {
 		return true
 	}
-	for _, cond := range where.Conditions {
-		op := cond.Operator
-		v, exists := readAttributeFrom(attributes, cond.Property)
+	for _, rule := range where.Rules {
 		var applies bool
-		switch op {
-		case state.OpIs:
-			applies = opIs(v, cond.Values)
-		case state.OpIsNot:
-			applies = !opIs(v, cond.Values)
-		case state.OpIsLessThan:
-			applies = opIsLessThan(v, cond.Values)
-		case state.OpIsLessThanOrEqualTo:
-			applies = opIsLessThanOrEqualTo(v, cond.Values)
-		case state.OpIsGreaterThan:
-			applies = opIsGreaterThan(v, cond.Values)
-		case state.OpIsGreaterThanOrEqualTo:
-			applies = opIsGreaterThanOrEqualTo(v, cond.Values)
-		case state.OpIsBetween:
-			applies = opIsBetween(v, cond.Values)
-		case state.OpIsNotBetween:
-			applies = !opIsBetween(v, cond.Values)
-		case state.OpContains:
-			applies = opContains(v, cond.Values)
-		case state.OpDoesNotContain:
-			applies = !opContains(v, cond.Values)
-		case state.OpIsOneOf:
-			applies = opIsIn(v, cond.Values)
-		case state.OpIsNotOneOf:
-			applies = !opIsIn(v, cond.Values)
-		case state.OpStartsWith:
-			applies = opStartsWith(v, cond.Values)
-		case state.OpEndsWith:
-			applies = opEndsWith(v, cond.Values)
-		case state.OpIsBefore:
-			applies = opIsBefore(v, cond.Values)
-		case state.OpIsOnOrBefore:
-			applies = opIsOnOrBefore(v, cond.Values)
-		case state.OpIsAfter:
-			applies = opIsAfter(v, cond.Values)
-		case state.OpIsOnOrAfter:
-			applies = opIsOnOrAfter(v, cond.Values)
-		case state.OpIsTrue:
-			applies = opIsTrue(v)
-		case state.OpIsFalse:
-			applies = opIsFalse(v)
-		case state.OpIsEmpty:
-			applies = opIsEmpty(v)
-		case state.OpIsNotEmpty:
-			applies = !opIsEmpty(v)
-		case state.OpIsNull:
-			applies = exists && opIsNull(v)
-		case state.OpIsNotNull:
-			applies = !(exists && opIsNull(v))
-		case state.OpExists:
-			applies = exists
-		case state.OpDoesNotExist:
-			applies = !exists
+		switch rule := rule.(type) {
+		case *state.Where:
+			applies = Applies(rule, attributes)
+		case *state.WhereCondition:
+			applies = appliesCondition(rule, attributes)
 		}
-		if applies && where.Logical == state.OpOr {
+		if applies && where.Operator == state.OpOr {
 			return true
 		}
-		if !applies && where.Logical == state.OpAnd {
+		if !applies && where.Operator == state.OpAnd {
 			return false
 		}
 	}
-	if where.Logical == state.OpOr {
+	if where.Operator == state.OpOr {
 		return false // none of the conditions applied.
 	}
 	// All the conditions applied.
 	return true
+}
+
+// appliesCondition reports whether condition matches the given attributes.
+func appliesCondition(condition *state.WhereCondition, attributes map[string]any) bool {
+
+	op := condition.Operator
+	v, exists := readAttributeFrom(attributes, condition.Property)
+	switch op {
+	case state.OpIs:
+		return opIs(v, condition.Values)
+	case state.OpIsNot:
+		return !opIs(v, condition.Values)
+	case state.OpIsLessThan:
+		return opIsLessThan(v, condition.Values)
+	case state.OpIsLessThanOrEqualTo:
+		return opIsLessThanOrEqualTo(v, condition.Values)
+	case state.OpIsGreaterThan:
+		return opIsGreaterThan(v, condition.Values)
+	case state.OpIsGreaterThanOrEqualTo:
+		return opIsGreaterThanOrEqualTo(v, condition.Values)
+	case state.OpIsBetween:
+		return opIsBetween(v, condition.Values)
+	case state.OpIsNotBetween:
+		return !opIsBetween(v, condition.Values)
+	case state.OpContains:
+		return opContains(v, condition.Values)
+	case state.OpDoesNotContain:
+		return !opContains(v, condition.Values)
+	case state.OpIsOneOf:
+		return opIsIn(v, condition.Values)
+	case state.OpIsNotOneOf:
+		return !opIsIn(v, condition.Values)
+	case state.OpStartsWith:
+		return opStartsWith(v, condition.Values)
+	case state.OpEndsWith:
+		return opEndsWith(v, condition.Values)
+	case state.OpIsBefore:
+		return opIsBefore(v, condition.Values)
+	case state.OpIsOnOrBefore:
+		return opIsOnOrBefore(v, condition.Values)
+	case state.OpIsAfter:
+		return opIsAfter(v, condition.Values)
+	case state.OpIsOnOrAfter:
+		return opIsOnOrAfter(v, condition.Values)
+	case state.OpIsTrue:
+		return opIsTrue(v)
+	case state.OpIsFalse:
+		return opIsFalse(v)
+	case state.OpIsEmpty:
+		return opIsEmpty(v)
+	case state.OpIsNotEmpty:
+		return !opIsEmpty(v)
+	case state.OpIsNull:
+		return exists && opIsNull(v)
+	case state.OpIsNotNull:
+		return !(exists && opIsNull(v))
+	case state.OpExists:
+		return exists
+	case state.OpDoesNotExist:
+		return !exists
+	}
+
+	return false
 }
 
 func opIs(v any, values []any) bool {

--- a/core/internal/filters/applies_test.go
+++ b/core/internal/filters/applies_test.go
@@ -542,16 +542,16 @@ func Test_Applies(t *testing.T) {
 				property = strings.Split(test.property, ".")
 			}
 			filter := &state.Where{
-				Logical: state.OpAnd,
-				Conditions: []state.WhereCondition{
-					{Property: property, Operator: test.op},
+				Operator: state.OpAnd,
+				Rules: []state.WhereRule{
+					&state.WhereCondition{Property: property, Operator: test.op},
 				},
 			}
 			if test.v0 != nil {
 				if test.v1 != nil {
-					filter.Conditions[0].Values = []any{test.v0, test.v1}
+					filter.Rules[0].(*state.WhereCondition).Values = []any{test.v0, test.v1}
 				} else {
-					filter.Conditions[0].Values = []any{test.v0}
+					filter.Rules[0].(*state.WhereCondition).Values = []any{test.v0}
 				}
 			}
 			attributes := map[string]any{"v": test.v}
@@ -573,10 +573,10 @@ func Test_Applies(t *testing.T) {
 
 	t.Run("logical and", func(t *testing.T) {
 		filter := &state.Where{
-			Logical: state.OpAnd,
-			Conditions: []state.WhereCondition{
-				{Property: []string{"a"}, Operator: state.OpIs, Values: []any{5}},
-				{Property: []string{"b"}, Operator: state.OpContains, Values: []any{"boo"}},
+			Operator: state.OpAnd,
+			Rules: []state.WhereRule{
+				&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIs, Values: []any{5}},
+				&state.WhereCondition{Property: []string{"b"}, Operator: state.OpContains, Values: []any{"boo"}},
 			},
 		}
 		if !Applies(filter, map[string]any{"a": 5, "b": "foo boo"}) {
@@ -589,10 +589,10 @@ func Test_Applies(t *testing.T) {
 
 	t.Run("logical or", func(t *testing.T) {
 		filter := &state.Where{
-			Logical: state.OpOr,
-			Conditions: []state.WhereCondition{
-				{Property: []string{"a"}, Operator: state.OpIs, Values: []any{5}},
-				{Property: []string{"b"}, Operator: state.OpContains, Values: []any{"boo"}},
+			Operator: state.OpOr,
+			Rules: []state.WhereRule{
+				&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIs, Values: []any{5}},
+				&state.WhereCondition{Property: []string{"b"}, Operator: state.OpContains, Values: []any{"boo"}},
 			},
 		}
 		if !Applies(filter, map[string]any{"a": 5, "b": "foo boo"}) {
@@ -606,16 +606,41 @@ func Test_Applies(t *testing.T) {
 		}
 	})
 
+	t.Run("nested groups", func(t *testing.T) {
+		filter := &state.Where{
+			Operator: state.OpAnd,
+			Rules: []state.WhereRule{
+				&state.WhereCondition{Property: []string{"a"}, Operator: state.OpIs, Values: []any{5}},
+				&state.Where{
+					Operator: state.OpOr,
+					Rules: []state.WhereRule{
+						&state.WhereCondition{Property: []string{"b"}, Operator: state.OpContains, Values: []any{"boo"}},
+						&state.WhereCondition{Property: []string{"c"}, Operator: state.OpIsTrue},
+					},
+				},
+			},
+		}
+		if !Applies(filter, map[string]any{"a": 5, "b": "foo boo", "c": false}) {
+			t.Fatal("expected true, got false")
+		}
+		if !Applies(filter, map[string]any{"a": 5, "b": "foo", "c": true}) {
+			t.Fatal("expected true, got false")
+		}
+		if Applies(filter, map[string]any{"a": 5, "b": "foo", "c": false}) {
+			t.Fatal("expected false, got true")
+		}
+	})
+
 }
 
 // Test_AppliesWithNestedPath ensures Applies handles filters with property
 // paths.
 func Test_AppliesWithNestedPath(t *testing.T) {
 	filter := &state.Where{
-		Logical: state.OpAnd,
-		Conditions: []state.WhereCondition{
-			{Property: []string{"n1", "b"}, Operator: state.OpIs, Values: []any{5}},
-			{Property: []string{"n2", "b"}, Operator: state.OpIs, Values: []any{func() state.JSONConditionValue {
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{Property: []string{"n1", "b"}, Operator: state.OpIs, Values: []any{5}},
+			&state.WhereCondition{Property: []string{"n2", "b"}, Operator: state.OpIs, Values: []any{func() state.JSONConditionValue {
 				d := decimal.MustInt(5)
 				return state.JSONConditionValue{Number: &d, String: "5"}
 			}()}},

--- a/core/internal/initdb/upgrade.go
+++ b/core/internal/initdb/upgrade.go
@@ -325,28 +325,40 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 			`ALTER TABLE pipelines ADD COLUMN IF NOT EXISTS required_consents varchar(100)[] NOT NULL DEFAULT '{}'`,
 			`ALTER TABLE pipelines ADD COLUMN IF NOT EXISTS required_consents_operator varchar(3) NOT NULL DEFAULT 'and' CHECK (required_consents_operator IN ('and', 'or'))`,
 			`UPDATE pipelines
-				SET filter = jsonb_build_object(
-					'operator', filter->'logical',
-					'rules', (
-						SELECT COALESCE(
-							jsonb_agg(
-								CASE
-									WHEN rule->>'operator' = 'OpIsNotBetween' THEN
-										jsonb_set(rule, '{operator}', '"IsNotBetween"'::jsonb)
-									ELSE rule
-								END
-								ORDER BY position
-							),
-							'[]'::jsonb
-						)
-						FROM jsonb_array_elements(filter->'conditions') WITH ORDINALITY AS rules(rule, position)
-					)
-				)
+				SET filter = regexp_replace(
+					(
+						CASE
+							WHEN filter ? 'logical'
+								AND filter ? 'conditions'
+								AND NOT (filter ? 'operator')
+								AND NOT (filter ? 'rules')
+							THEN jsonb_build_object(
+								'operator', filter->'logical',
+								'rules', (
+									SELECT COALESCE(
+										jsonb_agg(rule ORDER BY position),
+										'[]'::jsonb
+									)
+									FROM jsonb_array_elements(filter->'conditions') WITH ORDINALITY AS rules(rule, position)
+								)
+							)
+							ELSE filter
+						END
+					)::text,
+					'"operator"[[:space:]]*:[[:space:]]*"OpIsNotBetween"',
+					'"operator":"IsNotBetween"',
+					'g'
+				)::jsonb
 				WHERE filter IS NOT NULL
-					AND filter ? 'logical'
-					AND filter ? 'conditions'
-					AND NOT (filter ? 'operator')
-					AND NOT (filter ? 'rules')`,
+					AND (
+						(
+							filter ? 'logical'
+							AND filter ? 'conditions'
+							AND NOT (filter ? 'operator')
+							AND NOT (filter ? 'rules')
+						)
+						OR filter::text ~ '"operator"[[:space:]]*:[[:space:]]*"OpIsNotBetween"'
+					)`,
 			`ALTER TABLE pipelines_metrics ADD COLUMN IF NOT EXISTS passed_6 integer NOT NULL DEFAULT 0`,
 			`ALTER TABLE pipelines_metrics ADD COLUMN IF NOT EXISTS failed_6 integer NOT NULL DEFAULT 0`,
 			`ALTER TABLE pipelines_metrics ALTER COLUMN passed_6 DROP DEFAULT`,

--- a/core/internal/initdb/upgrade.go
+++ b/core/internal/initdb/upgrade.go
@@ -324,6 +324,29 @@ func Upgrade(ctx context.Context, database *db.DB) error {
 			`ALTER TYPE notification_name ADD VALUE IF NOT EXISTS 'UpdateConsentPurpose'`,
 			`ALTER TABLE pipelines ADD COLUMN IF NOT EXISTS required_consents varchar(100)[] NOT NULL DEFAULT '{}'`,
 			`ALTER TABLE pipelines ADD COLUMN IF NOT EXISTS required_consents_operator varchar(3) NOT NULL DEFAULT 'and' CHECK (required_consents_operator IN ('and', 'or'))`,
+			`UPDATE pipelines
+				SET filter = jsonb_build_object(
+					'operator', filter->'logical',
+					'rules', (
+						SELECT COALESCE(
+							jsonb_agg(
+								CASE
+									WHEN rule->>'operator' = 'OpIsNotBetween' THEN
+										jsonb_set(rule, '{operator}', '"IsNotBetween"'::jsonb)
+									ELSE rule
+								END
+								ORDER BY position
+							),
+							'[]'::jsonb
+						)
+						FROM jsonb_array_elements(filter->'conditions') WITH ORDINALITY AS rules(rule, position)
+					)
+				)
+				WHERE filter IS NOT NULL
+					AND filter ? 'logical'
+					AND filter ? 'conditions'
+					AND NOT (filter ? 'operator')
+					AND NOT (filter ? 'rules')`,
 			`ALTER TABLE pipelines_metrics ADD COLUMN IF NOT EXISTS passed_6 integer NOT NULL DEFAULT 0`,
 			`ALTER TABLE pipelines_metrics ADD COLUMN IF NOT EXISTS failed_6 integer NOT NULL DEFAULT 0`,
 			`ALTER TABLE pipelines_metrics ALTER COLUMN passed_6 DROP DEFAULT`,

--- a/core/internal/initdb/upgrade_test.go
+++ b/core/internal/initdb/upgrade_test.go
@@ -107,6 +107,13 @@ func TestUpgrade(t *testing.T) {
 				'User',
 				'{"operator":"Or","rules":[{"property":["b"],"operator":"IsNotBetween","values":[15,20]}]}',
 				NULL
+			),
+			(
+				'777777777777',
+				'333333333333',
+				'User',
+				'{"operator":"And","rules":[{"rules":[{"property":["b"],"operator":"OpIsNotBetween","values":[25,30]},{"property":["literal"],"operator":"Contains","values":["OpIsNotBetween"]}],"operator":"Or"}]}',
+				NULL
 			);
 		INSERT INTO pipelines_metrics (
 			pipeline, timeslot,
@@ -395,8 +402,8 @@ func assertNodeIDsUpgraded(t *testing.T, database *db.DB) {
 	}
 }
 
-// assertPipelineFiltersUpgraded verifies that legacy pipeline filters are
-// converted without changing filters already in the current format.
+// assertPipelineFiltersUpgraded verifies that pipeline filters are converted
+// and legacy operator names are corrected.
 func assertPipelineFiltersUpgraded(t *testing.T, database *db.DB) {
 
 	t.Helper()
@@ -415,6 +422,10 @@ func assertPipelineFiltersUpgraded(t *testing.T, database *db.DB) {
 		{
 			id:     "666666666666",
 			filter: `{"operator":"Or","rules":[{"property":["b"],"operator":"IsNotBetween","values":[15,20]}]}`,
+		},
+		{
+			id:     "777777777777",
+			filter: `{"operator":"And","rules":[{"rules":[{"property":["b"],"operator":"IsNotBetween","values":[25,30]},{"property":["literal"],"operator":"Contains","values":["OpIsNotBetween"]}],"operator":"Or"}]}`,
 		},
 	}
 	for _, test := range tests {

--- a/core/internal/initdb/upgrade_test.go
+++ b/core/internal/initdb/upgrade_test.go
@@ -53,6 +53,7 @@ func TestUpgrade(t *testing.T) {
 			id varchar(12) PRIMARY KEY,
 			connection varchar(12) NOT NULL REFERENCES connections (id),
 			target pipeline_target NOT NULL,
+			filter jsonb,
 			format varchar
 		);
 		CREATE TABLE pipelines_metrics (
@@ -86,7 +87,27 @@ func TestUpgrade(t *testing.T) {
 		INSERT INTO organizations (id, name, enabled) VALUES ('111111111111', 'ACME inc', true);
 		INSERT INTO workspaces (id, organization) VALUES ('222222222222', '111111111111');
 		INSERT INTO connections (id, workspace, connector, role) VALUES ('333333333333', '222222222222', 'dummy', 'Source');
-		INSERT INTO pipelines (id, connection, target, format) VALUES ('444444444444', '333333333333', 'User', 'csv');
+		INSERT INTO pipelines (id, connection, target, filter, format) VALUES
+			(
+				'444444444444',
+				'333333333333',
+				'User',
+				'{
+					"logical": "And",
+					"conditions": [
+						{"property": ["a"], "operator": "OpIsNotBetween", "values": [5, 10]},
+						{"property": ["b"], "operator": "IsNull"}
+					]
+				}',
+				'csv'
+			),
+			(
+				'666666666666',
+				'333333333333',
+				'User',
+				'{"operator":"Or","rules":[{"property":["b"],"operator":"IsNotBetween","values":[15,20]}]}',
+				NULL
+			);
 		INSERT INTO pipelines_metrics (
 			pipeline, timeslot,
 			passed_0, passed_1, passed_2, passed_3, passed_4, passed_5,
@@ -122,9 +143,9 @@ func TestUpgrade(t *testing.T) {
 	assertIndexExists(t, database, pipelinesMetricsTimeslotIndex)
 	assertOrganizationConnectorReferences(t, database)
 	assertNodeIDsUpgraded(t, database)
+	assertPipelineFiltersUpgraded(t, database)
 	assertPipelineMetricsUpgrade(t, database)
 	assertPipelineMetricsColumnOrder(t, database)
-	assertPipelineMetricsSurvivePipelineDelete(t, database)
 	assertStateRequestSyncSchemaUpgraded(t, database)
 	assertRateLimitLeaseFunction(t, database)
 	assertConsentStepColumns(t, database)
@@ -132,6 +153,8 @@ func TestUpgrade(t *testing.T) {
 	if err := Upgrade(ctx, database); err != nil {
 		t.Fatalf("expected second upgrade to succeed, got %s", err)
 	}
+	assertPipelineFiltersUpgraded(t, database)
+	assertPipelineMetricsSurvivePipelineDelete(t, database)
 }
 
 func assertRateLimitLeaseFunction(t *testing.T, database *db.DB) {
@@ -370,6 +393,43 @@ func assertNodeIDsUpgraded(t *testing.T, database *db.DB) {
 	if leader != "" {
 		t.Fatalf("expected upgraded election leader to be empty, got %q", leader)
 	}
+}
+
+// assertPipelineFiltersUpgraded verifies that legacy pipeline filters are
+// converted without changing filters already in the current format.
+func assertPipelineFiltersUpgraded(t *testing.T, database *db.DB) {
+
+	t.Helper()
+
+	tests := []struct {
+		id     string
+		filter string
+	}{
+		{
+			id: "444444444444",
+			filter: `{"operator":"And","rules":[` +
+				`{"property":["a"],"operator":"IsNotBetween","values":[5,10]},` +
+				`{"property":["b"],"operator":"IsNull"}` +
+				`]}`,
+		},
+		{
+			id:     "666666666666",
+			filter: `{"operator":"Or","rules":[{"property":["b"],"operator":"IsNotBetween","values":[15,20]}]}`,
+		},
+	}
+	for _, test := range tests {
+		exists, err := database.QueryExists(t.Context(), `
+			SELECT FROM pipelines
+			WHERE id = $1
+				AND filter = $2::jsonb`, test.id, test.filter)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Fatalf("expected pipeline %s to have filter %s", test.id, test.filter)
+		}
+	}
+
 }
 
 // assertPipelineMetricsUpgrade verifies that old pipeline metrics rows gain

--- a/core/internal/state/where.go
+++ b/core/internal/state/where.go
@@ -6,83 +6,72 @@ package state
 
 import (
 	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
+	"reflect"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/krenalis/krenalis/tools/decimal"
+	"github.com/krenalis/krenalis/tools/errors"
+	"github.com/krenalis/krenalis/tools/json"
 	"github.com/krenalis/krenalis/tools/types"
 )
 
-// Where represents a where expression.
-type Where struct {
-	Logical    WhereLogical     `json:"logical"`    // can be OpAnd or OpAny.
-	Conditions []WhereCondition `json:"conditions"` // cannot be empty.
+// WhereRule represents a condition or a nested where expression.
+// It is implemented by *WhereCondition and *Where.
+type WhereRule interface {
+	whereRule()
 }
 
-// Equal reports whether the receiver is equal to w.
-func (where *Where) Equal(w *Where) bool {
-	if where == nil && w == nil {
+// Where combines rules using a logical operator.
+type Where struct {
+	Operator WhereLogical `json:"operator"`
+	Rules    []WhereRule  `json:"rules"`
+}
+
+// Equal reports whether the receiver is equal to other.
+func (where *Where) Equal(other *Where) bool {
+	if where == nil && other == nil {
 		return true
 	}
-	if where == nil || w == nil {
+	if where == nil || other == nil {
 		return false
 	}
-	if where.Logical != w.Logical {
+	if where.Operator != other.Operator {
 		return false
 	}
-	if len(where.Conditions) != len(w.Conditions) {
+	if len(where.Rules) != len(other.Rules) {
 		return false
 	}
-	for i, c := range where.Conditions {
-		c2 := w.Conditions[i]
-		if !slices.Equal(c.Property, c2.Property) {
-			return false
-		}
-		if c.Operator != c2.Operator {
-			return false
-		}
-		if len(c.Values) != len(c2.Values) {
-			return false
-		}
-		for j, v := range c.Values {
-			v2 := c2.Values[j]
-			switch v := v.(type) {
-			case decimal.Decimal:
-				if v2, ok := v2.(decimal.Decimal); !ok || !v.Equal(v2) {
-					return false
-				}
-			default:
-				if v != v2 {
-					return false
-				}
+	for i, rule := range where.Rules {
+		switch rule := rule.(type) {
+		case *Where:
+			otherGroup, ok := other.Rules[i].(*Where)
+			if !ok || !rule.Equal(otherGroup) {
+				return false
 			}
+		case *WhereCondition:
+			otherCondition, ok := other.Rules[i].(*WhereCondition)
+			if !ok || !rule.Equal(otherCondition) {
+				return false
+			}
+		default:
+			return false
 		}
 	}
 	return true
 }
 
+// MarshalJSON returns the JSON representation of where.
 func (where *Where) MarshalJSON() ([]byte, error) {
-	var b bytes.Buffer
-	enc := json.NewEncoder(&b)
-	enc.SetEscapeHTML(false)
-	b.WriteString(`{"logical":"`)
-	b.WriteString(where.Logical.String())
-	b.WriteString(`","conditions":`)
-	err := enc.Encode(where.Conditions)
-	if err != nil {
-		return nil, err
-	}
-	b.Truncate(b.Len() - 1)
-	b.WriteString(`}`)
-	return b.Bytes(), nil
+	type plainWhere Where
+	return json.Marshal((*plainWhere)(where))
 }
 
-// WhereLogical represents the logical operator of a where.
-// It can be OpAnd or OpOr.
+// whereRule marks Where as a where rule.
+func (*Where) whereRule() {}
+
+// WhereLogical identifies the logical operator used by a Where.
 type WhereLogical int
 
 const (
@@ -90,13 +79,20 @@ const (
 	OpOr                      // or
 )
 
+// jsonLogicals contains the JSON representations of the logical operators.
 var jsonLogicals = []byte(`"And"Or"`)
-var jsonLogicalsIndexes = [...]uint{0, 4}
+
+// jsonLogicalOffsets contains the start offset of each value in jsonLogicals
+// followed by a terminal offset.
+var jsonLogicalOffsets = [...]uint{0, 4, 7}
 
 // MarshalJSON returns the JSON representation of op.
 func (op WhereLogical) MarshalJSON() ([]byte, error) {
-	i := jsonLogicalsIndexes[op]
-	j := jsonLogicalsIndexes[op+1] + 1
+	if op < OpAnd || op > OpOr {
+		return nil, fmt.Errorf("invalid logical operator %d", op)
+	}
+	i := jsonLogicalOffsets[op]
+	j := jsonLogicalOffsets[op+1] + 1
 	return jsonLogicals[i:j], nil
 }
 
@@ -106,7 +102,7 @@ func (op *WhereLogical) UnmarshalJSON(data []byte) error {
 	if k < 0 {
 		return errors.New("invalid logical operator")
 	}
-	h := slices.Index(jsonLogicalsIndexes[:], uint(k))
+	h := slices.Index(jsonLogicalOffsets[:], uint(k))
 	if h < 0 {
 		return errors.New("invalid logical operator")
 	}
@@ -115,21 +111,67 @@ func (op *WhereLogical) UnmarshalJSON(data []byte) error {
 }
 
 // String returns the string representation of op.
+// It panics if op is not a valid WhereLogical value.
 func (op WhereLogical) String() string {
-	if op == OpAnd {
-		return "And"
+	s, err := op.MarshalJSON()
+	if err != nil {
+		panic(err)
 	}
-	return "Or"
+	return string(s[1 : len(s)-1])
 }
 
-// WhereCondition represents the condition of a where.
+// WhereCondition applies an operator to a property and zero or more values.
 type WhereCondition struct {
-	Property []string      `json:"property"`         // property's path.
-	Operator WhereOperator `json:"operator"`         // operator.
-	Values   []any         `json:"values,omitempty"` // values.
+	Property []string      `json:"property"`
+	Operator WhereOperator `json:"operator"`
+	Values   []any         `json:"values,omitzero"`
 }
 
-// WhereOperator is a where operator.
+// Equal reports whether the receiver is equal to other.
+func (condition *WhereCondition) Equal(other *WhereCondition) bool {
+	if condition == nil && other == nil {
+		return true
+	}
+	if condition == nil || other == nil {
+		return false
+	}
+	if !slices.Equal(condition.Property, other.Property) {
+		return false
+	}
+	if condition.Operator != other.Operator {
+		return false
+	}
+	if len(condition.Values) != len(other.Values) {
+		return false
+	}
+	for i, value := range condition.Values {
+		otherValue := other.Values[i]
+		switch value := value.(type) {
+		case decimal.Decimal:
+			if otherValue, ok := otherValue.(decimal.Decimal); !ok || !value.Equal(otherValue) {
+				return false
+			}
+		case JSONConditionValue:
+			otherValue, ok := otherValue.(JSONConditionValue)
+			if !ok || value.String != otherValue.String || value.Number == nil != (otherValue.Number == nil) {
+				return false
+			}
+			if value.Number != nil && !value.Number.Equal(*otherValue.Number) {
+				return false
+			}
+		default:
+			if !reflect.DeepEqual(value, otherValue) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// whereRule marks WhereCondition as a where rule.
+func (*WhereCondition) whereRule() {}
+
+// WhereOperator identifies an operator supported by WhereCondition.
 type WhereOperator int
 
 const (
@@ -158,27 +200,41 @@ const (
 	OpIsNull                                      // is null
 	OpIsNotNull                                   // is not null
 
-	// OpExists and OpDoesNotExist must be placed at the end, as the convertWhere function in
-	// the "core/datastore" package relies on the other operators being in their expected positions.
+	// OpExists and OpDoesNotExist must remain at the end because convertWhere in
+	// core/internal/datastore relies on the positions of the preceding operators.
 	OpExists       // exists
 	OpDoesNotExist // does not exist
 )
 
+// jsonOperators contains the JSON representations of the condition operators.
 var jsonOperators = []byte(`"Is"IsNot"IsLessThan"IsLessThanOrEqualTo"IsGreaterThan"IsGreaterThanOrEqualTo"` +
-	`IsBetween"OpIsNotBetween"Contains"DoesNotContain"IsOneOf"IsNotOneOf"StartsWith"EndsWith"IsBefore"` +
+	`IsBetween"IsNotBetween"Contains"DoesNotContain"IsOneOf"IsNotOneOf"StartsWith"EndsWith"IsBefore"` +
 	`IsOnOrBefore"IsAfter"IsOnOrAfter"IsTrue"IsFalse"IsEmpty"IsNotEmpty"IsNull"IsNotNull"Exists"DoesNotExist"`)
-var jsonOperatorsIndexes = [...]uint16{0, 3, 9, 20, 40, 54, 77, 87, 102, 111, 126, 134, 145, 156, 165, 174, 187, 195, 207, 214, 222, 230, 241, 248, 258, 265, 278}
+
+// jsonOperatorOffsets contains the start offset of each value in jsonOperators
+// followed by a terminal offset.
+var jsonOperatorOffsets = [...]uint16{
+	0, 3, 9, 20, 40, 54, 77, 87, 100, 109, 124, 132, 143, 154,
+	163, 172, 185, 193, 205, 212, 220, 228, 239, 246, 256, 263, 276,
+}
 
 // MarshalJSON returns the JSON representation of op.
 func (op WhereOperator) MarshalJSON() ([]byte, error) {
-	i := jsonOperatorsIndexes[op]
-	j := jsonOperatorsIndexes[op+1] + 1
+	if op < OpIs || op > OpDoesNotExist {
+		return nil, fmt.Errorf("invalid operator %d", op)
+	}
+	i := jsonOperatorOffsets[op]
+	j := jsonOperatorOffsets[op+1] + 1
 	return jsonOperators[i:j], nil
 }
 
 // String returns the string representation of op.
+// It panics if op is not a valid WhereOperator value.
 func (op WhereOperator) String() string {
-	s, _ := op.MarshalJSON()
+	s, err := op.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
 	return string(s[1 : len(s)-1])
 }
 
@@ -188,7 +244,7 @@ func (op *WhereOperator) UnmarshalJSON(data []byte) error {
 	if k < 0 {
 		return errors.New("invalid operator")
 	}
-	h := slices.Index(jsonOperatorsIndexes[:], uint16(k))
+	h := slices.Index(jsonOperatorOffsets[:], uint16(k))
 	if h < 0 {
 		return errors.New("invalid operator")
 	}
@@ -197,10 +253,10 @@ func (op *WhereOperator) UnmarshalJSON(data []byte) error {
 }
 
 // JSONConditionValue represents a value in a Where condition that refers to a
-// json property.
+// JSON property.
 //
-// - String holds the raw value as a string.
-// - Number is non-nil if the String represents a numeric value.
+// - String holds the raw value.
+// - Number is non-nil if String represents a numeric value.
 type JSONConditionValue struct {
 	String string
 	Number *decimal.Decimal
@@ -211,82 +267,140 @@ func (v JSONConditionValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.String)
 }
 
+// whereConditionJSON is the persisted representation of a WhereCondition.
+type whereConditionJSON struct {
+	Property []string      `json:"property"`
+	Operator WhereOperator `json:"operator"`
+	Values   []json.Value  `json:"values,omitzero"`
+}
+
 // unmarshalConditionValue unmarshals a Where condition value and returns it.
 // v is the value to unmarshal, and t is the type of the property.
-func unmarshalConditionValue(v any, t types.Type) (any, error) {
+func unmarshalConditionValue(v json.Value, t types.Type) (any, error) {
 	switch t.Kind() {
 	case types.StringKind, types.UUIDKind, types.IPKind:
-		return v, nil
+		if !v.IsString() {
+			return nil, errors.New("where condition value must be a string")
+		}
+		return v.String(), nil
 	case types.IntKind:
 		if t.IsUnsigned() {
-			n, err := strconv.ParseUint(string(v.(json.Number)), 10, 64)
-			if err != nil {
-				return nil, err
-			}
-			return uint(n), nil
+			return v.Uint()
 		}
-		n, err := strconv.ParseInt(string(v.(json.Number)), 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		return int(n), nil
+		return v.Int()
 	case types.FloatKind:
-		return strconv.ParseFloat(string(v.(json.Number)), t.BitSize())
+		return v.Float(t.BitSize())
 	case types.DecimalKind:
-		return decimal.Parse(v.(json.Number), 0, 0)
+		return v.Decimal(0, 0)
 	case types.DateTimeKind:
-		t, err := time.Parse(time.RFC3339Nano, v.(string))
+		t, err := time.Parse(time.RFC3339Nano, v.String())
 		if err != nil {
 			return nil, err
 		}
 		return t.UTC(), nil
 	case types.DateKind:
-		t, err := time.Parse(time.DateOnly, v.(string))
+		t, err := time.Parse(time.DateOnly, v.String())
 		if err != nil {
 			return nil, err
 		}
 		t = t.UTC()
 		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC), nil
 	case types.TimeKind:
-		t, err := time.Parse("15:04:05.999999999", v.(string))
+		t, err := time.Parse("15:04:05.999999999", v.String())
 		if err != nil {
 			return nil, err
 		}
 		return time.Date(1970, 1, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC), nil
+	case types.YearKind:
+		return v.Int()
 	case types.JSONKind:
-		v := JSONConditionValue{String: v.(string)}
-		if d, err := decimal.Parse(v.String, 0, 0); err == nil {
-			v.Number = &d
+		if !v.IsString() {
+			return nil, errors.New("where condition value must be a string")
 		}
-		return v, nil
+		value := JSONConditionValue{String: v.String()}
+		if d, err := decimal.Parse(value.String, 0, 0); err == nil {
+			value.Number = &d
+		}
+		return value, nil
 	case types.ArrayKind:
 		return unmarshalConditionValue(v, t.Elem())
 	}
-	panic(fmt.Sprintf("unexpected kind %s", t.Kind()))
+	return nil, fmt.Errorf("unexpected kind %s in where condition", t.Kind())
 }
 
-// unmarshalWhere unmarshals a where and returns it.
+// unmarshalWhere unmarshals a Where value and returns it.
 func unmarshalWhere(b []byte, schema types.Type) (*Where, error) {
-	var where *Where
-	dec := json.NewDecoder(bytes.NewReader(b))
-	dec.UseNumber()
-	err := dec.Decode(&where)
-	if err != nil {
+	var value json.Value
+	if err := json.Unmarshal(b, &value); err != nil {
 		return nil, err
 	}
-	// Normalize values.
-	properties := schema.Properties()
-	for _, c := range where.Conditions {
-		p, err := properties.ByPathSlice(c.Property)
-		if err != nil && p.Type.Kind() != types.JSONKind {
+	return unmarshalWhereGroup(value, schema.Properties())
+}
+
+// unmarshalWhereCondition unmarshals a WhereCondition value and returns it.
+func unmarshalWhereCondition(value json.Value, properties types.Properties) (*WhereCondition, error) {
+	var condition whereConditionJSON
+	if err := value.Unmarshal(&condition); err != nil {
+		return nil, err
+	}
+	p, err := properties.ByPathSlice(condition.Property)
+	if err != nil && p.Type.Kind() != types.JSONKind {
+		return nil, err
+	}
+	var values []any
+	if condition.Values != nil {
+		values = make([]any, len(condition.Values))
+	}
+	for i, value := range condition.Values {
+		values[i], err = unmarshalConditionValue(value, p.Type)
+		if err != nil {
 			return nil, err
 		}
-		for i, value := range c.Values {
-			c.Values[i], err = unmarshalConditionValue(value, p.Type)
+	}
+	return &WhereCondition{Property: condition.Property, Operator: condition.Operator, Values: values}, nil
+}
+
+// unmarshalWhereGroup unmarshals a Where group and returns it.
+func unmarshalWhereGroup(value json.Value, properties types.Properties) (*Where, error) {
+
+	if !value.IsObject() {
+		return nil, errors.New("where group must be an object")
+	}
+	rawOperator, hasOperator := value.Get([]string{"operator"})
+	rawRules, hasRules := value.Get([]string{"rules"})
+	if !hasOperator || !hasRules {
+		return nil, errors.New("where group must contain operator and rules")
+	}
+	if !rawRules.IsArray() {
+		return nil, errors.New("where rules must be an array")
+	}
+
+	var operator WhereLogical
+	if err := rawOperator.Unmarshal(&operator); err != nil {
+		return nil, err
+	}
+	rules := make([]WhereRule, 0, rawRules.NumElement())
+
+	for _, rawRule := range rawRules.Elements() {
+		_, isGroup := rawRule.Get([]string{"rules"})
+		_, isCondition := rawRule.Get([]string{"property"})
+		switch {
+		case isGroup && !isCondition:
+			group, err := unmarshalWhereGroup(rawRule, properties)
 			if err != nil {
 				return nil, err
 			}
+			rules = append(rules, group)
+		case isCondition && !isGroup:
+			condition, err := unmarshalWhereCondition(rawRule, properties)
+			if err != nil {
+				return nil, err
+			}
+			rules = append(rules, condition)
+		default:
+			return nil, errors.New("where rule must be either a group or a condition")
 		}
 	}
-	return where, nil
+
+	return &Where{Operator: operator, Rules: rules}, nil
 }

--- a/core/internal/state/where_test.go
+++ b/core/internal/state/where_test.go
@@ -6,14 +6,17 @@ package state
 
 import (
 	"bytes"
-	"reflect"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/krenalis/krenalis/tools/decimal"
+	"github.com/krenalis/krenalis/tools/json"
 	"github.com/krenalis/krenalis/tools/types"
 )
 
+// Test_unmarshalWhere verifies decoding of persisted Where values.
 func Test_unmarshalWhere(t *testing.T) {
 
 	schema := types.Object([]types.Property{
@@ -32,6 +35,8 @@ func Test_unmarshalWhere(t *testing.T) {
 		{Name: "m", Type: types.Decimal(5, 3)},
 		{Name: "n", Type: types.UUID()},
 		{Name: "o", Type: types.IP()},
+		{Name: "p", Type: types.Year()},
+		{Name: "q", Type: types.Array(types.String())},
 	})
 
 	vDecimalInt := decimal.MustParse("34")
@@ -41,127 +46,181 @@ func Test_unmarshalWhere(t *testing.T) {
 	vTime := time.Date(1970, 1, 1, 11, 3, 6, 801586201, time.UTC)
 
 	tests := []struct {
+		name      string
 		condition string
 		expected  WhereCondition
 	}{
 		{
+			name:      "signed integer",
 			condition: `{"property":["a"],"operator":"Is","values":[5]}`,
 			expected:  WhereCondition{Property: []string{"a"}, Operator: OpIs, Values: []any{5}},
 		},
 		{
+			name:      "string",
 			condition: `{"property":["b"],"operator":"IsNot","values":["foo"]}`,
 			expected:  WhereCondition{Property: []string{"b"}, Operator: OpIsNot, Values: []any{"foo"}},
 		},
 		{
+			name:      "signed integer range",
 			condition: `{"property":["c"],"operator":"IsBetween","values":[10,20]}`,
 			expected:  WhereCondition{Property: []string{"c"}, Operator: OpIsBetween, Values: []any{10, 20}},
 		},
 		{
+			name:      "float",
 			condition: `{"property":["d"],"operator":"IsLessThan","values":[34.98]}`,
 			expected:  WhereCondition{Property: []string{"d"}, Operator: OpIsLessThan, Values: []any{34.98}},
 		},
 		{
+			name:      "numeric string",
 			condition: `{"property":["e"],"operator":"IsGreaterThan","values":["34"]}`,
 			expected:  WhereCondition{Property: []string{"e"}, Operator: OpIsGreaterThan, Values: []any{"34"}},
 		},
 		{
+			name:      "boolean unary",
 			condition: `{"property":["f"],"operator":"IsTrue"}`,
 			expected:  WhereCondition{Property: []string{"f"}, Operator: OpIsTrue},
 		},
 		{
+			name:      "unsigned integer",
 			condition: `{"property":["g"],"operator":"IsNotOneOf","values":[1,2,3]}`,
 			expected:  WhereCondition{Property: []string{"g"}, Operator: OpIsNotOneOf, Values: []any{uint(1), uint(2), uint(3)}},
 		},
 		{
+			name:      "JSON property",
 			condition: `{"property":["h"],"operator":"Is","values":["foo"]}`,
 			expected:  WhereCondition{Property: []string{"h"}, Operator: OpIs, Values: []any{JSONConditionValue{String: "foo"}}},
 		},
 		{
+			name:      "JSON path",
 			condition: `{"property":["h","x"],"operator":"Is","values":["foo"]}`,
 			expected:  WhereCondition{Property: []string{"h", "x"}, Operator: OpIs, Values: []any{JSONConditionValue{String: "foo"}}},
 		},
 		{
+			name:      "JSON number",
 			condition: `{"property":["i"],"operator":"IsBetween","values":["34"]}`,
 			expected:  WhereCondition{Property: []string{"i"}, Operator: OpIsBetween, Values: []any{JSONConditionValue{String: "34", Number: &vDecimalInt}}},
 		},
 		{
+			name:      "datetime",
 			condition: `{"property":["j"],"operator":"IsAfter","values":["2024-09-12T11:03:06.801586201Z"]}`,
 			expected:  WhereCondition{Property: []string{"j"}, Operator: OpIsAfter, Values: []any{vDateTime}},
 		},
 		{
+			name:      "date",
 			condition: `{"property":["k"],"operator":"IsBefore","values":["2024-09-12"]}`,
 			expected:  WhereCondition{Property: []string{"k"}, Operator: OpIsBefore, Values: []any{vDate}},
 		},
 		{
+			name:      "time",
 			condition: `{"property":["l"],"operator":"IsOnOrBefore","values":["11:03:06.801586201"]}`,
 			expected:  WhereCondition{Property: []string{"l"}, Operator: OpIsOnOrBefore, Values: []any{vTime}},
 		},
 		{
+			name:      "decimal",
 			condition: `{"property":["m"],"operator":"Is","values":[85.027]}`,
 			expected:  WhereCondition{Property: []string{"m"}, Operator: OpIs, Values: []any{vDecimalFloat}},
 		},
 		{
+			name:      "UUID",
 			condition: `{"property":["n"],"operator":"IsNot","values":["38d065ab-ca46-4812-a83c-a9712e09c153"]}`,
 			expected:  WhereCondition{Property: []string{"n"}, Operator: OpIsNot, Values: []any{"38d065ab-ca46-4812-a83c-a9712e09c153"}},
 		},
 		{
+			name:      "IP",
 			condition: `{"property":["o"],"operator":"Is","values":["192.168.1.1"]}`,
 			expected:  WhereCondition{Property: []string{"o"}, Operator: OpIs, Values: []any{"192.168.1.1"}},
+		},
+		{
+			name:      "year",
+			condition: `{"property":["p"],"operator":"Is","values":[2024]}`,
+			expected:  WhereCondition{Property: []string{"p"}, Operator: OpIs, Values: []any{2024}},
+		},
+		{
+			name:      "array element",
+			condition: `{"property":["q"],"operator":"Contains","values":["foo"]}`,
+			expected:  WhereCondition{Property: []string{"q"}, Operator: OpContains, Values: []any{"foo"}},
 		},
 	}
 
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			got, err := unmarshalWhere([]byte(`{"logical":"And","conditions":[`+test.condition+`]}`), schema)
+		t.Run(test.name, func(t *testing.T) {
+			got, err := unmarshalWhere([]byte(`{"operator":"And","rules":[`+test.condition+`]}`), schema)
 			if err != nil {
 				t.Fatalf("unexpected error %q", err)
 			}
 			if got == nil {
 				t.Fatalf("unexpected nil")
 			}
-			expected := &Where{Logical: OpAnd, Conditions: []WhereCondition{test.expected}}
-			if !reflect.DeepEqual(expected, got) {
+			expected := &Where{Operator: OpAnd, Rules: []WhereRule{
+				&test.expected}}
+			if !expected.Equal(got) {
 				t.Fatalf("\nexpected %#v\ngot      %#v", expected, got)
 			}
 		})
 	}
 
-	tests2 := []struct {
+	groups := []struct {
+		name     string
 		where    string
 		expected Where
 	}{
 		{
-			where: `{"logical":"And","conditions":[` +
+			name: "and group",
+			where: `{"operator":"And","rules":[` +
 				`{"property":["a"],"operator":"Is","values":[720347]},` +
 				`{"property":["b"],"operator":"IsLessThan","values":["foo boo"]},` +
 				`{"property":["c"],"operator":"IsBetween","values":[66,88]}` + `]}`,
 			expected: Where{
-				Logical: OpAnd,
-				Conditions: []WhereCondition{
-					{Property: []string{"a"}, Operator: OpIs, Values: []any{720347}},
-					{Property: []string{"b"}, Operator: OpIsLessThan, Values: []any{"foo boo"}},
-					{Property: []string{"c"}, Operator: OpIsBetween, Values: []any{66, 88}},
+				Operator: OpAnd,
+				Rules: []WhereRule{
+					&WhereCondition{Property: []string{"a"}, Operator: OpIs, Values: []any{720347}},
+					&WhereCondition{Property: []string{"b"}, Operator: OpIsLessThan, Values: []any{"foo boo"}},
+					&WhereCondition{Property: []string{"c"}, Operator: OpIsBetween, Values: []any{66, 88}},
 				},
 			},
 		},
 		{
-			where: `{"logical":"Or","conditions":[` +
+			name: "or group",
+			where: `{"operator":"Or","rules":[` +
 				`{"property":["d"],"operator":"Is","values":[90481.26681]},` +
 				`{"property":["e"],"operator":"StartsWith","values":["Boo"]},` +
 				`{"property":["f"],"operator":"IsFalse"}` + `]}`,
 			expected: Where{
-				Logical: OpOr,
-				Conditions: []WhereCondition{
-					{Property: []string{"d"}, Operator: OpIs, Values: []any{90481.26681}},
-					{Property: []string{"e"}, Operator: OpStartsWith, Values: []any{"Boo"}},
-					{Property: []string{"f"}, Operator: OpIsFalse},
+				Operator: OpOr,
+				Rules: []WhereRule{
+					&WhereCondition{Property: []string{"d"}, Operator: OpIs, Values: []any{90481.26681}},
+					&WhereCondition{Property: []string{"e"}, Operator: OpStartsWith, Values: []any{"Boo"}},
+					&WhereCondition{Property: []string{"f"}, Operator: OpIsFalse},
+				},
+			},
+		},
+		{
+			name: "nested group",
+			where: `{"operator":"And","rules":[` +
+				`{"property":["a"],"operator":"Is","values":[5]},` +
+				`{"operator":"Or","rules":[` +
+				`{"property":["b"],"operator":"Contains","values":["foo"]},` +
+				`{"property":["f"],"operator":"IsTrue"}` +
+				`]}` +
+				`]}`,
+			expected: Where{
+				Operator: OpAnd,
+				Rules: []WhereRule{
+					&WhereCondition{Property: []string{"a"}, Operator: OpIs, Values: []any{5}},
+					&Where{
+						Operator: OpOr,
+						Rules: []WhereRule{
+							&WhereCondition{Property: []string{"b"}, Operator: OpContains, Values: []any{"foo"}},
+							&WhereCondition{Property: []string{"f"}, Operator: OpIsTrue},
+						},
+					},
 				},
 			},
 		},
 	}
 
-	for _, test := range tests2 {
-		t.Run("", func(t *testing.T) {
+	for _, test := range groups {
+		t.Run(test.name, func(t *testing.T) {
 			got, err := unmarshalWhere([]byte(test.where), schema)
 			if err != nil {
 				t.Fatalf("unexpected error %q", err)
@@ -169,119 +228,328 @@ func Test_unmarshalWhere(t *testing.T) {
 			if got == nil {
 				t.Fatalf("unexpected nil")
 			}
-			if !reflect.DeepEqual(&test.expected, got) {
+			if !test.expected.Equal(got) {
 				t.Fatalf("\nexpected %#v\ngot      %#v", &test.expected, got)
 			}
 		})
 	}
 
+	invalid := []struct {
+		name          string
+		where         string
+		errorContains string
+	}{
+		{name: "invalid JSON", where: `{`, errorContains: "unexpected EOF"},
+		{name: "root is not an object", where: `[]`, errorContains: "where group must be an object"},
+		{name: "missing operator", where: `{"rules":[]}`, errorContains: "where group must contain operator and rules"},
+		{name: "missing rules", where: `{"operator":"And"}`, errorContains: "where group must contain operator and rules"},
+		{
+			name:          "rules is not an array",
+			where:         `{"operator":"And","rules":{}}`,
+			errorContains: "where rules must be an array",
+		},
+		{
+			name:          "invalid logical operator",
+			where:         `{"operator":"Invalid","rules":[]}`,
+			errorContains: "invalid logical operator",
+		},
+		{
+			name:          "rule is neither group nor condition",
+			where:         `{"operator":"And","rules":[{}]}`,
+			errorContains: "where rule must be either a group or a condition",
+		},
+		{
+			name:          "rule is both group and condition",
+			where:         `{"operator":"And","rules":[{"property":["a"],"operator":"Is","values":[5],"rules":[]}]}`,
+			errorContains: "where rule must be either a group or a condition",
+		},
+		{
+			name:          "unknown property",
+			where:         `{"operator":"And","rules":[{"property":["unknown"],"operator":"Is","values":[5]}]}`,
+			errorContains: `property path "unknown" does not exist`,
+		},
+		{
+			name:          "invalid condition operator",
+			where:         `{"operator":"And","rules":[{"property":["a"],"operator":"Invalid","values":[5]}]}`,
+			errorContains: "invalid operator",
+		},
+		{
+			name:          "wrong string value type",
+			where:         `{"operator":"And","rules":[{"property":["b"],"operator":"Is","values":[5]}]}`,
+			errorContains: "where condition value must be a string",
+		},
+		{
+			name:          "wrong integer value type",
+			where:         `{"operator":"And","rules":[{"property":["a"],"operator":"Is","values":["foo"]}]}`,
+			errorContains: "invalid syntax",
+		},
+		{
+			name:          "wrong array element type",
+			where:         `{"operator":"And","rules":[{"property":["q"],"operator":"Contains","values":[5]}]}`,
+			errorContains: "where condition value must be a string",
+		},
+		{
+			name:          "invalid datetime",
+			where:         `{"operator":"And","rules":[{"property":["j"],"operator":"IsAfter","values":["invalid"]}]}`,
+			errorContains: "cannot parse",
+		},
+		{
+			name:          "invalid date",
+			where:         `{"operator":"And","rules":[{"property":["k"],"operator":"IsBefore","values":["invalid"]}]}`,
+			errorContains: "cannot parse",
+		},
+		{
+			name:          "invalid time",
+			where:         `{"operator":"And","rules":[{"property":["l"],"operator":"IsBefore","values":["invalid"]}]}`,
+			errorContains: "cannot parse",
+		},
+	}
+	for _, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := unmarshalWhere([]byte(test.where), schema)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), test.errorContains) {
+				t.Fatalf("expected error containing %q, got %q", test.errorContains, err)
+			}
+		})
+	}
+
+	t.Run("legacy group", func(t *testing.T) {
+		_, err := unmarshalWhere([]byte(`{"logical":"And","conditions":[]}`), schema)
+		if err == nil {
+			t.Fatal("expected legacy where representation to be rejected")
+		}
+		if got, expected := err.Error(), "where group must contain operator and rules"; got != expected {
+			t.Fatalf("expected error %q, got %q", expected, got)
+		}
+	})
+
 }
 
+// Test_Where_Equal verifies equality of Where values, including nested
+// groups.
 func Test_Where_Equal(t *testing.T) {
 
 	tests := []struct {
+		name   string
 		w1, w2 *Where
 		equal  bool
 	}{
 		{
+			name:  "both nil",
 			w1:    nil,
 			w2:    nil,
 			equal: true,
 		},
 		{
-			w1:    &Where{Logical: OpAnd, Conditions: []WhereCondition{{Property: []string{"a"}, Operator: OpIsNull}}},
+			name: "other nil",
+			w1: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsNull}},
+			},
 			w2:    nil,
 			equal: false,
 		},
 		{
-			w1:    nil,
-			w2:    &Where{Logical: OpAnd, Conditions: []WhereCondition{{Property: []string{"a"}, Operator: OpIsNull}}},
+			name: "receiver nil",
+			w1:   nil,
+			w2: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsNull}},
+			},
 			equal: false,
 		},
 		{
-			w1:    &Where{Logical: OpAnd, Conditions: []WhereCondition{{Property: []string{"a"}, Operator: OpIsNull}}},
-			w2:    &Where{Logical: OpAnd, Conditions: []WhereCondition{{Property: []string{"a"}, Operator: OpIsNull}}},
+			name: "equal unary conditions",
+			w1: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsNull}},
+			},
+			w2: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsNull}},
+			},
 			equal: true,
 		},
 		{
-			w1:    &Where{Logical: OpAnd, Conditions: []WhereCondition{{Property: []string{"b"}, Operator: OpIs, Values: []any{5}}}},
-			w2:    &Where{Logical: OpAnd, Conditions: []WhereCondition{{Property: []string{"b"}, Operator: OpIs, Values: []any{5}}}},
+			name: "equal scalar values",
+			w1: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"b"}, Operator: OpIs, Values: []any{5}}},
+			},
+			w2: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"b"}, Operator: OpIs, Values: []any{5}}},
+			},
 			equal: true,
 		},
 		{
-			w1:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"x", "y"}, Operator: OpIsBetween, Values: []any{time.Date(2025, 01, 01, 12, 30, 0, 0, time.UTC), time.Date(2025, 12, 31, 16, 45, 12, 0, time.UTC)}}}},
-			w2:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"x", "y"}, Operator: OpIsBetween, Values: []any{time.Date(2025, 01, 01, 12, 30, 0, 0, time.UTC), time.Date(2025, 12, 31, 16, 45, 12, 0, time.UTC)}}}},
+			name: "equal time values",
+			w1: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"x", "y"}, Operator: OpIsBetween, Values: []any{time.Date(2025, 01, 01, 12, 30, 0, 0, time.UTC), time.Date(2025, 12, 31, 16, 45, 12, 0, time.UTC)}}},
+			},
+			w2: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"x", "y"}, Operator: OpIsBetween, Values: []any{time.Date(2025, 01, 01, 12, 30, 0, 0, time.UTC), time.Date(2025, 12, 31, 16, 45, 12, 0, time.UTC)}}},
+			},
 			equal: true,
 		},
 		{
-			w1:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"c"}, Operator: OpIs, Values: []any{decimal.MustParse("12.89")}}}},
-			w2:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"c"}, Operator: OpIs, Values: []any{decimal.MustParse("12.89")}}}},
+			name: "equal decimal values",
+			w1: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"c"}, Operator: OpIs, Values: []any{decimal.MustParse("12.89")}}},
+			},
+			w2: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"c"}, Operator: OpIs, Values: []any{decimal.MustParse("12.89")}}},
+			},
 			equal: true,
 		},
 		{
-			w1:    &Where{Logical: OpAnd, Conditions: []WhereCondition{{Property: []string{"a"}, Operator: OpIsFalse}}},
-			w2:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"a"}, Operator: OpIsFalse}}},
+			name: "different logical operator",
+			w1: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsFalse}},
+			},
+			w2: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsFalse}},
+			},
 			equal: false,
 		},
 		{
-			w1:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"a"}, Operator: OpIsFalse}}},
-			w2:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"b"}, Operator: OpIsFalse}}},
+			name: "different property",
+			w1: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsFalse}},
+			},
+			w2: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"b"}, Operator: OpIsFalse}},
+			},
 			equal: false,
 		},
 		{
-			w1:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"a"}, Operator: OpIsFalse}}},
-			w2:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"a"}, Operator: OpIsTrue}}},
+			name: "different condition operator",
+			w1: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsFalse}},
+			},
+			w2: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsTrue}},
+			},
 			equal: false,
 		},
 		{
-			w1:    &Where{Logical: OpAnd, Conditions: []WhereCondition{{Property: []string{"b"}, Operator: OpIs, Values: []any{"foo"}}}},
-			w2:    &Where{Logical: OpAnd, Conditions: []WhereCondition{{Property: []string{"b"}, Operator: OpIs, Values: []any{"foo", "boo"}}}},
+			name: "different value count",
+			w1: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"b"}, Operator: OpIs, Values: []any{"foo"}}},
+			},
+			w2: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"b"}, Operator: OpIs, Values: []any{"foo", "boo"}}},
+			},
 			equal: false,
 		},
 		{
-			w1:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"x", "y"}, Operator: OpIsBetween, Values: []any{time.Date(2025, 01, 01, 12, 30, 0, 0, time.UTC), time.Date(2025, 12, 31, 15, 45, 12, 0, time.UTC)}}}},
-			w2:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"x", "y"}, Operator: OpIsBetween, Values: []any{time.Date(2025, 01, 01, 12, 30, 0, 0, time.UTC), time.Date(2025, 12, 31, 16, 45, 12, 0, time.UTC)}}}},
+			name: "different rule count",
+			w1: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsNull}},
+			},
+			w2:    &Where{Operator: OpAnd},
 			equal: false,
 		},
 		{
-			w1:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"c"}, Operator: OpIs, Values: []any{decimal.MustParse("39.05")}}}},
-			w2:    &Where{Logical: OpOr, Conditions: []WhereCondition{{Property: []string{"c"}, Operator: OpIs, Values: []any{decimal.MustParse("12.89")}}}},
+			name: "different rule types",
+			w1: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&Where{Operator: OpOr},
+			}},
+			w2: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"a"}, Operator: OpIsNull},
+			}},
+			equal: false,
+		},
+		{
+			name:  "nil rule",
+			w1:    &Where{Operator: OpAnd, Rules: []WhereRule{nil}},
+			w2:    &Where{Operator: OpAnd, Rules: []WhereRule{nil}},
+			equal: false,
+		},
+		{
+			name: "different time value",
+			w1: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"x", "y"}, Operator: OpIsBetween, Values: []any{time.Date(2025, 01, 01, 12, 30, 0, 0, time.UTC), time.Date(2025, 12, 31, 15, 45, 12, 0, time.UTC)}}},
+			},
+			w2: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"x", "y"}, Operator: OpIsBetween, Values: []any{time.Date(2025, 01, 01, 12, 30, 0, 0, time.UTC), time.Date(2025, 12, 31, 16, 45, 12, 0, time.UTC)}}},
+			},
+			equal: false,
+		},
+		{
+			name: "different decimal value",
+			w1: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"c"}, Operator: OpIs, Values: []any{decimal.MustParse("39.05")}}},
+			},
+			w2: &Where{Operator: OpOr, Rules: []WhereRule{
+				&WhereCondition{Property: []string{"c"}, Operator: OpIs, Values: []any{decimal.MustParse("12.89")}}},
+			},
+			equal: false,
+		},
+		{
+			name: "equal nested groups",
+			w1: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&Where{Operator: OpOr, Rules: []WhereRule{
+					&WhereCondition{Property: []string{"a"}, Operator: OpIs, Values: []any{1}},
+				}},
+			}},
+			w2: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&Where{Operator: OpOr, Rules: []WhereRule{
+					&WhereCondition{Property: []string{"a"}, Operator: OpIs, Values: []any{1}},
+				}},
+			}},
+			equal: true,
+		},
+		{
+			name: "different nested condition",
+			w1: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&Where{Operator: OpOr, Rules: []WhereRule{
+					&WhereCondition{Property: []string{"a"}, Operator: OpIs, Values: []any{1}},
+				}},
+			}},
+			w2: &Where{Operator: OpAnd, Rules: []WhereRule{
+				&Where{Operator: OpOr, Rules: []WhereRule{
+					&WhereCondition{Property: []string{"a"}, Operator: OpIs, Values: []any{2}},
+				}},
+			}},
 			equal: false,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			equal := test.w1.Equal(test.w2)
 			if test.equal != equal {
 				t.Fatalf("expected equal %t, got %t", test.equal, equal)
 			}
 		})
 	}
+
 }
 
+// Test_Where_MarshalJSON verifies the persisted JSON representation of Where
+// values.
 func Test_Where_MarshalJSON(t *testing.T) {
 
 	tests := []struct {
+		name     string
 		where    Where
 		expected []byte
 	}{
 		{
+			name: "condition values",
 			where: Where{
-				Logical: OpAnd,
-				Conditions: []WhereCondition{
-					{Property: []string{"a"}, Operator: OpIs, Values: []any{5}},
-					{Property: []string{"b"}, Operator: OpIsNot, Values: []any{"foo"}},
-					{Property: []string{"c"}, Operator: OpIsBetween, Values: []any{10, 20}},
-					{Property: []string{"d"}, Operator: OpIsLessThan, Values: []any{34.98}},
-					{Property: []string{"e"}, Operator: OpIsGreaterThan, Values: []any{decimal.MustParse("34")}},
-					{Property: []string{"f"}, Operator: OpIsTrue},
-					{Property: []string{"g"}, Operator: OpIsNotOneOf, Values: []any{1, 2, 3}},
-					{Property: []string{"h"}, Operator: OpIs, Values: []any{JSONConditionValue{String: "foo"}}},
-					{Property: []string{"i"}, Operator: OpIsBetween, Values: []any{JSONConditionValue{String: "34", Number: new(decimal.MustParse("34"))}}},
+				Operator: OpAnd,
+				Rules: []WhereRule{
+					&WhereCondition{Property: []string{"a"}, Operator: OpIs, Values: []any{5}},
+					&WhereCondition{Property: []string{"b"}, Operator: OpIsNot, Values: []any{"foo"}},
+					&WhereCondition{Property: []string{"c"}, Operator: OpIsBetween, Values: []any{10, 20}},
+					&WhereCondition{Property: []string{"d"}, Operator: OpIsLessThan, Values: []any{34.98}},
+					&WhereCondition{Property: []string{"e"}, Operator: OpIsGreaterThan, Values: []any{decimal.MustParse("34")}},
+					&WhereCondition{Property: []string{"f"}, Operator: OpIsTrue},
+					&WhereCondition{Property: []string{"g"}, Operator: OpIsNotOneOf, Values: []any{1, 2, 3}},
+					&WhereCondition{Property: []string{"h"}, Operator: OpIs, Values: []any{JSONConditionValue{String: "foo"}}},
+					&WhereCondition{Property: []string{"i"}, Operator: OpIsBetween, Values: []any{JSONConditionValue{String: "34", Number: new(decimal.MustParse("34"))}}},
 				},
 			},
-			expected: []byte(`{"logical":"And","conditions":[` +
+			expected: []byte(`{"operator":"And","rules":[` +
 				`{"property":["a"],"operator":"Is","values":[5]},` +
 				`{"property":["b"],"operator":"IsNot","values":["foo"]},` +
 				`{"property":["c"],"operator":"IsBetween","values":[10,20]},` +
@@ -293,19 +561,40 @@ func Test_Where_MarshalJSON(t *testing.T) {
 				`{"property":["i"],"operator":"IsBetween","values":["34"]}` + `]}`),
 		},
 		{
+			name: "time pointer",
 			where: Where{
-				Logical: OpOr,
-				Conditions: []WhereCondition{
-					{Property: []string{"a"}, Operator: OpIsAfter, Values: []any{new(time.Date(2024, 9, 12, 11, 3, 6, 820793551, time.UTC))}},
+				Operator: OpOr,
+				Rules: []WhereRule{
+					&WhereCondition{Property: []string{"a"}, Operator: OpIsAfter, Values: []any{new(time.Date(2024, 9, 12, 11, 3, 6, 820793551, time.UTC))}},
 				},
 			},
-			expected: []byte(`{"logical":"Or","conditions":[{"property":["a"],"operator":"IsAfter","values":["2024-09-12T11:03:06.820793551Z"]}` + `]}`),
+			expected: []byte(`{"operator":"Or","rules":[{"property":["a"],"operator":"IsAfter","values":["2024-09-12T11:03:06.820793551Z"]}` + `]}`),
+		},
+		{
+			name: "nested group",
+			where: Where{
+				Operator: OpAnd,
+				Rules: []WhereRule{
+					&WhereCondition{Property: []string{"a"}, Operator: OpIs, Values: []any{5}},
+					&Where{Operator: OpOr, Rules: []WhereRule{
+						&WhereCondition{Property: []string{"b"}, Operator: OpIsNull},
+						&WhereCondition{Property: []string{"c"}, Operator: OpIsTrue},
+					}},
+				},
+			},
+			expected: []byte(`{"operator":"And","rules":[` +
+				`{"property":["a"],"operator":"Is","values":[5]},` +
+				`{"operator":"Or","rules":[` +
+				`{"property":["b"],"operator":"IsNull"},` +
+				`{"property":["c"],"operator":"IsTrue"}` +
+				`]}` +
+				`]}`),
 		},
 	}
 
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			got, err := test.where.MarshalJSON()
+		t.Run(test.name, func(t *testing.T) {
+			got, err := json.Marshal(&test.where)
 			if err != nil {
 				t.Fatalf("unexpected error %q", err)
 			}
@@ -317,22 +606,275 @@ func Test_Where_MarshalJSON(t *testing.T) {
 			}
 		})
 	}
+
 }
 
-func Test_JSONConditionValue_Marshal(t *testing.T) {
+// Test_WhereCondition_Equal verifies equality of WhereCondition values,
+// including non-comparable and JSON values.
+func Test_WhereCondition_Equal(t *testing.T) {
+
+	number34 := decimal.MustInt(34)
+	number34Copy := decimal.MustInt(34)
+	number35 := decimal.MustInt(35)
+	tests := []struct {
+		name        string
+		left, right *WhereCondition
+		equal       bool
+	}{
+		{name: "both nil", left: nil, right: nil, equal: true},
+		{name: "receiver nil", left: nil, right: &WhereCondition{}, equal: false},
+		{name: "other nil", left: &WhereCondition{}, right: nil, equal: false},
+		{
+			name:  "equal slices",
+			left:  &WhereCondition{Values: []any{[]int{1, 2}}},
+			right: &WhereCondition{Values: []any{[]int{1, 2}}},
+			equal: true,
+		},
+		{
+			name:  "different slices",
+			left:  &WhereCondition{Values: []any{[]int{1, 2}}},
+			right: &WhereCondition{Values: []any{[]int{1, 3}}},
+			equal: false,
+		},
+		{
+			name:  "equal maps",
+			left:  &WhereCondition{Values: []any{map[string]int{"a": 1}}},
+			right: &WhereCondition{Values: []any{map[string]int{"a": 1}}},
+			equal: true,
+		},
+		{
+			name:  "different maps",
+			left:  &WhereCondition{Values: []any{map[string]int{"a": 1}}},
+			right: &WhereCondition{Values: []any{map[string]int{"a": 2}}},
+			equal: false,
+		},
+		{
+			name: "equal JSON values",
+			left: &WhereCondition{Values: []any{
+				JSONConditionValue{String: "34", Number: &number34},
+			}},
+			right: &WhereCondition{Values: []any{
+				JSONConditionValue{String: "34", Number: &number34Copy},
+			}},
+			equal: true,
+		},
+		{
+			name: "different JSON strings",
+			left: &WhereCondition{Values: []any{
+				JSONConditionValue{String: "34", Number: &number34},
+			}},
+			right: &WhereCondition{Values: []any{
+				JSONConditionValue{String: "35", Number: &number34},
+			}},
+			equal: false,
+		},
+		{
+			name: "JSON number presence differs",
+			left: &WhereCondition{Values: []any{
+				JSONConditionValue{String: "34"},
+			}},
+			right: &WhereCondition{Values: []any{
+				JSONConditionValue{String: "34", Number: &number34},
+			}},
+			equal: false,
+		},
+		{
+			name: "different JSON numbers",
+			left: &WhereCondition{Values: []any{
+				JSONConditionValue{String: "34", Number: &number34},
+			}},
+			right: &WhereCondition{Values: []any{
+				JSONConditionValue{String: "34", Number: &number35},
+			}},
+			equal: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.left.Equal(test.right); got != test.equal {
+				t.Fatalf("expected equal %t, got %t", test.equal, got)
+			}
+		})
+	}
+
+}
+
+// Test_WhereLogical_JSON verifies the external representation of every
+// logical operator and the handling of invalid values.
+func Test_WhereLogical_JSON(t *testing.T) {
 
 	tests := []struct {
+		op   WhereLogical
+		name string
+	}{
+		{op: OpAnd, name: "And"},
+		{op: OpOr, name: "Or"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expected := []byte(`"` + test.name + `"`)
+			got, err := test.op.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, expected) {
+				t.Fatalf("expected %s, got %s", expected, got)
+			}
+			if got := test.op.String(); got != test.name {
+				t.Fatalf("expected %s, got %s", test.name, got)
+			}
+			var decoded WhereLogical
+			if err := json.Unmarshal(got, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if decoded != test.op {
+				t.Fatalf("expected %d, got %d", test.op, decoded)
+			}
+		})
+	}
+
+	invalid := []struct {
+		name string
+		op   WhereLogical
+	}{
+		{name: "negative", op: WhereLogical(-1)},
+		{name: "above maximum", op: OpOr + 1},
+	}
+	for _, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.op.MarshalJSON()
+			if err == nil {
+				t.Fatal("expected MarshalJSON to return an error")
+			}
+			defer func() {
+				recovered := recover()
+				if recovered == nil {
+					t.Fatal("expected String to panic")
+				}
+				if fmt.Sprint(recovered) != err.Error() {
+					t.Fatalf("expected panic %q, got %q", err, recovered)
+				}
+			}()
+			_ = test.op.String()
+		})
+	}
+
+}
+
+// Test_WhereOperator_JSON verifies the external representation of every
+// condition operator and the handling of invalid values.
+func Test_WhereOperator_JSON(t *testing.T) {
+
+	tests := []struct {
+		op   WhereOperator
+		name string
+	}{
+		{op: OpIs, name: "Is"},
+		{op: OpIsNot, name: "IsNot"},
+		{op: OpIsLessThan, name: "IsLessThan"},
+		{op: OpIsLessThanOrEqualTo, name: "IsLessThanOrEqualTo"},
+		{op: OpIsGreaterThan, name: "IsGreaterThan"},
+		{op: OpIsGreaterThanOrEqualTo, name: "IsGreaterThanOrEqualTo"},
+		{op: OpIsBetween, name: "IsBetween"},
+		{op: OpIsNotBetween, name: "IsNotBetween"},
+		{op: OpContains, name: "Contains"},
+		{op: OpDoesNotContain, name: "DoesNotContain"},
+		{op: OpIsOneOf, name: "IsOneOf"},
+		{op: OpIsNotOneOf, name: "IsNotOneOf"},
+		{op: OpStartsWith, name: "StartsWith"},
+		{op: OpEndsWith, name: "EndsWith"},
+		{op: OpIsBefore, name: "IsBefore"},
+		{op: OpIsOnOrBefore, name: "IsOnOrBefore"},
+		{op: OpIsAfter, name: "IsAfter"},
+		{op: OpIsOnOrAfter, name: "IsOnOrAfter"},
+		{op: OpIsTrue, name: "IsTrue"},
+		{op: OpIsFalse, name: "IsFalse"},
+		{op: OpIsEmpty, name: "IsEmpty"},
+		{op: OpIsNotEmpty, name: "IsNotEmpty"},
+		{op: OpIsNull, name: "IsNull"},
+		{op: OpIsNotNull, name: "IsNotNull"},
+		{op: OpExists, name: "Exists"},
+		{op: OpDoesNotExist, name: "DoesNotExist"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expected := []byte(`"` + test.name + `"`)
+			got, err := test.op.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, expected) {
+				t.Fatalf("expected %s, got %s", expected, got)
+			}
+			if got := test.op.String(); got != test.name {
+				t.Fatalf("expected %s, got %s", test.name, got)
+			}
+			var decoded WhereOperator
+			if err := json.Unmarshal(got, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if decoded != test.op {
+				t.Fatalf("expected %d, got %d", test.op, decoded)
+			}
+		})
+	}
+
+	t.Run("legacy name", func(t *testing.T) {
+		var op WhereOperator
+		if err := json.Unmarshal([]byte(`"OpIsNotBetween"`), &op); err == nil {
+			t.Fatal("expected legacy operator name to be rejected")
+		}
+	})
+
+	invalid := []struct {
+		name string
+		op   WhereOperator
+	}{
+		{name: "negative", op: WhereOperator(-1)},
+		{name: "above maximum", op: OpDoesNotExist + 1},
+	}
+	for _, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.op.MarshalJSON()
+			if err == nil {
+				t.Fatal("expected MarshalJSON to return an error")
+			}
+			defer func() {
+				recovered := recover()
+				if recovered == nil {
+					t.Fatal("expected String to panic")
+				}
+				if fmt.Sprint(recovered) != err.Error() {
+					t.Fatalf("expected panic %q, got %q", err, recovered)
+				}
+			}()
+			_ = test.op.String()
+		})
+	}
+
+}
+
+// Test_JSONConditionValue_MarshalJSON verifies that JSON condition values are
+// persisted using their raw strings.
+func Test_JSONConditionValue_MarshalJSON(t *testing.T) {
+
+	tests := []struct {
+		name     string
 		v        JSONConditionValue
 		expected []byte
 	}{
-		{v: JSONConditionValue{String: ""}, expected: []byte(`""`)},
-		{v: JSONConditionValue{String: "foo"}, expected: []byte(`"foo"`)},
-		{v: JSONConditionValue{String: "34", Number: new(decimal.MustInt(34))}, expected: []byte(`"34"`)},
-		{v: JSONConditionValue{String: "893.051", Number: new(decimal.MustParse("893.051"))}, expected: []byte(`"893.051"`)},
+		{name: "empty", v: JSONConditionValue{String: ""}, expected: []byte(`""`)},
+		{name: "string", v: JSONConditionValue{String: "foo"}, expected: []byte(`"foo"`)},
+		{name: "integer", v: JSONConditionValue{String: "34", Number: new(decimal.MustInt(34))}, expected: []byte(`"34"`)},
+		{
+			name:     "decimal",
+			v:        JSONConditionValue{String: "893.051", Number: new(decimal.MustParse("893.051"))},
+			expected: []byte(`"893.051"`),
+		},
 	}
 
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			got, err := test.v.MarshalJSON()
 			if err != nil {
 				t.Fatalf("unexpected error %q", err)
@@ -345,4 +887,5 @@ func Test_JSONConditionValue_Marshal(t *testing.T) {
 			}
 		})
 	}
+
 }

--- a/core/pipeline_validate_test.go
+++ b/core/pipeline_validate_test.go
@@ -78,9 +78,9 @@ func Test_validatePipeline(t *testing.T) {
 			pipeline: PipelineToSet{
 				Name: "Import users",
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "email_in",
 							Operator: OpIsNot,
 							Values:   []string{"a@b"},
@@ -239,14 +239,14 @@ func Test_validatePipeline(t *testing.T) {
 			pipeline: PipelineToSet{
 				Name: "Import users",
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "email_in",
 							Operator: OpIsNot,
 							Values:   []string{"a@b"},
 						},
-						{
+						&FilterCondition{
 							Property: "id",
 							Operator: OpIsNot,
 							Values:   []string{"1234567890"},
@@ -411,9 +411,9 @@ func Test_validatePipeline(t *testing.T) {
 			name: "GOOD: Source/SDK/Event - with filters",
 			pipeline: PipelineToSet{
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "anonymousId",
 							Operator: OpIsNot,
 							Values:   []string{"abc"},
@@ -598,9 +598,9 @@ func Test_validatePipeline(t *testing.T) {
 			pipeline: PipelineToSet{
 				Name: "Export users",
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "email_in",
 							Operator: OpIsNot,
 							Values:   []string{"a@b"},
@@ -928,9 +928,9 @@ func Test_validatePipeline(t *testing.T) {
 			pipeline: PipelineToSet{
 				Name: "Export users",
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{Property: "first_name", Operator: OpIs, Values: []string{"Bob"}},
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{Property: "first_name", Operator: OpIs, Values: []string{"Bob"}},
 					},
 				},
 				InSchema: types.Object([]types.Property{
@@ -2665,9 +2665,9 @@ func Test_validatePipeline(t *testing.T) {
 			pipeline: PipelineToSet{
 				Name: "Export users",
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "_id",
 							Operator: OpIsNot,
 							Values:   []string{"a@b"},
@@ -2703,9 +2703,9 @@ func Test_validatePipeline(t *testing.T) {
 			pipeline: PipelineToSet{
 				Name: "Export users",
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "_id",
 							Operator: OpIsNot,
 							Values:   []string{"a@b"},
@@ -3093,14 +3093,14 @@ func Test_validatePipeline(t *testing.T) {
 			pipeline: PipelineToSet{
 				Name: "Import users",
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "email_in",
 							Operator: OpIsNot,
 							Values:   []string{"a@b"},
 						},
-						{
+						&FilterCondition{
 							Property: "id",
 							Operator: OpIsNot,
 							Values:   []string{"1234567890"},
@@ -3133,9 +3133,9 @@ func Test_validatePipeline(t *testing.T) {
 			name: "BAD: Source/SDK/Event - cannot provide input schema",
 			pipeline: PipelineToSet{
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "anonymousId",
 							Operator: OpIsNot,
 							Values:   []string{"a@b"},
@@ -3273,9 +3273,9 @@ func Test_validatePipeline(t *testing.T) {
 			pipeline: PipelineToSet{
 				Name: "Import users",
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "email_in",
 							Operator: OpIsNot,
 							Values:   []string{"a@b"},
@@ -3382,9 +3382,9 @@ func Test_validatePipeline(t *testing.T) {
 			pipeline: PipelineToSet{
 				Name: "Import users",
 				Filter: &Filter{
-					Logical: OpAnd,
-					Conditions: []FilterCondition{
-						{
+					Operator: OpAnd,
+					Rules: []FilterRule{
+						&FilterCondition{
 							Property: "email_in",
 							Operator: OpIsNot,
 							Values:   []string{"a@b"},

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -231,11 +231,16 @@ func (this *Workspace) Attributes(ctx context.Context, kpid string) (json.Value,
 	}
 
 	properties := this.workspace.ProfileSchema.Properties().Names()
-	where := &state.Where{Logical: state.OpAnd, Conditions: []state.WhereCondition{{
-		Property: []string{"_kpid"},
-		Operator: state.OpIs,
-		Values:   []any{kpid},
-	}}}
+	where := &state.Where{
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{
+				Property: []string{"_kpid"},
+				Operator: state.OpIs,
+				Values:   []any{kpid},
+			},
+		},
+	}
 
 	// Retrieve the profile attributes.
 	profiles, _, err := this.store.Profiles(ctx, datastore.Query{
@@ -968,11 +973,16 @@ func (this *Workspace) Identities(ctx context.Context, kpid string, first, limit
 	if limit < 1 || limit > 1000 {
 		return nil, 0, errors.BadRequest("limit %d is not valid", limit)
 	}
-	where := &state.Where{Logical: state.OpAnd, Conditions: []state.WhereCondition{{
-		Property: []string{"_kpid"},
-		Operator: state.OpIs,
-		Values:   []any{kpid},
-	}}}
+	where := &state.Where{
+		Operator: state.OpAnd,
+		Rules: []state.WhereRule{
+			&state.WhereCondition{
+				Property: []string{"_kpid"},
+				Operator: state.OpIs,
+				Values:   []any{kpid},
+			},
+		},
+	}
 	ws := &Workspace{
 		core:      this.core,
 		store:     this.store,

--- a/test/anonymous_not_anonymous_test.go
+++ b/test/anonymous_not_anonymous_test.go
@@ -42,10 +42,10 @@ func TestAnonymousNotAnonymous(t *testing.T) {
 			{Name: "email", Type: types.String().WithMaxLength(300), ReadOptional: true},
 		}),
 		Filter: &krenalistester.Filter{
-			Logical: "or",
-			Conditions: []krenalistester.FilterCondition{
-				{Property: "messageId", Operator: "is", Values: []string{"message1"}}, // message of the anonymous identity
-				{Property: "messageId", Operator: "is", Values: []string{"message3"}}, // message of the not-anonymous identity
+			Operator: krenalistester.OpOr,
+			Rules: []krenalistester.FilterRule{
+				&krenalistester.FilterCondition{Property: "messageId", Operator: "is", Values: []string{"message1"}}, // message of the anonymous identity
+				&krenalistester.FilterCondition{Property: "messageId", Operator: "is", Values: []string{"message3"}}, // message of the not-anonymous identity
 			},
 		},
 		Transformation: &krenalistester.Transformation{
@@ -65,9 +65,9 @@ func TestAnonymousNotAnonymous(t *testing.T) {
 			{Name: "email", Type: types.String().WithMaxLength(300), ReadOptional: true},
 		}),
 		Filter: &krenalistester.Filter{
-			Logical: "or",
-			Conditions: []krenalistester.FilterCondition{
-				{Property: "messageId", Operator: "is", Values: []string{"message2"}}, // message of the anonymous identity
+			Operator: krenalistester.OpOr,
+			Rules: []krenalistester.FilterRule{
+				&krenalistester.FilterCondition{Property: "messageId", Operator: "is", Values: []string{"message2"}}, // message of the anonymous identity
 			},
 		},
 		Transformation: &krenalistester.Transformation{

--- a/test/krenalistester/support.go
+++ b/test/krenalistester/support.go
@@ -392,17 +392,17 @@ func (k *Krenalis) CreateWorkspaceRestrictedAPIKey(name string) string {
 // DefaultFilterUserFromEvents is the filter that the admin adds by default to
 // the pipelines that import users from events.
 var DefaultFilterUserFromEvents = &Filter{
-	Logical: "or",
-	Conditions: []FilterCondition{
-		{
+	Operator: OpOr,
+	Rules: []FilterRule{
+		&FilterCondition{
 			Property: "type",
 			Operator: "is",
 			Values:   []string{"identify"},
 		},
-		{
+		&FilterCondition{
 			Property: "traits",
 			Operator: "is not empty",
-			Values:   nil,
+			Values:   []string{},
 		},
 	},
 }
@@ -633,9 +633,9 @@ func (k *Krenalis) ProfileEvents(kpid uuid.UUID, properties []string) []map[stri
 		"limit":      []string{"10"},
 	}
 	filter := Filter{
-		Logical: OpAnd,
-		Conditions: []FilterCondition{
-			{Property: "kpid",
+		Operator: OpAnd,
+		Rules: []FilterRule{
+			&FilterCondition{Property: "kpid",
 				Operator: OpIs,
 				Values:   []string{kpid.String()}},
 		},

--- a/test/krenalistester/support.go
+++ b/test/krenalistester/support.go
@@ -402,7 +402,6 @@ var DefaultFilterUserFromEvents = &Filter{
 		&FilterCondition{
 			Property: "traits",
 			Operator: "is not empty",
-			Values:   []string{},
 		},
 	},
 }

--- a/test/krenalistester/support_types.go
+++ b/test/krenalistester/support_types.go
@@ -124,17 +124,6 @@ type FilterCondition struct {
 	Values   []string       `json:"values"`
 }
 
-// MarshalJSON returns the JSON representation of condition.
-func (condition FilterCondition) MarshalJSON() ([]byte, error) {
-
-	if condition.Values == nil {
-		condition.Values = []string{}
-	}
-	type plainFilterCondition FilterCondition
-
-	return json.Marshal(plainFilterCondition(condition))
-}
-
 // filterRule marks FilterCondition as a filter rule.
 func (*FilterCondition) filterRule() {}
 

--- a/test/krenalistester/support_types.go
+++ b/test/krenalistester/support_types.go
@@ -93,11 +93,23 @@ const (
 	CreateOrUpdate ExportMode = "CreateOrUpdate"
 )
 
-type Filter struct {
-	Logical    FilterLogical     `json:"logical"`
-	Conditions []FilterCondition `json:"conditions"`
+// FilterRule represents a condition or a nested filter group.
+// It is implemented by *FilterCondition and *Filter.
+type FilterRule interface {
+	filterRule()
 }
 
+// Filter represents a logical expression whose rules are combined using AND or OR.
+type Filter struct {
+	Operator FilterLogical `json:"operator"`
+	Rules    []FilterRule  `json:"rules"`
+}
+
+// filterRule marks Filter as a filter rule.
+func (*Filter) filterRule() {}
+
+// FilterLogical represents the logical operator of a filter.
+// It can be OpAnd or OpOr.
 type FilterLogical string
 
 const (
@@ -105,12 +117,28 @@ const (
 	OpOr  FilterLogical = "or"
 )
 
+// FilterCondition represents a single filter condition.
 type FilterCondition struct {
 	Property string         `json:"property"`
 	Operator FilterOperator `json:"operator"`
 	Values   []string       `json:"values"`
 }
 
+// MarshalJSON returns the JSON representation of condition.
+func (condition FilterCondition) MarshalJSON() ([]byte, error) {
+
+	if condition.Values == nil {
+		condition.Values = []string{}
+	}
+	type plainFilterCondition FilterCondition
+
+	return json.Marshal(plainFilterCondition(condition))
+}
+
+// filterRule marks FilterCondition as a filter rule.
+func (*FilterCondition) filterRule() {}
+
+// FilterOperator represents a filter condition operator.
 type FilterOperator string
 
 const (

--- a/test/krenalistester/support_types_test.go
+++ b/test/krenalistester/support_types_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by an Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package krenalistester
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestFilterJSON verifies the recursive filter JSON representation, including
+// encoding a nil FilterCondition.Values slice as an empty array.
+func TestFilterJSON(t *testing.T) {
+
+	filter := Filter{
+		Operator: OpAnd,
+		Rules: []FilterRule{
+			&FilterCondition{Property: "x", Operator: OpExists},
+			&Filter{
+				Operator: OpOr,
+				Rules: []FilterRule{
+					&FilterCondition{Property: "y", Operator: OpIs, Values: []string{"a"}},
+					&FilterCondition{Property: "z", Operator: OpIs, Values: []string{"b"}},
+				},
+			},
+		},
+	}
+
+	got, err := json.Marshal(filter)
+	if err != nil {
+		t.Fatalf("cannot marshal filter: %v", err)
+	}
+	expected := `{"operator":"and","rules":[{"property":"x","operator":"exists","values":[]},` +
+		`{"operator":"or","rules":[{"property":"y","operator":"is","values":["a"]},` +
+		`{"property":"z","operator":"is","values":["b"]}]}]}`
+	if string(got) != expected {
+		t.Fatalf("expected %s, got %s", expected, got)
+	}
+
+}

--- a/test/krenalistester/support_types_test.go
+++ b/test/krenalistester/support_types_test.go
@@ -9,8 +9,24 @@ import (
 	"testing"
 )
 
+// TestDefaultFilterUserFromEventsJSON verifies the JSON representation of the
+// default filter for pipelines that import users from events.
+func TestDefaultFilterUserFromEventsJSON(t *testing.T) {
+
+	got, err := json.Marshal(DefaultFilterUserFromEvents)
+	if err != nil {
+		t.Fatalf("cannot marshal filter: %v", err)
+	}
+	expected := `{"operator":"or","rules":[{"property":"type","operator":"is","values":["identify"]},` +
+		`{"property":"traits","operator":"is not empty","values":null}]}`
+	if string(got) != expected {
+		t.Fatalf("expected %s, got %s", expected, got)
+	}
+
+}
+
 // TestFilterJSON verifies the recursive filter JSON representation, including
-// encoding a nil FilterCondition.Values slice as an empty array.
+// encoding a nil FilterCondition.Values slice as null.
 func TestFilterJSON(t *testing.T) {
 
 	filter := Filter{
@@ -31,7 +47,7 @@ func TestFilterJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot marshal filter: %v", err)
 	}
-	expected := `{"operator":"and","rules":[{"property":"x","operator":"exists","values":[]},` +
+	expected := `{"operator":"and","rules":[{"property":"x","operator":"exists","values":null},` +
 		`{"operator":"or","rules":[{"property":"y","operator":"is","values":["a"]},` +
 		`{"property":"z","operator":"is","values":["b"]}]}]}`
 	if string(got) != expected {

--- a/test/source_app_users_filtering_test.go
+++ b/test/source_app_users_filtering_test.go
@@ -27,9 +27,9 @@ func TestSourceAppUsersFiltering(t *testing.T) {
 		Name:    "Import users from Dummy",
 		Enabled: true,
 		Filter: &krenalistester.Filter{
-			Logical: krenalistester.OpAnd,
-			Conditions: []krenalistester.FilterCondition{
-				{
+			Operator: krenalistester.OpAnd,
+			Rules: []krenalistester.FilterRule{
+				&krenalistester.FilterCondition{
 					Property: "email",
 					Operator: krenalistester.OpIsNot,
 					Values:   []string{"kdericut4@example.com"},

--- a/test/source_file_storage_users_filtering_test.go
+++ b/test/source_file_storage_users_filtering_test.go
@@ -36,12 +36,27 @@ func TestSourceFileStorageUsersFiltering(t *testing.T) {
 		Enabled: true,
 		Path:    "users.csv",
 		Filter: &krenalistester.Filter{
-			Logical: krenalistester.OpAnd,
-			Conditions: []krenalistester.FilterCondition{
-				{
+			Operator: krenalistester.OpAnd,
+			Rules: []krenalistester.FilterRule{
+				&krenalistester.FilterCondition{
 					Property: "email",
 					Operator: krenalistester.OpIsNot,
-					Values:   []string{"et@example.com"},
+					Values:   []string{"ap@example.com"},
+				},
+				&krenalistester.Filter{
+					Operator: krenalistester.OpOr,
+					Rules: []krenalistester.FilterRule{
+						&krenalistester.FilterCondition{
+							Property: "email",
+							Operator: krenalistester.OpIs,
+							Values:   []string{"ap@example.com"},
+						},
+						&krenalistester.FilterCondition{
+							Property: "email",
+							Operator: krenalistester.OpIs,
+							Values:   []string{"cp@example.com"},
+						},
+					},
 				},
 			},
 		},
@@ -71,9 +86,9 @@ func TestSourceFileStorageUsersFiltering(t *testing.T) {
 
 	_, _, total := k.Profiles([]string{"email"}, "", false, 0, 100)
 
-	// The CSV file contains 10 profiles, but one of them was filtered out, so
-	// there must be 9.
-	const expectedTotal = 9
+	// Only cp@example.com satisfies "email is not ap@example.com" AND
+	// ("email is ap@example.com" OR "email is cp@example.com").
+	const expectedTotal = 1
 	if expectedTotal != total {
 		t.Fatalf("expected %d profiles, got %d", expectedTotal, total)
 	}

--- a/tools/json/functions.go
+++ b/tools/json/functions.go
@@ -162,8 +162,11 @@ func IndentSorted(data []byte, prefix, indent string) ([]byte, error) {
 // Marshal encodes the given data.
 func Marshal(data any) (Value, error) {
 	val, err := json.Marshal(data)
-	if _, ok := err.(*jsontext.SyntacticError); ok {
-		return Value{}, &SyntaxError{err: err}
+	if err != nil {
+		if _, ok := err.(*jsontext.SyntacticError); ok {
+			return Value{}, &SyntaxError{err: err}
+		}
+		return Value{}, err
 	}
 	return val, nil
 }

--- a/tools/json/functions_test.go
+++ b/tools/json/functions_test.go
@@ -6,6 +6,7 @@ package json
 
 import (
 	"bytes"
+	"math"
 	"reflect"
 	"testing"
 )
@@ -157,6 +158,17 @@ func Test_IndentSorted(t *testing.T) {
 			t.Fatalf("unexpected value.\nexpected: %q\ngot:      %q\n", test.expected, got)
 		}
 	}
+}
+
+// Test_Marshal verifies that Marshal returns semantic encoding errors.
+func Test_Marshal(t *testing.T) {
+
+	_, err := Marshal(math.Inf(1))
+	if err != nil {
+		return
+	}
+	t.Fatal("expected error, got no error")
+
 }
 
 func Test_Quote(t *testing.T) {


### PR DESCRIPTION
```
all: replace flat filters with compound filter groups (#2427)

The existing filter model applies a single logical operator to all
conditions, making nested logical combinations impossible to express.
It can express:

a AND b AND c

or

a OR b OR c

Introduce compound filter groups that allow conditions to be combined
more flexibly:

a AND (b OR c)

Align filter parsing, validation, persistence, evaluation, and editing
across the backend and Admin console. Migrate existing persisted filters
to the new representation and correct existing inconsistencies in filter
handling.
```