### PR TITLE
all: avoid warehouse DDL for metadata-only schema changes

### DIFF
--- a/admin/src/components/routes/SchemaEdit/SchemaEdit.helpers.ts
+++ b/admin/src/components/routes/SchemaEdit/SchemaEdit.helpers.ts
@@ -67,12 +67,9 @@ const normalizeSchema = (schema: EditableSchema): ObjectType => {
 		const property = schema[k];
 		const isFirstLevelProperty = property.indentation === 0;
 		if (isFirstLevelProperty) {
-			const typ = property.type;
-			if (typ.kind === 'object') {
-				// empty the properties, they will be populated with the
-				// edited subproperties.
-				typ.properties = [];
-			}
+			// Copy the type and empty its properties; they will be populated
+			// with the edited subproperties.
+			const typ = property.type.kind === 'object' ? { ...property.type, properties: [] } : property.type;
 			const p: any = {
 				name: property.name,
 				type: typ,
@@ -96,12 +93,9 @@ const normalizeSchema = (schema: EditableSchema): ObjectType => {
 				const typ = subProperties.find((p) => p.name === name).type as ObjectType;
 				subProperties = typ.properties;
 			}
-			const typ = property.type;
-			if (typ.kind === 'object') {
-				// empty the properties, they will be populated with the
-				// edited subproperties.
-				typ.properties = [];
-			}
+			// Copy the type and empty its properties; they will be populated
+			// with the edited subproperties.
+			const typ = property.type.kind === 'object' ? { ...property.type, properties: [] } : property.type;
 			const subP: any = {
 				name: property.name,
 				type: typ,

--- a/admin/src/components/routes/SchemaEdit/SchemaEdit.tsx
+++ b/admin/src/components/routes/SchemaEdit/SchemaEdit.tsx
@@ -39,8 +39,11 @@ const SchemaEdit = () => {
 		columns,
 		primarySources,
 		queries,
+		hasSchemaChanges,
+		isSchemaPreviewLoading,
 		isQueriesLoading,
 		isConfirmChangesLoading,
+		warehouseDDLRequired,
 		onAddProperty,
 		onEditProperty,
 		onRemoveProperty,
@@ -50,6 +53,7 @@ const SchemaEdit = () => {
 		onCancelChanges,
 		sortableGridRef,
 	} = useSchemaEdit(schema, onAddClick, onEditClick, onRemoveClick, closeFullscreen);
+	const hasNoWarehouseQueries = queries?.length === 0;
 
 	const onCancelRemove = () => {
 		setPropertyToRemove(null);
@@ -67,8 +71,14 @@ const SchemaEdit = () => {
 					<SlButton className='schema-edit__header-cancel-button' onClick={onCancelEdit}>
 						Cancel
 					</SlButton>
-					<SlButton className='schema-edit__header-apply-button' variant='primary' onClick={onApplyChanges}>
-						Review and apply changes...
+					<SlButton
+						className='schema-edit__header-apply-button'
+						variant='primary'
+						onClick={onApplyChanges}
+						disabled={!hasSchemaChanges || isSchemaPreviewLoading}
+						loading={hasSchemaChanges && isSchemaPreviewLoading}
+					>
+						{hasSchemaChanges && warehouseDDLRequired ? 'Review and apply changes...' : 'Apply changes'}
 					</SlButton>
 				</div>
 			</div>
@@ -93,7 +103,7 @@ const SchemaEdit = () => {
 			/>
 			<SlDialog
 				open={isQueriesLoading || queries != null}
-				label='Review changes'
+				label={hasNoWarehouseQueries ? 'Apply schema changes?' : 'Review changes'}
 				onSlAfterHide={onCancelChanges}
 				className={`schema-edit__queries ${isQueriesLoading ? ' schema-edit__queries--loading' : ''}`}
 			>
@@ -115,7 +125,10 @@ const SchemaEdit = () => {
 									<SyntaxHighlight language='sql'>{queries.join('\n\n')}</SyntaxHighlight>
 								</div>
 							) : (
-								<div className='schema-edit__no-query'>No query for this operation</div>
+								<div className='schema-edit__no-query'>
+									These changes affect only the schema definition. The data warehouse will not be
+									modified.
+								</div>
 							)}
 							<div className='schema-edit__queries-buttons' slot='footer'>
 								<SlButton size='small' onClick={onCancelChanges}>
@@ -124,11 +137,11 @@ const SchemaEdit = () => {
 								<SlButton
 									className='schema-edit__apply-alter-button'
 									size='small'
-									variant='danger'
+									variant={hasNoWarehouseQueries ? 'primary' : 'danger'}
 									onClick={onConfirmChanges}
 									loading={isConfirmChangesLoading}
 								>
-									Apply alter schema
+									Apply changes
 								</SlButton>
 							</div>
 						</>

--- a/admin/src/components/routes/SchemaEdit/useSchemaEdit.tsx
+++ b/admin/src/components/routes/SchemaEdit/useSchemaEdit.tsx
@@ -373,10 +373,7 @@ const useSchemaEdit = (
 		// Applied property types are read-only, so these fields are enough to
 		// identify edits that cannot change the warehouse schema.
 		const warehouseSchemaUnchanged =
-			!current.isEditable &&
-			property.name === current.name &&
-			property.type === current.type &&
-			property.nullable === current.nullable;
+			!current.isEditable && property.name === current.name && property.type === current.type;
 		if (warehouseSchemaUnchanged && currentSchemaPreview != null) {
 			const request = buildSchemaPreviewRequest(s, rePaths.current);
 			setSchemaPreview({ key: request.key, queries: currentSchemaPreview.queries });

--- a/admin/src/components/routes/SchemaEdit/useSchemaEdit.tsx
+++ b/admin/src/components/routes/SchemaEdit/useSchemaEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, ReactNode, useRef, useContext } from 'react';
+import React, { useState, useMemo, useEffect, ReactNode, useRef, useContext, useCallback } from 'react';
 import Type, { ObjectType, Role, TypeKind } from '../../../lib/api/types/types';
 import { SortableGridRow, GridColumn } from '../../base/Grid/Grid.types';
 import SlButton from '@shoelace-style/shoelace/dist/react/button/index.js';
@@ -46,6 +46,17 @@ interface PropertyToRemove {
 	type: TypeKind;
 }
 
+interface SchemaPreviewRequest {
+	key: string;
+	schema: ObjectType;
+	rePaths: RePaths;
+}
+
+interface SchemaPreview {
+	key: string;
+	queries: string[];
+}
+
 const useSchemaEdit = (
 	schema: ObjectType,
 	onAddClick: (parentKey: string, indentation: number, root: string) => void,
@@ -55,6 +66,8 @@ const useSchemaEdit = (
 ) => {
 	const [editableSchema, setEditableSchema] = useState<EditableSchema>();
 	const [queries, setQueries] = useState<string[]>();
+	const [schemaPreview, setSchemaPreview] = useState<SchemaPreview>();
+	const [isSchemaPreviewLoading, setIsSchemaPreviewLoading] = useState<boolean>(false);
 	const [isQueriesLoading, setIsQueriesLoading] = useState<boolean>(false);
 	const [isConfirmChangesLoading, setIsConfirmChangesLoading] = useState<boolean>(false);
 
@@ -68,6 +81,56 @@ const useSchemaEdit = (
 	const primarySources = useRef<PrimarySources>(workspaces.find((w) => w.id === selectedWorkspace).primarySources);
 	const rePaths = useRef<RePaths>({});
 	const deletedAppliedKeys = useRef<string[]>([]);
+	const initialSchemaEditStateKey = useRef<string>();
+	const schemaPreviewInFlight = useRef<{
+		key: string;
+		promise: Promise<PreviewAlterProfileSchemaResponse>;
+	}>();
+
+	const requestSchemaPreview = useCallback(
+		(request: SchemaPreviewRequest): Promise<PreviewAlterProfileSchemaResponse> => {
+			if (schemaPreviewInFlight.current?.key === request.key) {
+				return schemaPreviewInFlight.current.promise;
+			}
+			const promise = api.workspaces.previewAlterProfileSchema(request.schema, request.rePaths);
+			schemaPreviewInFlight.current = { key: request.key, promise };
+			const clearRequest = () => {
+				if (schemaPreviewInFlight.current?.promise === promise) {
+					schemaPreviewInFlight.current = undefined;
+				}
+			};
+			void promise.then(clearRequest, clearRequest);
+			return promise;
+		},
+		[api],
+	);
+
+	const schemaPreviewRequest = useMemo(() => {
+		if (editableSchema == null) {
+			return null;
+		}
+		try {
+			return buildSchemaPreviewRequest(editableSchema, rePaths.current);
+		} catch {
+			return null;
+		}
+	}, [editableSchema]);
+
+	const currentSchemaPreview = schemaPreview?.key === schemaPreviewRequest?.key ? schemaPreview : undefined;
+	const schemaEditStateKey = useMemo(() => {
+		if (editableSchema == null) {
+			return null;
+		}
+		try {
+			return buildSchemaEditStateKey(editableSchema, primarySources.current, rePaths.current);
+		} catch {
+			return null;
+		}
+	}, [editableSchema]);
+
+	const hasSchemaChanges =
+		initialSchemaEditStateKey.current != null && schemaEditStateKey !== initialSchemaEditStateKey.current;
+	const warehouseDDLRequired = currentSchemaPreview != null && currentSchemaPreview.queries.length > 0;
 
 	const rows = useMemo(() => {
 		return getRows(editableSchema, primarySources.current, connections, onAddClick, onEditClick, onRemoveClick);
@@ -84,8 +147,50 @@ const useSchemaEdit = (
 				s.properties.push(p);
 			}
 		}
-		setEditableSchema(transformSchema(s));
+		rePaths.current = {};
+		deletedAppliedKeys.current = [];
+		const editable = transformSchema(s);
+		const request = buildSchemaPreviewRequest(editable, rePaths.current);
+		initialSchemaEditStateKey.current = buildSchemaEditStateKey(editable, primarySources.current, rePaths.current);
+		setIsSchemaPreviewLoading(false);
+		setSchemaPreview({ key: request.key, queries: [] });
+		setEditableSchema(editable);
 	}, [schema]);
+
+	useEffect(() => {
+		if (!hasSchemaChanges) {
+			setIsSchemaPreviewLoading(false);
+			if (schemaPreviewRequest != null && schemaPreview?.key !== schemaPreviewRequest.key) {
+				setSchemaPreview({ key: schemaPreviewRequest.key, queries: [] });
+			}
+			return;
+		}
+		const shouldRequestPreview = schemaPreviewRequest != null && schemaPreview?.key !== schemaPreviewRequest.key;
+		setIsSchemaPreviewLoading(shouldRequestPreview);
+		if (!shouldRequestPreview) {
+			return;
+		}
+		let active = true;
+		const timeout = window.setTimeout(async () => {
+			try {
+				const res = await requestSchemaPreview(schemaPreviewRequest);
+				if (active) {
+					setSchemaPreview({ key: schemaPreviewRequest.key, queries: res.queries });
+					setIsSchemaPreviewLoading(false);
+				}
+			} catch {
+				// Automatic previews are best-effort. Errors are reported if
+				// the user explicitly tries to apply the changes.
+				if (active) {
+					setIsSchemaPreviewLoading(false);
+				}
+			}
+		}, 300);
+		return () => {
+			active = false;
+			window.clearTimeout(timeout);
+		};
+	}, [hasSchemaChanges, requestSchemaPreview, schemaPreview, schemaPreviewRequest]);
 
 	const onAddProperty = (property: PropertyToEdit, primarySource: string | null) => {
 		if (isMetaProperty(property.name)) {
@@ -234,7 +339,7 @@ const useSchemaEdit = (
 				// If the property now renamed takes the name of a
 				// previously deleted property, add the “null” repath.
 				rePaths.current[newKey] = null;
-			} else if (!current.isEditable) {
+			} else if (!current.isEditable && newKey !== key) {
 				// If the property was already applied to the schema,
 				// add the repath.
 				rePaths.current[newKey] = key;
@@ -265,6 +370,17 @@ const useSchemaEdit = (
 			isEditable: current.isEditable ? current.isEditable : false,
 		};
 		s[key] = editedProperty;
+		// Applied property types are read-only, so these fields are enough to
+		// identify edits that cannot change the warehouse schema.
+		const warehouseSchemaUnchanged =
+			!current.isEditable &&
+			property.name === current.name &&
+			property.type === current.type &&
+			property.nullable === current.nullable;
+		if (warehouseSchemaUnchanged && currentSchemaPreview != null) {
+			const request = buildSchemaPreviewRequest(s, rePaths.current);
+			setSchemaPreview({ key: request.key, queries: currentSchemaPreview.queries });
+		}
 		setEditableSchema(s);
 	};
 
@@ -324,18 +440,21 @@ const useSchemaEdit = (
 	};
 
 	const onApplyChanges = async () => {
-		setIsQueriesLoading(true);
+		let request: SchemaPreviewRequest;
 		try {
-			validateEditableSchema(editableSchema);
+			request = buildSchemaPreviewRequest(editableSchema, rePaths.current);
 		} catch (err) {
 			handleError(err);
-			setIsQueriesLoading(false);
 			return;
 		}
-		const s = normalizeSchema(editableSchema);
+		if (schemaPreview?.key === request.key) {
+			setQueries(schemaPreview.queries);
+			return;
+		}
+		setIsQueriesLoading(true);
 		let res: PreviewAlterProfileSchemaResponse;
 		try {
-			res = await api.workspaces.previewAlterProfileSchema(s, rePaths.current);
+			res = await requestSchemaPreview(request);
 		} catch (err) {
 			setTimeout(() => {
 				setQueries(null);
@@ -345,6 +464,7 @@ const useSchemaEdit = (
 			return;
 		}
 		setTimeout(() => {
+			setSchemaPreview({ key: request.key, queries: res.queries });
 			setQueries(res.queries);
 			setIsQueriesLoading(false);
 		}, 300);
@@ -396,8 +516,11 @@ const useSchemaEdit = (
 		columns: SCHEMA_COLUMNS,
 		primarySources: primarySources.current,
 		queries,
+		hasSchemaChanges,
+		isSchemaPreviewLoading,
 		isQueriesLoading,
 		isConfirmChangesLoading,
+		warehouseDDLRequired,
 		onAddProperty,
 		onEditProperty,
 		onRemoveProperty,
@@ -406,6 +529,28 @@ const useSchemaEdit = (
 		onConfirmChanges,
 		onCancelChanges,
 		sortableGridRef,
+	};
+};
+
+const buildSchemaEditStateKey = (
+	editableSchema: EditableSchema,
+	primarySources: PrimarySources,
+	rePaths: RePaths,
+): string => {
+	const schema = normalizeSchema(editableSchema);
+	const sortedPrimarySources = Object.entries(primarySources).sort(([a], [b]) => a.localeCompare(b));
+	const sortedRePaths = Object.entries(rePaths).sort(([a], [b]) => a.localeCompare(b));
+	return JSON.stringify({ schema, primarySources: sortedPrimarySources, rePaths: sortedRePaths });
+};
+
+const buildSchemaPreviewRequest = (editableSchema: EditableSchema, rePaths: RePaths): SchemaPreviewRequest => {
+	validateEditableSchema(editableSchema);
+	const schema = normalizeSchema(editableSchema);
+	const currentRePaths = { ...rePaths };
+	return {
+		key: JSON.stringify({ schema, rePaths: currentRePaths }),
+		schema,
+		rePaths: currentRePaths,
 	};
 };
 

--- a/admin/tests/schema.spec.ts
+++ b/admin/tests/schema.spec.ts
@@ -9,10 +9,121 @@ test.afterEach(async ({ page }) => {
 	await logout(page);
 });
 
+test(`Preview schema metadata changes`, async ({ page }) => {
+	await page.goto(`${adminURL}/profile-unification/schema`);
+
+	await page.click('.schema-grid__alter-button');
+	const applyButton = page.locator('.schema-edit__header-apply-button');
+	await expect(applyButton).toHaveText('Apply changes');
+	await expect(applyButton).toHaveAttribute('disabled');
+	let previewRequests = 0;
+	page.on('request', (request) => {
+		if (request.url().includes('/profiles/schema/preview') && request.method() === 'PUT') {
+			previewRequests++;
+		}
+	});
+	// Record every label so the test also detects changes that are too brief for
+	// a final-state assertion.
+	await applyButton.evaluate((button: any) => {
+		button.observedLabels = [button.textContent.trim()];
+		button.labelObserver = new MutationObserver(() => {
+			button.observedLabels.push(button.textContent.trim());
+		});
+		button.labelObserver.observe(button, { childList: true, subtree: true, characterData: true });
+	});
+
+	await page.click('.grid__row[data-id="email"] .schema-edit__property-buttons-edit');
+	const description = page.locator('sl-textarea >> textarea[name="description"]');
+	const originalDescription = await description.inputValue();
+	await description.fill('Updated description');
+
+	await page.waitForTimeout(1000); // Add a timeout to ensure that the React state is synced with the form controls.
+
+	await page.click('.property-dialog__save');
+	await expect(applyButton).toHaveText('Apply changes');
+	await expect(applyButton).not.toHaveAttribute('disabled');
+	await page.waitForTimeout(1000);
+	expect(previewRequests).toBe(0);
+	const observedLabels = await applyButton.evaluate((button: any) => {
+		button.labelObserver.disconnect();
+		return button.observedLabels;
+	});
+	expect(observedLabels).not.toContain('Review and apply changes...');
+
+	await applyButton.click();
+	const dialog = page.locator('.schema-edit__queries');
+	await expect(dialog).toHaveAttribute('label', 'Apply schema changes?');
+	await expect(dialog.locator('.schema-edit__no-query')).toHaveText(
+		'These changes affect only the schema definition. The data warehouse will not be modified.',
+	);
+	await expect(dialog.locator('.schema-edit__apply-alter-button')).toHaveAttribute('variant', 'primary');
+	await dialog.locator('.schema-edit__queries-buttons sl-button').first().click();
+
+	await page.click('.grid__row[data-id="email"] .schema-edit__property-buttons-edit');
+	await description.fill(originalDescription);
+	await page.waitForTimeout(1000); // Add a timeout to ensure that the React state is synced with the form controls.
+	await page.click('.property-dialog__save');
+	await expect(applyButton).toHaveText('Apply changes');
+	await expect(applyButton).toHaveAttribute('disabled');
+	await page.waitForTimeout(1000);
+	expect(previewRequests).toBe(0);
+
+	// Cache a preview for a change that requires warehouse DDL.
+	await page.click('.schema-edit__add-property');
+	await page.locator('.property-dialog__name-input').evaluate((el: any, value) => {
+		el.value = value;
+		el.dispatchEvent(new CustomEvent('sl-input', { bubbles: true, composed: true }));
+	}, 'temporary_preview_property');
+	await page.locator('.property-dialog__type-select').evaluate((el: any, value) => {
+		el.value = value;
+		el.dispatchEvent(new CustomEvent('sl-change', { bubbles: true, composed: true }));
+	}, 'string');
+	await page.waitForTimeout(1000); // Add a timeout to ensure that the React state is synced with the form controls.
+	await Promise.all([
+		page.waitForResponse(
+			(response) => response.url().includes('/profiles/schema/preview') && response.request().method() === 'PUT',
+		),
+		page.click('.property-dialog__save'),
+	]);
+	await expect(applyButton).toHaveText('Review and apply changes...');
+
+	// Add a metadata change before removing the temporary property.
+	await page.click('.grid__row[data-id="email"] .schema-edit__property-buttons-edit');
+	await description.fill('Updated description');
+	await page.waitForTimeout(1000); // Add a timeout to ensure that the React state is synced with the form controls.
+	await page.click('.property-dialog__save');
+	await expect(applyButton).toHaveText('Review and apply changes...');
+
+	// A failed preview must not leave the warehouse status of an earlier
+	// version of the schema on the apply button.
+	await page.route(
+		'**/profiles/schema/preview',
+		async (route) => {
+			await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
+		},
+		{ times: 1 },
+	);
+	const failedPreviewResponse = page.waitForResponse(
+		(response) =>
+			response.url().includes('/profiles/schema/preview') &&
+			response.request().method() === 'PUT' &&
+			response.status() === 500,
+	);
+	await page.click('.grid__row[data-id="temporary_preview_property"] .schema-edit__property-buttons-remove');
+	await page.click('.schema-edit__confirm-remove-property');
+	await failedPreviewResponse;
+	await expect(applyButton).not.toHaveAttribute('loading');
+	await expect(applyButton).toHaveText('Apply changes');
+	await expect(applyButton).not.toHaveAttribute('disabled');
+});
+
 test(`Add schema property`, async ({ page }) => {
 	await page.goto(`${adminURL}/profile-unification/schema`);
 
 	await page.click('.schema-grid__alter-button');
+	const applyButton = page.locator('.schema-edit__header-apply-button');
+	await expect(applyButton).toHaveText('Apply changes');
+	await expect(applyButton).toHaveAttribute('disabled');
 	await page.click('.schema-edit__add-property');
 
 	await page.locator('.property-dialog__name-input').evaluate((el: any, value) => {
@@ -27,10 +138,20 @@ test(`Add schema property`, async ({ page }) => {
 
 	await page.waitForTimeout(1000); // Add a timeout to ensure that the React state is synced with the form controls.
 
+	const previewResponse = page.waitForResponse(
+		(response) => response.url().includes('/profiles/schema/preview') && response.request().method() === 'PUT',
+	);
 	await page.click('.property-dialog__save');
+	await expect(applyButton).toHaveAttribute('loading');
+	await expect(applyButton).toHaveAttribute('disabled');
+	await previewResponse;
 	await logValidationErrors(page, ['.property-dialog__control-error']);
+	await expect(applyButton).toHaveText('Review and apply changes...');
+	await expect(applyButton).not.toHaveAttribute('disabled');
 
-	await page.click('.schema-edit__header-apply-button');
+	await applyButton.click();
+	await expect(page.locator('.schema-edit__queries')).toHaveAttribute('label', 'Review changes');
+	await expect(page.locator('.schema-edit__apply-alter-button')).toHaveAttribute('variant', 'danger');
 	await page.click('.schema-edit__apply-alter-button');
 
 	await expect(page.locator('.schema-grid')).toBeAttached();
@@ -62,6 +183,7 @@ test(`Edit schema property`, async ({ page }) => {
 	await page.click('.property-dialog__save');
 	await logValidationErrors(page, ['.property-dialog__control-error']);
 
+	await expect(page.locator('.schema-edit__header-apply-button')).toHaveText('Review and apply changes...');
 	await page.click('.schema-edit__header-apply-button');
 	await page.click('.schema-edit__apply-alter-button');
 
@@ -130,6 +252,7 @@ test(`Check that RePaths are sent correctly`, async ({ page }) => {
 		}
 	});
 
+	await expect(page.locator('.schema-edit__header-apply-button')).toHaveText('Review and apply changes...');
 	await page.click('.schema-edit__header-apply-button');
 	await page.click('.schema-edit__apply-alter-button');
 
@@ -193,6 +316,7 @@ test(`Add schema object property with sub-property`, async ({ page }) => {
 	await page.click('.property-dialog__save');
 	await logValidationErrors(page, ['.property-dialog__control-error']);
 
+	await expect(page.locator('.schema-edit__header-apply-button')).toHaveText('Review and apply changes...');
 	await page.click('.schema-edit__header-apply-button');
 
 	await page.click('.schema-edit__apply-alter-button');
@@ -243,6 +367,7 @@ test(`Remove schema properties`, async ({ page }) => {
 	await page.click('.grid__row[data-id="test_obj"] .schema-edit__property-buttons-remove');
 	await page.click('.schema-edit__confirm-remove-property');
 
+	await expect(page.locator('.schema-edit__header-apply-button')).toHaveText('Review and apply changes...');
 	await page.click('.schema-edit__header-apply-button');
 	await page.click('.schema-edit__apply-alter-button');
 

--- a/core/alter_profileschema.go
+++ b/core/alter_profileschema.go
@@ -13,8 +13,10 @@ import (
 	"github.com/krenalis/krenalis/core/internal/datastore"
 	"github.com/krenalis/krenalis/core/internal/datastore/diffschemas"
 	"github.com/krenalis/krenalis/core/internal/state"
+	"github.com/krenalis/krenalis/core/internal/util"
 	"github.com/krenalis/krenalis/tools/errors"
 	"github.com/krenalis/krenalis/tools/types"
+	"github.com/krenalis/krenalis/warehouses"
 )
 
 // AlterProfileSchema alters the profile schema and the primary sources of the
@@ -133,6 +135,9 @@ func (this *Workspace) PreviewAlterProfileSchema(ctx context.Context, schema typ
 	if err != nil {
 		return nil, errors.Unprocessable(InvalidAlterSchema, "cannot alter the schema as specified: %s", err)
 	}
+	if !profileSchemaChangeRequiresWarehouseDDL(this.workspace.ProfileSchema, schema, operations) {
+		return []string{}, nil
+	}
 	queries, err := this.store.PreviewAlterProfileSchema(ctx, schema, operations)
 	if err != nil {
 		if err, ok := err.(*datastore.UnavailableError); ok {
@@ -201,6 +206,27 @@ func checkAllowedPropertyProfileSchema(schema types.Type) error {
 		}
 	}
 	return nil
+}
+
+// profileSchemaChangeRequiresWarehouseDDL reports whether changing from
+// oldSchema to newSchema requires DDL on the data warehouse. operations must be
+// the result of comparing the two schemas with diffschemas.Diff.
+func profileSchemaChangeRequiresWarehouseDDL(oldSchema, newSchema types.Type, operations []warehouses.AlterOperation) bool {
+	if len(operations) > 0 {
+		return true
+	}
+	columns1 := util.PropertiesToColumns(oldSchema.Properties())
+	columns2 := util.PropertiesToColumns(newSchema.Properties())
+	if len(columns1) != len(columns2) {
+		return true
+	}
+	for i, c1 := range columns1 {
+		c2 := columns2[i]
+		if c1.Name != c2.Name || c1.Nullable != c2.Nullable || !types.Equal(c1.Type, c2.Type) {
+			return true
+		}
+	}
+	return false
 }
 
 // validatePrimarySources validates a primary source returning an error if it is

--- a/core/alter_profileschema.go
+++ b/core/alter_profileschema.go
@@ -222,7 +222,7 @@ func profileSchemaChangeRequiresWarehouseDDL(oldSchema, newSchema types.Type, op
 	}
 	for i, c1 := range columns1 {
 		c2 := columns2[i]
-		if c1.Name != c2.Name || c1.Nullable != c2.Nullable || !types.Equal(c1.Type, c2.Type) {
+		if c1.Name != c2.Name || !types.Equal(c1.Type, c2.Type) {
 			return true
 		}
 	}

--- a/core/alter_profileschema_test.go
+++ b/core/alter_profileschema_test.go
@@ -159,7 +159,7 @@ func Test_checkAllowedTypesProfileSchema(t *testing.T) {
 
 }
 
-// Test_profileSchemaChangeRequiresWarehouseDDL tests whether profile schema
+// Test_profileSchemaChangeRequiresWarehouseDDL tests which profile schema
 // changes require DDL on the data warehouse.
 func Test_profileSchemaChangeRequiresWarehouseDDL(t *testing.T) {
 
@@ -189,6 +189,25 @@ func Test_profileSchemaChangeRequiresWarehouseDDL(t *testing.T) {
 			}),
 		},
 		{
+			name:      "Property added",
+			oldSchema: types.Object([]types.Property{property("a")}),
+			newSchema: types.Object([]types.Property{property("a"), property("b")}),
+			expected:  true,
+		},
+		{
+			name:      "Property removed",
+			oldSchema: types.Object([]types.Property{property("a"), property("b")}),
+			newSchema: types.Object([]types.Property{property("a")}),
+			expected:  true,
+		},
+		{
+			name:      "Property renamed",
+			oldSchema: types.Object([]types.Property{property("a")}),
+			newSchema: types.Object([]types.Property{property("b")}),
+			rePaths:   map[string]any{"b": "a"},
+			expected:  true,
+		},
+		{
 			name:      "Top-level properties reordered",
 			oldSchema: types.Object([]types.Property{property("a"), property("b")}),
 			newSchema: types.Object([]types.Property{property("b"), property("a")}),
@@ -214,7 +233,18 @@ func Test_profileSchemaChangeRequiresWarehouseDDL(t *testing.T) {
 	}
 
 	for _, test := range tests {
+
 		t.Run(test.name, func(t *testing.T) {
+
+			// Keep the fixtures within the profile schema domain. Invalid
+			// properties, including nullable ones, belong to validation tests.
+			if err := checkAllowedPropertyProfileSchema(test.oldSchema); err != nil {
+				t.Fatalf("old schema contains a property not allowed in a profile schema: %s", err)
+			}
+			if err := checkAllowedPropertyProfileSchema(test.newSchema); err != nil {
+				t.Fatalf("new schema contains a property not allowed in a profile schema: %s", err)
+			}
+
 			operations, err := diffschemas.Diff(test.oldSchema, test.newSchema, test.rePaths, "")
 			if err != nil {
 				t.Fatal(err)
@@ -223,7 +253,9 @@ func Test_profileSchemaChangeRequiresWarehouseDDL(t *testing.T) {
 			if actual != test.expected {
 				t.Fatalf("expected %t, got %t", test.expected, actual)
 			}
+
 		})
+
 	}
 
 }

--- a/core/alter_profileschema_test.go
+++ b/core/alter_profileschema_test.go
@@ -7,6 +7,7 @@ package core
 import (
 	"testing"
 
+	"github.com/krenalis/krenalis/core/internal/datastore/diffschemas"
 	"github.com/krenalis/krenalis/tools/types"
 )
 
@@ -152,6 +153,75 @@ func Test_checkAllowedTypesProfileSchema(t *testing.T) {
 			}
 			if gotErrStr != test.err {
 				t.Fatalf("expected error %q, got %q", test.err, gotErrStr)
+			}
+		})
+	}
+
+}
+
+// Test_profileSchemaChangeRequiresWarehouseDDL tests whether profile schema
+// changes require DDL on the data warehouse.
+func Test_profileSchemaChangeRequiresWarehouseDDL(t *testing.T) {
+
+	property := func(name string) types.Property {
+		return types.Property{Name: name, Type: types.String(), ReadOptional: true}
+	}
+
+	tests := []struct {
+		name      string
+		oldSchema types.Type
+		newSchema types.Type
+		rePaths   map[string]any
+		expected  bool
+	}{
+		{
+			name:      "Identical schemas",
+			oldSchema: types.Object([]types.Property{property("a"), property("b")}),
+			newSchema: types.Object([]types.Property{property("a"), property("b")}),
+		},
+		{
+			name: "Description changed",
+			oldSchema: types.Object([]types.Property{
+				property("a"),
+			}),
+			newSchema: types.Object([]types.Property{
+				{Name: "a", Type: types.String(), ReadOptional: true, Description: "New description"},
+			}),
+		},
+		{
+			name:      "Top-level properties reordered",
+			oldSchema: types.Object([]types.Property{property("a"), property("b")}),
+			newSchema: types.Object([]types.Property{property("b"), property("a")}),
+			expected:  true,
+		},
+		{
+			name: "Nested properties reordered",
+			oldSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{property("a"), property("b")}), ReadOptional: true},
+			}),
+			newSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{property("b"), property("a")}), ReadOptional: true},
+			}),
+			expected: true,
+		},
+		{
+			name:      "Explicit property recreation",
+			oldSchema: types.Object([]types.Property{property("a")}),
+			newSchema: types.Object([]types.Property{property("a")}),
+			rePaths:   map[string]any{"a": nil},
+			expected:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			operations, err := diffschemas.Diff(test.oldSchema, test.newSchema, test.rePaths, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			actual := profileSchemaChangeRequiresWarehouseDDL(test.oldSchema, test.newSchema, operations)
+			if actual != test.expected {
+				t.Fatalf("expected %t, got %t", test.expected, actual)
 			}
 		})
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -1614,32 +1614,35 @@ func (core *Core) executeAlterProfileSchema(workspace, opID string, schema types
 	if !ok {
 		return
 	}
-	// Keep calling 'AlterProfileSchema' until it (1) returns successfully, (2)
-	// returns with a *warehouses.OperationError, or (3) the context is
-	// canceled.
 	var alterSchemaErr *warehouses.OperationError
-	bo := backoff.New(200)
-	bo.SetCap(5 * time.Minute)
-	for bo.Next(ctx) {
-		err := store.AlterProfileSchema(ctx, opID, schema, operations)
-		// In case of success, go on and send an EndAlterProfileSchema
-		// notification.
-		if err == nil {
-			break
+	if profileSchemaChangeRequiresWarehouseDDL(ws.ProfileSchema, schema, operations) {
+
+		// Keep calling 'AlterProfileSchema' until it (1) returns successfully,
+		// (2) returns with a *warehouses.OperationError, or (3) the context is
+		// canceled.
+		bo := backoff.New(200)
+		bo.SetCap(5 * time.Minute)
+		for bo.Next(ctx) {
+			err := store.AlterProfileSchema(ctx, opID, schema, operations)
+			// In case of success, go on and send an EndAlterProfileSchema
+			// notification.
+			if err == nil {
+				break
+			}
+			// If the context has expired, just return.
+			if ctx.Err() != nil {
+				return
+			}
+			// In case of OperationError log it, then go on and send an
+			// EndAlterProfileSchema notification.
+			if err2, ok := err.(*warehouses.OperationError); ok {
+				slog.Error("alter schema ended with an error", "error", err2)
+				alterSchemaErr = err2
+				break
+			}
+			// In case of unknown error, try again.
+			slog.Error("alter schema on warehouse returned an unknown error; retrying", "retry_after", bo.WaitTime(), "error", err)
 		}
-		// If the context has expired, just return.
-		if ctx.Err() != nil {
-			return
-		}
-		// In case of OperationError log it, then go on and send an
-		// EndAlterProfileSchema notification.
-		if err2, ok := err.(*warehouses.OperationError); ok {
-			slog.Error("alter schema ended with an error", "error", err2)
-			alterSchemaErr = err2
-			break
-		}
-		// In case of unknown error, try again.
-		slog.Error("alter schema on warehouse returned an unknown error; retrying", "retry_after", bo.WaitTime(), "error", err)
 
 	}
 	nEnd := state.EndAlterProfileSchema{

--- a/core/core.go
+++ b/core/core.go
@@ -1616,7 +1616,6 @@ func (core *Core) executeAlterProfileSchema(workspace, opID string, schema types
 	}
 	var alterSchemaErr *warehouses.OperationError
 	if profileSchemaChangeRequiresWarehouseDDL(ws.ProfileSchema, schema, operations) {
-
 		// Keep calling 'AlterProfileSchema' until it (1) returns successfully,
 		// (2) returns with a *warehouses.OperationError, or (3) the context is
 		// canceled.
@@ -1643,7 +1642,6 @@ func (core *Core) executeAlterProfileSchema(workspace, opID string, schema types
 			// In case of unknown error, try again.
 			slog.Error("alter schema on warehouse returned an unknown error; retrying", "retry_after", bo.WaitTime(), "error", err)
 		}
-
 	}
 	nEnd := state.EndAlterProfileSchema{
 		Workspace: workspace,

--- a/test/change_user_schema_test.go
+++ b/test/change_user_schema_test.go
@@ -56,8 +56,11 @@ func TestChangeProfileSchema(t *testing.T) {
 
 	// Alter the profile schema.
 	queries := k.PreviewAlterProfileSchema(file.Schema, file.RePaths)
-	if len(queries) != 4 {
-		t.Fatalf("expected 4 queries, got %d", len(queries))
+	if queries == nil {
+		t.Fatal("expected an empty query list, got nil")
+	}
+	if len(queries) != 0 {
+		t.Fatalf("expected no queries, got %#v", queries)
 	}
 	k.AlterProfileSchemaAndWait(file.Schema, file.PrimarySources, file.RePaths)
 
@@ -67,6 +70,24 @@ func TestChangeProfileSchema(t *testing.T) {
 	}
 	if err := checkSchemaProperties(ws.ProfileSchema); err != nil {
 		t.Fatalf("invalid profile schema: %s", err)
+	}
+	if !slices.Equal(identifiers, ws.Identifiers) {
+		t.Fatalf("expected identifiers %v, got %v", identifiers, ws.Identifiers)
+	}
+
+	// Change only schema metadata.
+	descriptionProperties := file.Schema.Properties().Slice()
+	descriptionProperties[0].Description = "Updated description"
+	descriptionSchema := types.Object(descriptionProperties)
+	queries = k.PreviewAlterProfileSchema(descriptionSchema, nil)
+	if len(queries) != 0 {
+		t.Fatalf("expected no queries, got %#v", queries)
+	}
+	k.AlterProfileSchemaAndWait(descriptionSchema, file.PrimarySources, nil)
+
+	ws = k.Workspace()
+	if !types.Equal(descriptionSchema, ws.ProfileSchema) {
+		t.Fatal("expected the metadata-only schema change to be persisted")
 	}
 	if !slices.Equal(identifiers, ws.Identifiers) {
 		t.Fatalf("expected identifiers %v, got %v", identifiers, ws.Identifiers)

--- a/warehouses/postgresql/alter_schema.go
+++ b/warehouses/postgresql/alter_schema.go
@@ -89,8 +89,8 @@ func (warehouse *PostgreSQL) PreviewAlterProfileSchema(ctx context.Context, colu
 
 // alterProfileSchemaQueries returns the queries that perform the given
 // operations. profilesTableName is the current name of the profiles table, for
-// example "krenalis_profiles_42". operations must contain at least one
-// operation.
+// example "krenalis_profiles_42". operations may be empty when only the profile
+// column order changes.
 func alterProfileSchemaQueries(profilesTableName string, columns []warehouses.Column, operations []warehouses.AlterOperation) []string {
 
 	// The operations are performed in this order:

--- a/warehouses/snowflake/alter_schema.go
+++ b/warehouses/snowflake/alter_schema.go
@@ -88,8 +88,8 @@ func (warehouse *Snowflake) PreviewAlterProfileSchema(ctx context.Context, colum
 
 // alterProfileSchemaQueries returns the queries that perform the given
 // operations. profilesTableName is the current name of the profiles table, for
-// example "krenalis_profiles_42". operations must contain at least one
-// operation.
+// example "krenalis_profiles_42". operations may be empty when only the profile
+// column order changes.
 func alterProfileSchemaQueries(profilesTableName string, columns []warehouses.Column, operations []warehouses.AlterOperation) []string {
 
 	// The operations are performed in this order:


### PR DESCRIPTION
```
all: avoid warehouse DDL for metadata-only schema changes (#2429)

Profile schema updates are always treated as data warehouse changes,
even when they affect only metadata such as property descriptions. This
causes unnecessary DDL and shows users a warehouse query review with no
queries.

Determine whether a schema update changes the physical warehouse
representation and perform warehouse operations only when necessary.
Continue applying metadata-only changes to the schema, while presenting
them as a direct confirmation instead of a warehouse query review.
```