### PR TITLE
warehouses: preserve profiles after failed Identity Resolution

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1761,28 +1761,32 @@ func (core *Core) executeIdentityResolution(workspace, opID string) {
 	var unknownErrorMsg string
 	for bo.Next(ctx) {
 		err := store.ResolveIdentities(ctx, opID)
-		// In case of success, go on and send an EndIdentityResolution
-		// notification.
-		if err == nil {
-			break
+		if err != nil {
+			// If the context has expired, just return.
+			if ctx.Err() != nil {
+				unknownErrorMsg = ""
+				return
+			}
+			// If the workspace no longer exists, stop the operation.
+			if errors.Is(err, datastore.ErrWorkspaceNotExist) {
+				return
+			}
+			// In case of OperationError log it, then go on and send an
+			// EndIdentityResolution notification.
+			if operationError, ok := errors.AsType[*warehouses.OperationError](err); ok {
+				slog.Error("identity resolution ended with an error", "error", operationError)
+				unknownErrorMsg = ""
+				break
+			}
+			// In case of unknown error, try again.
+			loggedError := warehouses.NewOperationError(err)
+			if msg := loggedError.Error(); unknownErrorMsg != msg {
+				slog.Warn("failed to check the identity resolution status; retrying", "error", loggedError)
+				unknownErrorMsg = msg
+			}
+			continue
 		}
-		// If the context has expired, just return.
-		if ctx.Err() != nil {
-			unknownErrorMsg = ""
-			return
-		}
-		// In case of OperationError log it, then go on and send an
-		// EndIdentityResolution notification.
-		if err2, ok := err.(*warehouses.OperationError); ok {
-			slog.Error("identity resolution ended with an error", "error", err2)
-			unknownErrorMsg = ""
-			break
-		}
-		// In case of unknown error, try again.
-		if msg := err.Error(); unknownErrorMsg != msg {
-			slog.Warn("failed to check the identity resolution status; retrying", "error", err)
-			unknownErrorMsg = msg
-		}
+		break
 	}
 	if unknownErrorMsg != "" {
 		slog.Info("Identity resolution status checked successfully")

--- a/core/internal/datastore/store.go
+++ b/core/internal/datastore/store.go
@@ -6,7 +6,6 @@ package datastore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/krenalis/krenalis/core/internal/schemas"
 	"github.com/krenalis/krenalis/core/internal/state"
 	"github.com/krenalis/krenalis/core/internal/util"
+	"github.com/krenalis/krenalis/tools/errors"
 	"github.com/krenalis/krenalis/tools/json"
 	"github.com/krenalis/krenalis/tools/types"
 	"github.com/krenalis/krenalis/warehouses"
@@ -37,6 +37,10 @@ var ErrInspectionMode = errors.New("the data warehouse is in inspection mode")
 // ErrMaintenanceMode is returned by Store methods when they cannot execute due
 // to the data warehouse being in maintenance mode.
 var ErrMaintenanceMode = errors.New("the data warehouse is in maintenance mode")
+
+// ErrWorkspaceNotExist is returned by Store methods when the workspace no
+// longer exists.
+var ErrWorkspaceNotExist = errors.New("workspace does not exist anymore")
 
 // UnavailableError represents an error with the data warehouse.
 type UnavailableError struct {
@@ -379,8 +383,9 @@ func (store *Store) PreviewAlterProfileSchema(ctx context.Context, schema types.
 //
 // If the data warehouse is in maintenance mode, it returns the
 // ErrMaintenanceMode error. If the schema, which must be valid, does not align
-// with the profile schema, it returns a *schemas.Error error. If an error
-// occurs with the data warehouse, it returns an *UnavailableError error.
+// with the profile schema, it returns a *schemas.Error error. If the workspace
+// no longer exists, it returns [ErrWorkspaceNotExist]. If an error occurs with
+// the data warehouse, it returns an *UnavailableError error.
 func (store *Store) ProfileRecords(ctx context.Context, query Query, schema types.Type, matching *Matching) (*Records, error) {
 	store.mustBeOpen()
 	ctx, done, err := store.mc.StartOperation(ctx, normalMode|inspectionMode)
@@ -396,7 +401,7 @@ func (store *Store) ProfileRecords(ctx context.Context, query Query, schema type
 	}
 	workspace, ok := store.ds.state.Workspace(store.workspace)
 	if !ok {
-		return nil, fmt.Errorf("workspace does not exist anymore")
+		return nil, ErrWorkspaceNotExist
 	}
 	// Check that schema is aligned with the profile schema.
 	err = schemas.CheckAlignment(schema, workspace.ProfileSchema, nil)
@@ -481,17 +486,19 @@ func (store *Store) Repair(ctx context.Context, userSchema types.Type) error {
 // the operation ended successfully or with a *warehouses.OperationError error,
 // that result is returned again.
 //
-// This method, once called, can then return in four distinct cases:
+// This method, once called, can then return in five distinct cases:
 //
 // (1) the operation was successful and no error was returned;
 //
-// (2) the context was canceled;
+// (2) the workspace no longer exists and [ErrWorkspaceNotExist] was returned;
 //
-// (3) the operation ended with an error of type *warehouses.OperationError, and
+// (3) the context was canceled;
+//
+// (4) the operation ended with an error of type *warehouses.OperationError, and
 // this means that even if the method is called again with the same ID, this
 // error is still returned;
 //
-// (4) the operation ended with an unexpected and unknown error, and it is
+// (5) the operation ended with an unexpected and unknown error, and it is
 // therefore up to the caller to try calling this method again by providing the
 // same ID.
 func (store *Store) ResolveIdentities(ctx context.Context, opID string) error {
@@ -509,7 +516,7 @@ func (store *Store) ResolveIdentities(ctx context.Context, opID string) error {
 	// Retrieve the workspace.
 	ws, ok := store.ds.state.Workspace(store.workspace)
 	if !ok {
-		return nil
+		return ErrWorkspaceNotExist
 	}
 
 	// Determine the identifiers columns.

--- a/warehouses/operationerror_test.go
+++ b/warehouses/operationerror_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+package warehouses_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/krenalis/krenalis/tools/errors"
+	"github.com/krenalis/krenalis/warehouses"
+)
+
+// TestNewOperationError verifies that operation error messages remain valid
+// UTF-8 and are abbreviated without exceeding the supported size.
+func TestNewOperationError(t *testing.T) {
+
+	const suffix = "[...]"
+	const invalidMessage = "warehouse operation failed with an invalid error message"
+	maxBytes := warehouses.MaxOperationErrorBytes
+	exactUTF8 := strings.Repeat("a", maxBytes-2) + "é"
+	unicodePrefix := strings.Repeat("a", maxBytes-len(suffix)-1)
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{name: "short", message: "warehouse failure", want: "warehouse failure"},
+		{name: "exact UTF-8 limit", message: exactUTF8, want: exactUTF8},
+		{
+			name:    "oversized ASCII",
+			message: strings.Repeat("x", maxBytes+1),
+			want:    strings.Repeat("x", maxBytes-len(suffix)) + suffix,
+		},
+		{
+			name:    "UTF-8 boundary",
+			message: unicodePrefix + "é" + strings.Repeat("b", 10),
+			want:    unicodePrefix + suffix,
+		},
+		{name: "invalid UTF-8", message: string([]byte{'a', 0xff, 'b'}), want: invalidMessage},
+		{
+			name:    "oversized invalid UTF-8",
+			message: strings.Repeat(string([]byte{0x80}), maxBytes+1),
+			want:    invalidMessage,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := warehouses.NewOperationError(errors.New(test.message)).Error()
+			if got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("expected valid UTF-8, got %q", got)
+			}
+			if len(got) > maxBytes {
+				t.Fatalf("expected at most %d bytes, got %d", maxBytes, len(got))
+			}
+		})
+	}
+
+}
+
+// TestNewPersistedOperationError verifies that invalid or oversized persisted
+// operation error messages are replaced with a fixed message rather than
+// normalized.
+func TestNewPersistedOperationError(t *testing.T) {
+
+	const invalidMessage = "warehouse operation failed with an invalid or oversized error message"
+	maxSizeMessage := strings.Repeat("x", warehouses.MaxOperationErrorBytes)
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{name: "valid", message: "warehouse failure", want: "warehouse failure"},
+		{name: "maximum size", message: maxSizeMessage, want: maxSizeMessage},
+		{
+			name:    "oversized",
+			message: strings.Repeat("x", warehouses.MaxOperationErrorBytes+1),
+			want:    invalidMessage,
+		},
+		{name: "invalid UTF-8", message: string([]byte{'a', 0xff, 'b'}), want: invalidMessage},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := warehouses.NewPersistedOperationError(test.message).Error()
+			if got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+
+}

--- a/warehouses/postgresql/alter_schema.go
+++ b/warehouses/postgresql/alter_schema.go
@@ -21,24 +21,36 @@ import (
 
 // AlterProfileSchema alters the profile schema.
 func (warehouse *PostgreSQL) AlterProfileSchema(ctx context.Context, opID string, columns []warehouses.Column, operations []warehouses.AlterOperation) error {
+	pool, _, err := warehouse.connectionPool(ctx, false)
+	if err != nil {
+		return err
+	}
 	status, err := warehouse.executeOperation(ctx, opID, alterProfileSchema)
 	if err != nil {
 		return err
 	}
 	if status.alreadyCompleted {
-		return status.executionError
+		if status.executionError != nil {
+			return status.executionError
+		}
+		return nil
 	}
+	var operationErr *warehouses.OperationError
 	err = warehouse.alterProfileSchema(ctx, columns, operations)
+	if err != nil {
+		operationErr = warehouses.NewOperationError(err)
+	}
 	bo := backoff.New(200)
 	bo.SetCap(time.Second)
 	for bo.Next(ctx) {
-		err2 := warehouse.setOperationAsCompleted(ctx, opID, err)
+		err2 := warehouse.setOperationAsCompleted(ctx, pool, opID, operationErr)
 		if err2 != nil {
-			slog.Error("cannot set alter profile columns operation as completed, retrying", "err", err2, "operationError", err)
+			slog.Error("cannot set alter profile columns operation as completed, retrying",
+				"err", warehouses.NewOperationError(err2), "operationError", operationErr)
 			continue
 		}
-		if err != nil {
-			return warehouses.NewOperationError(err)
+		if operationErr != nil {
+			return operationErr
 		}
 		return nil
 	}

--- a/warehouses/postgresql/alter_schema.go
+++ b/warehouses/postgresql/alter_schema.go
@@ -59,14 +59,14 @@ func (warehouse *PostgreSQL) AlterProfileSchema(ctx context.Context, opID string
 
 func (warehouse *PostgreSQL) alterProfileSchema(ctx context.Context, columns []warehouses.Column, operations []warehouses.AlterOperation) error {
 
-	// Retrieve the current version of the "krenalis_profiles" table.
-	profilesVersion, err := warehouse.profilesVersion(ctx)
+	// Retrieve the published version of the "krenalis_profiles" table.
+	publishedProfilesVersion, err := warehouse.publishedProfilesVersion(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Determine the alter schema queries.
-	queries := alterProfileSchemaQueries("krenalis_profiles_"+strconv.Itoa(profilesVersion), columns, operations)
+	queries := alterProfileSchemaQueries("krenalis_profiles_"+strconv.Itoa(publishedProfilesVersion), columns, operations)
 
 	// Execute the alter schema queries within a transaction.
 	err = warehouse.execTransaction(ctx, func(tx pgx.Tx) error {
@@ -86,11 +86,11 @@ func (warehouse *PostgreSQL) alterProfileSchema(ctx context.Context, columns []w
 // operation by returning the queries that would be executed on the warehouse to
 // perform a given alter schema.
 func (warehouse *PostgreSQL) PreviewAlterProfileSchema(ctx context.Context, columns []warehouses.Column, operations []warehouses.AlterOperation) ([]string, error) {
-	profilesVersion, err := warehouse.profilesVersion(ctx)
+	publishedProfilesVersion, err := warehouse.publishedProfilesVersion(ctx)
 	if err != nil {
 		return nil, err
 	}
-	queries := alterProfileSchemaQueries("krenalis_profiles_"+strconv.Itoa(profilesVersion), columns, operations)
+	queries := alterProfileSchemaQueries("krenalis_profiles_"+strconv.Itoa(publishedProfilesVersion), columns, operations)
 	queries = append([]string{"BEGIN"}, queries...)
 	queries = append(queries, "COMMIT")
 	for i, q := range queries {

--- a/warehouses/postgresql/identityresolution.go
+++ b/warehouses/postgresql/identityresolution.go
@@ -46,9 +46,9 @@ func (warehouse *PostgreSQL) ResolveIdentities(ctx context.Context, opID string,
 		err = warehouse.finalizeIdentityResolution(ctx, pool, opID, err)
 	}()
 
-	// Determine the current version of the "krenalis_profiles" table and create a copy
-	// of it with the incremented version.
-	profilesVersion, err := warehouse.profilesVersion(ctx)
+	// Determine the greatest recorded version of the "krenalis_profiles" table
+	// and allocate the next version.
+	maxProfilesVersion, err := warehouse.maxProfilesVersion(ctx)
 	if err != nil {
 		return err
 	}
@@ -56,14 +56,14 @@ func (warehouse *PostgreSQL) ResolveIdentities(ctx context.Context, opID string,
 	if err != nil {
 		return err
 	}
-	newProfilesVersion := profilesVersion + 1
+	newProfilesVersion := maxProfilesVersion + 1
 	newProfilesName := fmt.Sprintf("krenalis_profiles_%d", newProfilesVersion)
 
 	// Prepare a candidate profiles version without exposing partial Identity
 	// Resolution results.
 	err = warehouse.execTransaction(ctx, func(tx pgx.Tx) error {
 		removePreviousProfilesTable := false
-		if profilesVersion != publishedProfilesVersion {
+		if maxProfilesVersion != publishedProfilesVersion {
 			// The latest unpublished profiles version may belong to an operation
 			// that is still running. Replace it only if that operation failed.
 			err = tx.QueryRow(ctx, `SELECT EXISTS (
@@ -73,17 +73,18 @@ func (warehouse *PostgreSQL) ResolveIdentities(ctx context.Context, opID string,
 				WHERE "v"."version" = $1
 					AND "o"."completed_at" IS NOT NULL
 					AND "o"."error" <> ''
-			)`, profilesVersion).Scan(&removePreviousProfilesTable)
+			)`, maxProfilesVersion).Scan(&removePreviousProfilesTable)
 			if err != nil {
 				return err
 			}
 			if !removePreviousProfilesTable {
 				return fmt.Errorf(
-					"profiles version %d is unpublished but does not belong to a failed operation", profilesVersion)
+					"profiles version %d is unpublished but does not belong to a failed operation", maxProfilesVersion)
 			}
 		}
-		// Create the candidate table by copying the schema from the current profiles table.
-		_, err := tx.Exec(ctx, fmt.Sprintf(`CREATE TABLE %s (LIKE "krenalis_profiles_%d")`, quoteIdent(newProfilesName), profilesVersion))
+		// Create the candidate table by copying the schema from the published profiles table.
+		_, err := tx.Exec(ctx, fmt.Sprintf(`CREATE TABLE %s (LIKE "krenalis_profiles_%d")`,
+			quoteIdent(newProfilesName), publishedProfilesVersion))
 		if err != nil {
 			return fmt.Errorf("cannot create profiles table (with name %s): %s", quoteIdent(newProfilesName), err)
 		}
@@ -95,8 +96,8 @@ func (warehouse *PostgreSQL) ResolveIdentities(ctx context.Context, opID string,
 			return err
 		}
 		if removePreviousProfilesTable {
-			// Drop the failed candidate table after preserving its schema changes.
-			_, err = tx.Exec(ctx, `DROP TABLE IF EXISTS "krenalis_profiles_`+strconv.Itoa(profilesVersion)+`"`)
+			// Drop the failed candidate table.
+			_, err = tx.Exec(ctx, `DROP TABLE IF EXISTS "krenalis_profiles_`+strconv.Itoa(maxProfilesVersion)+`"`)
 			if err != nil {
 				return err
 			}

--- a/warehouses/postgresql/identityresolution.go
+++ b/warehouses/postgresql/identityresolution.go
@@ -24,37 +24,27 @@ import (
 var identityResolutionQueries string
 
 // ResolveIdentities resolves the identities.
-func (warehouse *PostgreSQL) ResolveIdentities(ctx context.Context, opID string, identifiers, profileColumns []warehouses.Column, profilePrimarySources map[string]string) error {
-	status, err := warehouse.executeOperation(ctx, opID, identityResolution)
-	if err != nil {
-		return err
-	}
-	if status.alreadyCompleted {
-		return status.executionError
-	}
-	err = warehouse.resolveIdentities(ctx, opID, identifiers, profileColumns, profilePrimarySources)
-	bo := backoff.New(200)
-	bo.SetCap(time.Second)
-	for bo.Next(ctx) {
-		err2 := warehouse.setOperationAsCompleted(ctx, opID, err)
-		if err2 != nil {
-			slog.Error("cannot set identity resolution operation as completed, retrying", "err", err2, "operationError", err)
-			continue
-		}
-		if err != nil {
-			return warehouses.NewOperationError(err)
-		}
-		return nil
-	}
-	return ctx.Err()
-}
-
-func (warehouse *PostgreSQL) resolveIdentities(ctx context.Context, opID string, identifiers, profileColumns []warehouses.Column, primarySources map[string]string) error {
+func (warehouse *PostgreSQL) ResolveIdentities(ctx context.Context, opID string, identifiers, profileColumns []warehouses.Column, primarySources map[string]string) (err error) {
 
 	pool, _, err := warehouse.connectionPool(ctx, false)
 	if err != nil {
 		return err
 	}
+
+	status, err := warehouse.executeOperation(ctx, opID, identityResolution)
+	if err != nil {
+		return err
+	}
+	if status.alreadyCompleted {
+		if status.executionError != nil {
+			return status.executionError
+		}
+		return nil
+	}
+
+	defer func() {
+		err = warehouse.finalizeIdentityResolution(ctx, pool, opID, err)
+	}()
 
 	// Determine the current version of the "krenalis_profiles" table and create a copy
 	// of it with the incremented version.
@@ -62,20 +52,54 @@ func (warehouse *PostgreSQL) resolveIdentities(ctx context.Context, opID string,
 	if err != nil {
 		return err
 	}
+	publishedProfilesVersion, err := warehouse.publishedProfilesVersion(ctx)
+	if err != nil {
+		return err
+	}
 	newProfilesVersion := profilesVersion + 1
 	newProfilesName := fmt.Sprintf("krenalis_profiles_%d", newProfilesVersion)
 
-	// Create a copy of the current profiles table and set its new version in
-	// 'krenalis_profile_schema_versions'.
+	// Prepare a candidate profiles version without exposing partial Identity
+	// Resolution results.
 	err = warehouse.execTransaction(ctx, func(tx pgx.Tx) error {
+		removePreviousProfilesTable := false
+		if profilesVersion != publishedProfilesVersion {
+			// The latest unpublished profiles version may belong to an operation
+			// that is still running. Replace it only if that operation failed.
+			err = tx.QueryRow(ctx, `SELECT EXISTS (
+				SELECT 1
+				FROM "krenalis_profile_schema_versions" "v"
+				JOIN "krenalis_system_operations" "o" ON "o"."id" = "v"."operation"
+				WHERE "v"."version" = $1
+					AND "o"."completed_at" IS NOT NULL
+					AND "o"."error" <> ''
+			)`, profilesVersion).Scan(&removePreviousProfilesTable)
+			if err != nil {
+				return err
+			}
+			if !removePreviousProfilesTable {
+				return fmt.Errorf(
+					"profiles version %d is unpublished but does not belong to a failed operation", profilesVersion)
+			}
+		}
+		// Create the candidate table by copying the schema from the current profiles table.
 		_, err := tx.Exec(ctx, fmt.Sprintf(`CREATE TABLE %s (LIKE "krenalis_profiles_%d")`, quoteIdent(newProfilesName), profilesVersion))
 		if err != nil {
 			return fmt.Errorf("cannot create profiles table (with name %s): %s", quoteIdent(newProfilesName), err)
 		}
+		// Link the candidate version to this operation so it can be published on
+		// success or removed on failure.
 		_, err = tx.Exec(ctx, `INSERT INTO "krenalis_profile_schema_versions" ("version", "operation", "timestamp")`+
 			` VALUES ($1, $2, $3)`, newProfilesVersion, opID, time.Now().UTC())
 		if err != nil {
 			return err
+		}
+		if removePreviousProfilesTable {
+			// Drop the failed candidate table after preserving its schema changes.
+			_, err = tx.Exec(ctx, `DROP TABLE IF EXISTS "krenalis_profiles_`+strconv.Itoa(profilesVersion)+`"`)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -208,20 +232,62 @@ func (warehouse *PostgreSQL) resolveIdentities(ctx context.Context, opID string,
 		return err
 	}
 
-	// Replace the current "profiles" view with a new one using the "CREATE OR
-	// REPLACE VIEW" statement since the table "_profiles" that the view refers
-	// to has changed its name.
-	_, err = pool.Exec(ctx, createViewQuery(newProfilesName, profileColumns, true))
-	if err != nil {
-		return err
-	}
+	err = warehouse.execTransaction(ctx, func(tx pgx.Tx) error {
 
-	// Drop the 'profiles' table that existed before executing this Identity
-	// Resolution.
-	_, err = pool.Exec(ctx, `DROP TABLE IF EXISTS "krenalis_profiles_`+strconv.Itoa(profilesVersion)+`"`)
+		// Replace the current "profiles" view with a new one using the "CREATE OR REPLACE VIEW"
+		// statement since the table "_profiles" that the view refers to has changed its name.
+		_, err = tx.Exec(ctx, createViewQuery(newProfilesName, profileColumns, true))
+		if err != nil {
+			return err
+		}
+
+		// Drop the "profiles" table that existed before executing this Identity Resolution.
+		_, err = tx.Exec(ctx, `DROP TABLE IF EXISTS "krenalis_profiles_`+strconv.Itoa(publishedProfilesVersion)+`"`)
+		if err != nil {
+			return err
+		}
+
+		return warehouse.setOperationAsCompleted(ctx, tx, opID, nil)
+	})
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// finalizeIdentityResolution returns nil on local success. On failure, it
+// attempts to mark the operation as failed and returns its persisted outcome.
+func (warehouse *PostgreSQL) finalizeIdentityResolution(ctx context.Context, conn connection, opID string, operationErr error) error {
+
+	if operationErr == nil {
+		return nil
+	}
+	operationError := warehouses.NewOperationError(operationErr)
+
+	bo := backoff.New(200)
+	bo.SetCap(30 * time.Second)
+	for bo.Next(ctx) {
+		if err := warehouse.setOperationAsCompleted(ctx, conn, opID, operationError); err != nil {
+			slog.Error("cannot mark identity resolution operation as failed, retrying",
+				"err", warehouses.NewOperationError(err), "operationError", operationError)
+			continue
+		}
+		status, err := warehouse.readOperationStatus(ctx, conn, opID)
+		if err != nil {
+			return err
+		}
+		if status == nil {
+			return fmt.Errorf("identity resolution operation %s not found", opID)
+		}
+		if !status.alreadyCompleted {
+			return fmt.Errorf("identity resolution operation %s is not completed", opID)
+		}
+		if status.executionError != nil {
+			return status.executionError
+		}
+		return nil
+	}
+
+	return ctx.Err()
 }

--- a/warehouses/postgresql/identityresolution_test.go
+++ b/warehouses/postgresql/identityresolution_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+package postgresql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/krenalis/krenalis/tools/errors"
+	"github.com/krenalis/krenalis/tools/types"
+	"github.com/krenalis/krenalis/warehouses"
+)
+
+// Test_finalizeIdentityResolutionPreservesPersistedSuccess verifies that a
+// persisted successful operation takes precedence over a conflicting local
+// error.
+func Test_finalizeIdentityResolutionPreservesPersistedSuccess(t *testing.T) {
+
+	warehouse, pool := newTestPostgreSQLWarehouse(t)
+	if _, err := pool.Exec(t.Context(), createSystemOperationsTable); err != nil {
+		t.Fatal(err)
+	}
+
+	const opID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d0"
+	_, err := pool.Exec(t.Context(), `INSERT INTO "krenalis_system_operations"
+		("id", "operation_type", "completed_at") VALUES ($1, $2, $3)`, opID, identityResolution, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localErr := errors.New("commit response unavailable")
+	err = warehouse.finalizeIdentityResolution(t.Context(), pool, opID, localErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var operationError string
+	if err := pool.QueryRow(t.Context(), `SELECT "error" FROM "krenalis_system_operations" WHERE "id" = $1`, opID).
+		Scan(&operationError); err != nil {
+		t.Fatal(err)
+	}
+	if operationError != "" {
+		t.Fatalf("expected successful operation to remain successful, got error %q", operationError)
+	}
+
+}
+
+// TestResolveIdentitiesRemovesObsoleteProfileTables verifies that a successful
+// operation after a failure removes obsolete profile tables and retains only
+// the published table.
+func TestResolveIdentitiesRemovesObsoleteProfileTables(t *testing.T) {
+
+	warehouse, pool := newTestPostgreSQLWarehouse(t)
+	profileColumns := []warehouses.Column{{Name: "email", Type: types.String(), Nullable: true}}
+	if err := warehouse.Initialize(t.Context(), profileColumns); err != nil {
+		t.Fatal(err)
+	}
+
+	badProfileColumns := append([]warehouses.Column{}, profileColumns...)
+	badProfileColumns = append(badProfileColumns, warehouses.Column{
+		Name:     "column_not_in_profiles_table",
+		Type:     types.String(),
+		Nullable: true,
+	})
+	const failedOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d1"
+	err := warehouse.ResolveIdentities(t.Context(), failedOpID, profileColumns, badProfileColumns, nil)
+	isOperationError := false
+	if err != nil {
+		_, isOperationError = errors.AsType[*warehouses.OperationError](err)
+	}
+	if !isOperationError {
+		t.Fatalf("expected failed operation to return *warehouses.OperationError, got %v", err)
+	}
+
+	const successfulOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d2"
+	err = warehouse.ResolveIdentities(t.Context(), successfulOpID, profileColumns, profileColumns, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tables := []struct {
+		name        string
+		shouldExist bool
+	}{
+		{name: "krenalis_profiles_0", shouldExist: false},
+		{name: "krenalis_profiles_1", shouldExist: false},
+		{name: "krenalis_profiles_2", shouldExist: true},
+	}
+	for _, table := range tables {
+		var exists bool
+		if err := pool.QueryRow(t.Context(), `SELECT to_regclass($1) IS NOT NULL`, table.name).Scan(&exists); err != nil {
+			t.Fatal(err)
+		}
+		if exists != table.shouldExist {
+			t.Fatalf("expected table %q existence to be %t, got %t", table.name, table.shouldExist, exists)
+		}
+	}
+
+}
+
+// TestResolveIdentitiesRetainsProfileTableFromRunningOperation verifies that
+// a second operation fails without removing the unpublished profiles table of
+// an operation still in progress.
+func TestResolveIdentitiesRetainsProfileTableFromRunningOperation(t *testing.T) {
+
+	warehouse, pool := newTestPostgreSQLWarehouse(t)
+	profileColumns := []warehouses.Column{{Name: "email", Type: types.String(), Nullable: true}}
+	if err := warehouse.Initialize(t.Context(), profileColumns); err != nil {
+		t.Fatal(err)
+	}
+
+	const runningOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d3"
+	_, err := pool.Exec(t.Context(), `INSERT INTO "krenalis_system_operations" ("id", "operation_type") VALUES ($1, $2)`,
+		runningOpID, identityResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(t.Context(), `CREATE TABLE "krenalis_profiles_1" (LIKE "krenalis_profiles_0")`); err != nil {
+		t.Fatal(err)
+	}
+	_, err = pool.Exec(t.Context(), `INSERT INTO "krenalis_profile_schema_versions" ("version", "operation", "timestamp")`+
+		` VALUES ($1, $2, $3)`, 1, runningOpID, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const conflictingOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d4"
+	err = warehouse.ResolveIdentities(t.Context(), conflictingOpID, profileColumns, profileColumns, nil)
+	isOperationError := false
+	if err != nil {
+		_, isOperationError = errors.AsType[*warehouses.OperationError](err)
+	}
+	if !isOperationError {
+		t.Fatalf("expected conflicting operation to return *warehouses.OperationError, got %v", err)
+	}
+
+	tables := []struct {
+		name        string
+		shouldExist bool
+	}{
+		{name: "krenalis_profiles_1", shouldExist: true},
+		{name: "krenalis_profiles_2", shouldExist: false},
+	}
+	for _, table := range tables {
+		var exists bool
+		if err := pool.QueryRow(t.Context(), `SELECT to_regclass($1) IS NOT NULL`, table.name).Scan(&exists); err != nil {
+			t.Fatal(err)
+		}
+		if exists != table.shouldExist {
+			t.Fatalf("expected table %q existence to be %t, got %t", table.name, table.shouldExist, exists)
+		}
+	}
+
+}

--- a/warehouses/postgresql/identityresolution_test.go
+++ b/warehouses/postgresql/identityresolution_test.go
@@ -5,6 +5,7 @@
 package postgresql
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +43,160 @@ func Test_finalizeIdentityResolutionPreservesPersistedSuccess(t *testing.T) {
 	}
 	if operationError != "" {
 		t.Fatalf("expected successful operation to remain successful, got error %q", operationError)
+	}
+
+}
+
+// TestAlterProfileSchemaUsesPublishedProfilesAfterIdentityResolutionFailure
+// verifies that after a failed Identity Resolution, altering the profile schema
+// keeps the last published profiles visible and updates the published profiles
+// table.
+func TestAlterProfileSchemaUsesPublishedProfilesAfterIdentityResolutionFailure(t *testing.T) {
+
+	warehouse, pool := newTestPostgreSQLWarehouse(t)
+	profileColumns := []warehouses.Column{{Name: "email", Type: types.String(), Nullable: true}}
+	identifiers := profileColumns
+	err := warehouse.Initialize(t.Context(), profileColumns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = pool.Exec(t.Context(), `INSERT INTO "krenalis_profiles_0"
+		("_kpid", "_identities", "_updated_at", "email") VALUES ($1, ARRAY[1], $2, $3)`,
+		"a44731d8-d89d-44b9-ac87-a8ce1a8770d7", time.Now().UTC(), "person@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	badProfileColumns := append([]warehouses.Column{}, profileColumns...)
+	badProfileColumns = append(badProfileColumns, warehouses.Column{
+		Name:     "column_not_in_profiles_table",
+		Type:     types.String(),
+		Nullable: true,
+	})
+	const failedOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d8"
+	err = warehouse.ResolveIdentities(t.Context(), failedOpID, identifiers, badProfileColumns, nil)
+	if err != nil {
+		_, ok := errors.AsType[*warehouses.OperationError](err)
+		if !ok {
+			t.Fatalf("expected failed operation to return *warehouses.OperationError, got %T: %v", err, err)
+		}
+	}
+	if err == nil {
+		t.Fatal("expected Identity Resolution to fail")
+	}
+
+	var email string
+	err = pool.QueryRow(t.Context(), `SELECT "email" FROM "profiles" WHERE "_kpid" = $1`,
+		"a44731d8-d89d-44b9-ac87-a8ce1a8770d7").Scan(&email)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if email != "person@example.com" {
+		t.Errorf("expected the published profile to remain visible after failed Identity Resolution, got email %q", email)
+	}
+
+	var failedProfilesTableExists bool
+	err = pool.QueryRow(t.Context(), `SELECT EXISTS (
+		SELECT 1 FROM information_schema.tables
+		WHERE table_schema = current_schema()
+			AND table_name = 'krenalis_profiles_1'
+	)`).Scan(&failedProfilesTableExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !failedProfilesTableExists {
+		t.Fatal("expected the failed profiles table to exist")
+	}
+
+	newProfileColumns := append([]warehouses.Column{}, profileColumns...)
+	newProfileColumns = append(newProfileColumns, warehouses.Column{Name: "phone", Type: types.String(), Nullable: true})
+	alterOperations := []warehouses.AlterOperation{{
+		Operation: warehouses.OperationAddColumn,
+		Column:    "phone",
+		Type:      types.String(),
+	}}
+	preview, err := warehouse.PreviewAlterProfileSchema(t.Context(), newProfileColumns, alterOperations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previewSQL := strings.Join(preview, "\n")
+	if !strings.Contains(previewSQL, `ALTER TABLE "krenalis_profiles_0"`) {
+		t.Errorf("expected preview to alter the published profiles table, got:\n%s", previewSQL)
+	}
+	if strings.Contains(previewSQL, `ALTER TABLE "krenalis_profiles_1"`) {
+		t.Errorf("expected preview not to alter the failed profiles table, got:\n%s", previewSQL)
+	}
+
+	const alterOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d9"
+	err = warehouse.AlterProfileSchema(t.Context(), alterOpID, newProfileColumns, alterOperations)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = pool.QueryRow(t.Context(), `SELECT "email" FROM "profiles" WHERE "_kpid" = $1`,
+		"a44731d8-d89d-44b9-ac87-a8ce1a8770d7").Scan(&email)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if email != "person@example.com" {
+		t.Errorf("expected the published profile to remain visible, got email %q", email)
+	}
+
+	var columnExists bool
+	err = pool.QueryRow(t.Context(), `SELECT EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_schema = current_schema()
+			AND table_name = 'krenalis_profiles_0'
+			AND column_name = 'phone'
+	)`).Scan(&columnExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !columnExists {
+		t.Error("expected the published profiles table to contain the new column")
+	}
+	err = pool.QueryRow(t.Context(), `SELECT EXISTS (
+		SELECT 1 FROM information_schema.tables
+		WHERE table_schema = current_schema()
+			AND table_name = 'krenalis_profiles_1'
+	)`).Scan(&failedProfilesTableExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !failedProfilesTableExists {
+		t.Fatal("expected the failed profiles table to remain after schema alteration")
+	}
+	err = pool.QueryRow(t.Context(), `SELECT EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_schema = current_schema()
+			AND table_name = 'krenalis_profiles_1'
+			AND column_name = 'phone'
+	)`).Scan(&columnExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if columnExists {
+		t.Error("expected the failed profiles table not to contain the new column")
+	}
+
+	const successfulOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770da"
+	err = warehouse.ResolveIdentities(t.Context(), successfulOpID, identifiers, newProfileColumns, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = pool.QueryRow(t.Context(), `SELECT EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_schema = current_schema()
+			AND table_name = 'krenalis_profiles_2'
+			AND column_name = 'phone'
+	)`).Scan(&columnExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !columnExists {
+		t.Error("expected the next profiles table to copy the published schema")
 	}
 
 }

--- a/warehouses/postgresql/operations.go
+++ b/warehouses/postgresql/operations.go
@@ -6,12 +6,13 @@ package postgresql
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/krenalis/krenalis/tools/backoff"
+	"github.com/krenalis/krenalis/tools/errors"
 	"github.com/krenalis/krenalis/warehouses"
 )
 
@@ -25,91 +26,98 @@ const (
 type opStatus struct {
 	canBeStarted     bool
 	alreadyCompleted bool
-	// executionError is significant only if 'alreadyCompleted' is true.
-	// If executionError is not nil, it has type warehouses.OperationError.
-	executionError error
+	executionError   *warehouses.OperationError
+}
+
+// connection is implemented by PostgreSQL pools and transactions.
+type connection interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 // executeOperation starts an operation, identified by an ID.
 //
-// The returned status indicates whether the operation can be started, or
-// returns the status of a current executing or previous execution.
+// The returned status indicates whether the operation can be started or
+// describes an operation that has already completed.
 func (warehouse *PostgreSQL) executeOperation(ctx context.Context, opID string, opType warehouseOp) (status *opStatus, err error) {
-	var completedAt *time.Time
-	var opError string
+
 	bo := backoff.New(200)
 	bo.SetCap(500 * time.Millisecond)
 	for bo.Next(ctx) {
-		err := warehouse.execTransaction(ctx, func(tx pgx.Tx) error {
+		err = warehouse.execTransaction(ctx, func(tx pgx.Tx) error {
 			_, err = tx.Exec(ctx, `LOCK "krenalis_system_operations"`)
 			if err != nil {
 				return err
 			}
-			var readID *string
-			rows, err := tx.Query(ctx, `SELECT "id", "completed_at", "error" FROM "krenalis_system_operations" WHERE "id" = $1`, opID)
+			status, err = warehouse.readOperationStatus(ctx, tx, opID)
 			if err != nil {
 				return err
 			}
-			defer rows.Close()
-			for rows.Next() {
-				err := rows.Scan(&readID, &completedAt, &opError)
-				if err != nil {
-					return err
-				}
-			}
-			if err := rows.Err(); err != nil {
-				return err
-			}
-			if readID == nil {
-				// No rows in DB, so the operation can be started.
-				_, err = tx.Exec(ctx, `INSERT INTO "krenalis_system_operations" ("id", "operation_type") VALUES ($1, $2)`, opID, opType)
-				if err != nil {
-					return err
-				}
-				status = &opStatus{canBeStarted: true}
+			if status != nil {
 				return nil
 			}
+			// No existing operation was found, so this one can be started.
+			_, err = tx.Exec(ctx,
+				`INSERT INTO "krenalis_system_operations" ("id", "operation_type") VALUES ($1, $2)`,
+				opID, opType)
+			if err != nil {
+				return err
+			}
+			status = &opStatus{canBeStarted: true}
 			return nil
 		})
 		if err != nil {
 			return nil, err
 		}
-		if status != nil {
+		if status.canBeStarted || status.alreadyCompleted {
 			return status, nil
 		}
-		// Operation is still running, so wait 500ms then try again to check if
-		// it has completed.
-		if completedAt == nil {
-			continue
-		}
-		// Operation is completed with an error.
-		if opError != "" {
-			return &opStatus{alreadyCompleted: true, executionError: warehouses.NewOperationError(errors.New(opError))}, nil
-		}
-		// Operations is completed without errors.
-		return &opStatus{alreadyCompleted: true}, nil
+		// The operation is still running, so wait before checking again.
 	}
+
 	return nil, ctx.Err()
 }
 
-// setOperationAsCompleted sets the given operation as completed. opError is the
-// possible error in the execution of the operation, which will be stored in the
-// database; nil means operation ended successfully.
-// If an operation has already been set as completed, this method does
-// nothing.
-func (warehouse *PostgreSQL) setOperationAsCompleted(ctx context.Context, opID string, opError error) error {
-	pool, _, err := warehouse.connectionPool(ctx, false)
+// readOperationStatus reads the persisted status of an operation. It returns
+// nil when the operation does not exist.
+func (warehouse *PostgreSQL) readOperationStatus(ctx context.Context, conn connection, opID string) (*opStatus, error) {
+
+	var completedAt *time.Time
+	var opError string
+	err := conn.QueryRow(ctx, `SELECT "completed_at", LEFT("error", $2)`+
+		` FROM "krenalis_system_operations" WHERE "id" = $1 LIMIT 1`,
+		opID, warehouses.MaxOperationErrorBytes+1).
+		Scan(&completedAt, &opError)
 	if err != nil {
-		return err
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
 	}
+	status := &opStatus{}
+	if completedAt == nil {
+		return status, nil
+	}
+	status.alreadyCompleted = true
+	if opError != "" {
+		status.executionError = warehouses.NewPersistedOperationError(opError)
+	}
+
+	return status, nil
+}
+
+// setOperationAsCompleted sets the given operation as completed. opError is the
+// error returned by the operation; nil indicates that it completed
+// successfully. If the operation has already been set as completed, this
+// method does nothing.
+func (warehouse *PostgreSQL) setOperationAsCompleted(ctx context.Context, conn connection, opID string, opError *warehouses.OperationError) error {
+
 	var opErrorStr string
 	if opError != nil {
 		opErrorStr = opError.Error()
 	}
-	_, err = pool.Exec(ctx, `UPDATE "krenalis_system_operations" SET "completed_at" = $1, "error" = $2`+
+	_, err := conn.Exec(ctx, `UPDATE "krenalis_system_operations" SET "completed_at" = $1, "error" = $2`+
 		` WHERE "id" = $3 AND "completed_at" IS NULL`, time.Now().UTC(), opErrorStr, opID)
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return err
 }

--- a/warehouses/postgresql/tables/profile_schema_versions.sql
+++ b/warehouses/postgresql/tables/profile_schema_versions.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS krenalis_profile_schema_versions (
     version integer NOT NULL,
-    operation uuid NOT NULL,          -- useful for logging purposes.
-    timestamp timestamp(3) NOT NULL,  -- useful for logging purposes.
+    operation uuid NOT NULL,          -- operation that created this version of the profile schema.
+    timestamp timestamp(3) NOT NULL,  -- timestamp when this version was created.
     PRIMARY KEY ("version")
 );

--- a/warehouses/postgresql/warehouse.go
+++ b/warehouses/postgresql/warehouse.go
@@ -80,8 +80,8 @@ func (warehouse *PostgreSQL) CheckReadOnlyAccess(ctx context.Context) error {
 	// the 'has_table_privilege' function).
 	const disallowedPrivileges = `INSERT,UPDATE,DELETE,TRUNCATE`
 
-	// Retrieve the profiles table version.
-	profileSchemaVersion, err := warehouse.profilesVersion(ctx)
+	// Retrieve the greatest recorded profiles table version.
+	profileSchemaVersion, err := warehouse.maxProfilesVersion(ctx)
 	if err != nil {
 		return err
 	}
@@ -425,8 +425,9 @@ func (warehouse *PostgreSQL) execTransaction(ctx context.Context, f func(pgx.Tx)
 	return nil
 }
 
-// profilesVersion returns the version of the "krenalis_profiles" table.
-func (warehouse *PostgreSQL) profilesVersion(ctx context.Context) (int, error) {
+// maxProfilesVersion returns the greatest recorded version of the
+// "krenalis_profiles" table.
+func (warehouse *PostgreSQL) maxProfilesVersion(ctx context.Context) (int, error) {
 	pool, _, err := warehouse.connectionPool(ctx, false)
 	if err != nil {
 		return 0, err

--- a/warehouses/postgresql/warehouse.go
+++ b/warehouses/postgresql/warehouse.go
@@ -439,6 +439,27 @@ func (warehouse *PostgreSQL) profilesVersion(ctx context.Context) (int, error) {
 	return v, nil
 }
 
+// publishedProfilesVersion returns the version of the currently published
+// profiles table.
+func (warehouse *PostgreSQL) publishedProfilesVersion(ctx context.Context) (int, error) {
+	pool, _, err := warehouse.connectionPool(ctx, false)
+	if err != nil {
+		return 0, err
+	}
+	var version int
+	err = pool.QueryRow(ctx, `SELECT COALESCE(MAX("v"."version"), 0)
+		FROM "krenalis_profile_schema_versions" "v"
+		JOIN "krenalis_system_operations" "o" ON "o"."id" = "v"."operation"
+		WHERE "o"."completed_at" IS NOT NULL AND "o"."error" = ''`).Scan(&version)
+	if err != nil {
+		return 0, err
+	}
+	if version < 0 {
+		return 0, fmt.Errorf("warehouse returned a negative published profile schema version")
+	}
+	return version, nil
+}
+
 // validateSettings validates the settings.
 // It returns a *warehouses.SettingsError if the settings are not valid.
 func validateSettings(s *pgSettings) error {

--- a/warehouses/snowflake/alter_schema.go
+++ b/warehouses/snowflake/alter_schema.go
@@ -58,14 +58,14 @@ func (warehouse *Snowflake) AlterProfileSchema(ctx context.Context, opID string,
 
 func (warehouse *Snowflake) alterProfileSchema(ctx context.Context, columns []warehouses.Column, operations []warehouses.AlterOperation) error {
 
-	// Retrieve the current version of the "krenalis_profiles" table.
-	profilesVersion, err := warehouse.profilesVersion(ctx)
+	// Retrieve the published version of the "krenalis_profiles" table.
+	publishedProfilesVersion, err := warehouse.publishedProfilesVersion(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Determine the alter schema queries.
-	queries := alterProfileSchemaQueries("KRENALIS_PROFILES_"+strconv.Itoa(profilesVersion), columns, operations)
+	queries := alterProfileSchemaQueries("KRENALIS_PROFILES_"+strconv.Itoa(publishedProfilesVersion), columns, operations)
 
 	// Execute the alter schema queries within a transaction.
 	err = warehouse.execTransaction(ctx, func(tx *sql.Tx) error {
@@ -85,11 +85,11 @@ func (warehouse *Snowflake) alterProfileSchema(ctx context.Context, columns []wa
 // operation by returning the queries that would be executed on the warehouse to
 // perform a given alter schema.
 func (warehouse *Snowflake) PreviewAlterProfileSchema(ctx context.Context, columns []warehouses.Column, operations []warehouses.AlterOperation) ([]string, error) {
-	profilesVersion, err := warehouse.profilesVersion(ctx)
+	publishedProfilesVersion, err := warehouse.publishedProfilesVersion(ctx)
 	if err != nil {
 		return nil, err
 	}
-	queries := alterProfileSchemaQueries("KRENALIS_PROFILES_"+strconv.Itoa(profilesVersion), columns, operations)
+	queries := alterProfileSchemaQueries("KRENALIS_PROFILES_"+strconv.Itoa(publishedProfilesVersion), columns, operations)
 	queries = append([]string{"BEGIN"}, queries...)
 	queries = append(queries, "COMMIT")
 	for i, q := range queries {

--- a/warehouses/snowflake/alter_schema.go
+++ b/warehouses/snowflake/alter_schema.go
@@ -20,24 +20,36 @@ import (
 
 // AlterProfileSchema alters the profile schema.
 func (warehouse *Snowflake) AlterProfileSchema(ctx context.Context, opID string, columns []warehouses.Column, operations []warehouses.AlterOperation) error {
+	db, err := warehouse.openDB(ctx)
+	if err != nil {
+		return snowflake(err)
+	}
 	status, err := warehouse.executeOperation(ctx, opID, alterProfileSchema)
 	if err != nil {
 		return err
 	}
 	if status.alreadyCompleted {
-		return status.executionError
+		if status.executionError != nil {
+			return status.executionError
+		}
+		return nil
 	}
+	var operationErr *warehouses.OperationError
 	err = warehouse.alterProfileSchema(ctx, columns, operations)
+	if err != nil {
+		operationErr = warehouses.NewOperationError(err)
+	}
 	bo := backoff.New(200)
 	bo.SetCap(time.Second)
 	for bo.Next(ctx) {
-		err2 := warehouse.setOperationAsCompleted(ctx, opID, err)
+		err2 := warehouse.setOperationAsCompleted(ctx, db, opID, operationErr)
 		if err2 != nil {
-			slog.Error("cannot set alter profile columns operation as completed, retrying", "err", err2, "operationError", err)
+			slog.Error("cannot set alter profile columns operation as completed, retrying",
+				"err", warehouses.NewOperationError(err2), "operationError", operationErr)
 			continue
 		}
-		if err != nil {
-			return warehouses.NewOperationError(err)
+		if operationErr != nil {
+			return operationErr
 		}
 		return nil
 	}

--- a/warehouses/snowflake/identityresolution.go
+++ b/warehouses/snowflake/identityresolution.go
@@ -46,9 +46,9 @@ func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, 
 		err = warehouse.finalizeIdentityResolution(ctx, db, opID, err)
 	}()
 
-	// Determine the current version of the "krenalis_profiles" table and create
-	// a copy of it with the incremented version.
-	profilesVersion, err := warehouse.profilesVersion(ctx)
+	// Determine the greatest recorded version of the "KRENALIS_PROFILES" table
+	// and allocate the next version.
+	maxProfilesVersion, err := warehouse.maxProfilesVersion(ctx)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, 
 	if err != nil {
 		return err
 	}
-	newProfilesVersion := profilesVersion + 1
+	newProfilesVersion := maxProfilesVersion + 1
 	newProfilesName := fmt.Sprintf("KRENALIS_PROFILES_%d", newProfilesVersion)
 	currentProfilesName := fmt.Sprintf("KRENALIS_PROFILES_%d", publishedProfilesVersion)
 
@@ -64,7 +64,7 @@ func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, 
 	// Resolution results.
 	removePreviousProfilesTable := false
 	err = warehouse.execTransaction(ctx, func(tx *sql.Tx) error {
-		if profilesVersion != publishedProfilesVersion {
+		if maxProfilesVersion != publishedProfilesVersion {
 			// The latest unpublished profiles version may belong to an operation
 			// that is still running. Replace it only if that operation failed.
 			err = tx.QueryRowContext(ctx, `SELECT EXISTS (
@@ -74,18 +74,19 @@ func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, 
 				WHERE "V"."VERSION" = ?
 					AND "O"."COMPLETED_AT" IS NOT NULL
 					AND "O"."ERROR" <> ''
-			)`, profilesVersion).Scan(&removePreviousProfilesTable)
+			)`, maxProfilesVersion).Scan(&removePreviousProfilesTable)
 			if err != nil {
 				return snowflake(err)
 			}
 			if !removePreviousProfilesTable {
 				return fmt.Errorf(
-					"profiles version %d is unpublished but does not belong to a failed operation", profilesVersion)
+					"profiles version %d is unpublished but does not belong to a failed operation", maxProfilesVersion)
 			}
 		}
-		// Create the candidate table by copying the schema from the current profiles table.
+		// Create the candidate table by copying the schema from the published profiles table.
 		_, err = tx.ExecContext(ctx,
-			fmt.Sprintf(`CREATE TABLE %s LIKE "KRENALIS_PROFILES_%d"`, quoteIdent(newProfilesName), profilesVersion))
+			fmt.Sprintf(`CREATE TABLE %s LIKE "KRENALIS_PROFILES_%d"`,
+				quoteIdent(newProfilesName), publishedProfilesVersion))
 		if err != nil {
 			return fmt.Errorf("cannot create profiles table (with name %s): %s", quoteIdent(newProfilesName), err)
 		}
@@ -110,8 +111,8 @@ func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, 
 		return snowflake(err)
 	}
 	if removePreviousProfilesTable {
-		// Drop the failed candidate table after preserving its schema changes.
-		_, err = db.ExecContext(ctx, `DROP TABLE IF EXISTS "KRENALIS_PROFILES_`+strconv.Itoa(profilesVersion)+`"`)
+		// Drop the failed candidate table.
+		_, err = db.ExecContext(ctx, `DROP TABLE IF EXISTS "KRENALIS_PROFILES_`+strconv.Itoa(maxProfilesVersion)+`"`)
 		if err != nil {
 			return snowflake(err)
 		}

--- a/warehouses/snowflake/identityresolution.go
+++ b/warehouses/snowflake/identityresolution.go
@@ -25,32 +25,26 @@ import (
 var identityResolutionQueries string
 
 // ResolveIdentities resolves the identities.
-func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, identifiers, profileColumns []warehouses.Column, primarySources map[string]string) error {
+func (warehouse *Snowflake) ResolveIdentities(ctx context.Context, opID string, identifiers, profileColumns []warehouses.Column, primarySources map[string]string) (err error) {
+
+	db, err := warehouse.openDB(ctx)
+	if err != nil {
+		return snowflake(err)
+	}
 	status, err := warehouse.executeOperation(ctx, opID, identityResolution)
 	if err != nil {
 		return err
 	}
 	if status.alreadyCompleted {
-		return status.executionError
-	}
-	err = warehouse.resolveIdentities(ctx, opID, identifiers, profileColumns, primarySources)
-	bo := backoff.New(200)
-	bo.SetCap(time.Second)
-	for bo.Next(ctx) {
-		err2 := warehouse.setOperationAsCompleted(ctx, opID, err)
-		if err2 != nil {
-			slog.Error("cannot set identity resolution operation as completed, retrying", "err", err2, "operationError", err)
-			continue
-		}
-		if err != nil {
-			return warehouses.NewOperationError(err)
+		if status.executionError != nil {
+			return status.executionError
 		}
 		return nil
 	}
-	return ctx.Err()
-}
 
-func (warehouse *Snowflake) resolveIdentities(ctx context.Context, opID string, identifiers, profileColumns []warehouses.Column, profilePrimarySources map[string]string) error {
+	defer func() {
+		err = warehouse.finalizeIdentityResolution(ctx, db, opID, err)
+	}()
 
 	// Determine the current version of the "krenalis_profiles" table and create
 	// a copy of it with the incremented version.
@@ -58,18 +52,46 @@ func (warehouse *Snowflake) resolveIdentities(ctx context.Context, opID string, 
 	if err != nil {
 		return err
 	}
+	publishedProfilesVersion, err := warehouse.publishedProfilesVersion(ctx)
+	if err != nil {
+		return err
+	}
 	newProfilesVersion := profilesVersion + 1
 	newProfilesName := fmt.Sprintf("KRENALIS_PROFILES_%d", newProfilesVersion)
+	currentProfilesName := fmt.Sprintf("KRENALIS_PROFILES_%d", publishedProfilesVersion)
 
-	// Create a copy of the current profiles table and set its new version in
-	// 'KRENALIS_PROFILE_SCHEMA_VERSIONS'.
+	// Prepare a candidate profiles version without exposing partial Identity
+	// Resolution results.
+	removePreviousProfilesTable := false
 	err = warehouse.execTransaction(ctx, func(tx *sql.Tx) error {
-		likeTable := fmt.Sprintf(`KRENALIS_PROFILES_%d`, profilesVersion)
-		_, err = tx.Exec(fmt.Sprintf(`CREATE TABLE %s LIKE %s`, quoteIdent(newProfilesName), quoteIdent(likeTable)))
-		if err != nil {
-			return fmt.Errorf("cannot create profiles table (with name %s) like table %s: %s", quoteIdent(newProfilesName), quoteIdent(likeTable), err)
+		if profilesVersion != publishedProfilesVersion {
+			// The latest unpublished profiles version may belong to an operation
+			// that is still running. Replace it only if that operation failed.
+			err = tx.QueryRowContext(ctx, `SELECT EXISTS (
+				SELECT 1
+				FROM "KRENALIS_PROFILE_SCHEMA_VERSIONS" "V"
+				JOIN "KRENALIS_SYSTEM_OPERATIONS" "O" ON "O"."ID" = "V"."OPERATION"
+				WHERE "V"."VERSION" = ?
+					AND "O"."COMPLETED_AT" IS NOT NULL
+					AND "O"."ERROR" <> ''
+			)`, profilesVersion).Scan(&removePreviousProfilesTable)
+			if err != nil {
+				return snowflake(err)
+			}
+			if !removePreviousProfilesTable {
+				return fmt.Errorf(
+					"profiles version %d is unpublished but does not belong to a failed operation", profilesVersion)
+			}
 		}
-		_, err = tx.Exec(`INSERT INTO "KRENALIS_PROFILE_SCHEMA_VERSIONS" ("VERSION", "OPERATION", "TIMESTAMP")`+
+		// Create the candidate table by copying the schema from the current profiles table.
+		_, err = tx.ExecContext(ctx,
+			fmt.Sprintf(`CREATE TABLE %s LIKE "KRENALIS_PROFILES_%d"`, quoteIdent(newProfilesName), profilesVersion))
+		if err != nil {
+			return fmt.Errorf("cannot create profiles table (with name %s): %s", quoteIdent(newProfilesName), err)
+		}
+		// Link the candidate version to this operation so it can be published on
+		// success or removed on failure.
+		_, err = tx.ExecContext(ctx, `INSERT INTO "KRENALIS_PROFILE_SCHEMA_VERSIONS" ("VERSION", "OPERATION", "TIMESTAMP")`+
 			` VALUES (?, ?, ?)`, newProfilesVersion, opID, time.Now().UTC())
 		if err != nil {
 			return snowflake(err)
@@ -78,6 +100,21 @@ func (warehouse *Snowflake) resolveIdentities(ctx context.Context, opID string, 
 	})
 	if err != nil {
 		return err
+	}
+
+	// Snowflake commits each DDL statement independently. Stage the view before
+	// running Identity Resolution so it keeps returning the published profiles
+	// and no longer depends on a table left by a previous failed operation.
+	_, err = db.ExecContext(ctx, createPendingViewQuery(currentProfilesName, newProfilesName, opID, profileColumns))
+	if err != nil {
+		return snowflake(err)
+	}
+	if removePreviousProfilesTable {
+		// Drop the failed candidate table after preserving its schema changes.
+		_, err = db.ExecContext(ctx, `DROP TABLE IF EXISTS "KRENALIS_PROFILES_`+strconv.Itoa(profilesVersion)+`"`)
+		if err != nil {
+			return snowflake(err)
+		}
 	}
 
 	// Generate the SQL function that determines if two identities are the same
@@ -120,7 +157,7 @@ func (warehouse *Snowflake) resolveIdentities(ctx context.Context, opID string, 
 				`) = [] THEN NULL ELSE ARRAY_SORT(ARRAY_DISTINCT(ARRAY_FLATTEN(ARRAY_AGG(` + quoteIdent(c.Name) + `)))) END`)
 		} else {
 			mergeProfiles.WriteString(`(ARRAY_CAT(`)
-			if s, ok := profilePrimarySources[c.Name]; ok {
+			if s, ok := primarySources[c.Name]; ok {
 				// In the case of primary sources, list these values first,
 				// sorted by last change time, excluding those that are NULL.
 				mergeProfiles.WriteString(`ARRAY_AGG(CASE WHEN `)
@@ -189,10 +226,6 @@ func (warehouse *Snowflake) resolveIdentities(ctx context.Context, opID string, 
 	query = strings.ReplaceAll(query, "{{ new_profiles_name }}", quoteIdent(newProfilesName))
 	query = strings.ReplaceAll(query, "{{ new_profiles_version }}", strconv.Itoa(newProfilesVersion))
 	ctxMulti := gosnowflake.WithMultiStatement(ctx, 5) // TODO(Gianluca): is there a better way?
-	db, err := warehouse.openDB(ctx)
-	if err != nil {
-		return snowflake(err)
-	}
 	_, err = db.ExecContext(ctxMulti, query)
 	if err != nil {
 		return snowflake(err)
@@ -205,20 +238,104 @@ func (warehouse *Snowflake) resolveIdentities(ctx context.Context, opID string, 
 		return snowflake(err)
 	}
 
-	// Replace the current "profiles" view with a new one using the "CREATE OR
-	// REPLACE VIEW" statement since the table "_profiles" that the view refers to
-	// has changed its name.
-	_, err = db.ExecContext(ctx, createViewQuery(newProfilesName, profileColumns, true))
+	// Committing the successful operation switches the staged view to the new
+	// profiles without requiring another DDL statement.
+	err = warehouse.execTransaction(ctx, func(tx *sql.Tx) error {
+		return warehouse.setOperationAsCompleted(ctx, tx, opID, nil)
+	})
 	if err != nil {
-		return snowflake(err)
+		return err
 	}
 
-	// Drop the 'profiles' table that existed before executing this Identity
-	// Resolution.
-	_, err = db.ExecContext(ctx, `DROP TABLE IF EXISTS "KRENALIS_PROFILES_`+strconv.Itoa(profilesVersion)+`"`)
-	if err != nil {
-		return snowflake(err)
+	// Replace the staged view with its final definition, then remove the old
+	// profiles table. These are best-effort cleanups: the operation is already
+	// successful and the staged view already exposes the new profiles.
+	_, err2 := db.ExecContext(ctx, createViewQuery(newProfilesName, profileColumns, true))
+	if err2 != nil {
+		slog.Warn("cannot finalize identity resolution view", "err", warehouses.NewOperationError(snowflake(err2)))
+		return nil
+	}
+	_, err2 = db.ExecContext(ctx, `DROP TABLE IF EXISTS `+quoteIdent(currentProfilesName))
+	if err2 != nil {
+		slog.Warn("cannot drop previous identity resolution table", "err", warehouses.NewOperationError(snowflake(err2)))
 	}
 
 	return nil
+}
+
+// finalizeIdentityResolution returns nil on local success. On failure, it
+// attempts to mark the operation as failed and returns its persisted outcome.
+func (warehouse *Snowflake) finalizeIdentityResolution(ctx context.Context, conn connection, opID string, operationErr error) error {
+
+	if operationErr == nil {
+		return nil
+	}
+	operationError := warehouses.NewOperationError(operationErr)
+
+	bo := backoff.New(200)
+	bo.SetCap(30 * time.Second)
+	for bo.Next(ctx) {
+		if err := warehouse.setOperationAsCompleted(ctx, conn, opID, operationError); err != nil {
+			slog.Error("cannot mark identity resolution operation as failed, retrying",
+				"err", warehouses.NewOperationError(err), "operationError", operationError)
+			continue
+		}
+		status, err := warehouse.readOperationStatus(ctx, conn, opID)
+		if err != nil {
+			return err
+		}
+		if status == nil {
+			return fmt.Errorf("identity resolution operation %s not found", opID)
+		}
+		if !status.alreadyCompleted {
+			return fmt.Errorf("identity resolution operation %s is not completed", opID)
+		}
+		if status.executionError != nil {
+			return status.executionError
+		}
+		return nil
+	}
+
+	return ctx.Err()
+}
+
+// createPendingViewQuery returns a Snowflake view definition that exposes the
+// new profiles only after opID has been completed successfully.
+func createPendingViewQuery(currentProfilesName, newProfilesName, opID string, profileColumns []warehouses.Column) string {
+
+	var completed strings.Builder
+	completed.WriteString(`EXISTS (
+		SELECT 1 FROM "KRENALIS_SYSTEM_OPERATIONS"
+		WHERE "ID" = `)
+	quoteString(&completed, opID)
+	completed.WriteString(`
+			AND "COMPLETED_AT" IS NOT NULL
+			AND "ERROR" = ''
+	)`)
+
+	var b strings.Builder
+	b.WriteString(`CREATE OR REPLACE VIEW "PROFILES" AS SELECT` + "\n")
+	metaProps := []string{"_KPID", "_UPDATED_AT"}
+	for i, property := range metaProps {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		b.WriteString("\t")
+		b.WriteString(quoteIdent(property))
+	}
+	for _, column := range profileColumns {
+		b.WriteString(",\n\t")
+		b.WriteString(quoteIdent(column.Name))
+	}
+	b.WriteString("\nFROM (\n\tSELECT * FROM ")
+	b.WriteString(quoteIdent(newProfilesName))
+	b.WriteString(" WHERE ")
+	b.WriteString(completed.String())
+	b.WriteString("\n\tUNION ALL\n\tSELECT * FROM ")
+	b.WriteString(quoteIdent(currentProfilesName))
+	b.WriteString(" WHERE NOT ")
+	b.WriteString(completed.String())
+	b.WriteString("\n) AS \"PUBLISHED_PROFILES\"")
+
+	return b.String()
 }

--- a/warehouses/snowflake/identityresolution_test.go
+++ b/warehouses/snowflake/identityresolution_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026 Open2b. All rights reserved.
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+package snowflake
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krenalis/krenalis/tools/errors"
+	"github.com/krenalis/krenalis/tools/types"
+	"github.com/krenalis/krenalis/warehouses"
+)
+
+// Test_createPendingViewQuery verifies that the pending view selects the table
+// corresponding to the persisted operation outcome.
+func Test_createPendingViewQuery(t *testing.T) {
+	query := createPendingViewQuery("KRENALIS_PROFILES_1", "KRENALIS_PROFILES_2", "operation'id", []warehouses.Column{{
+		Name: "email",
+		Type: types.String(),
+	}})
+	wants := []string{
+		`SELECT` + "\n\t" + `"_KPID",` + "\n\t" + `"_UPDATED_AT",` + "\n\t" + `"EMAIL"`,
+		`SELECT * FROM "KRENALIS_PROFILES_2" WHERE EXISTS (`,
+		`WHERE "ID" = 'operation\'id'`,
+		`AND "COMPLETED_AT" IS NOT NULL`,
+		`AND "ERROR" = ''`,
+		`SELECT * FROM "KRENALIS_PROFILES_1" WHERE NOT EXISTS (`,
+	}
+	for _, want := range wants {
+		if !strings.Contains(query, want) {
+			t.Errorf("expected pending view query to contain %q, got:\n%s", want, query)
+		}
+	}
+}
+
+// Test_finalizeIdentityResolutionPreservesPersistedSuccess verifies that a
+// persisted successful operation takes precedence over a conflicting local
+// error.
+func Test_finalizeIdentityResolutionPreservesPersistedSuccess(t *testing.T) {
+
+	warehouse, db := newTestSnowflakeWarehouse(t)
+	if _, err := db.ExecContext(t.Context(), createOperationsTable); err != nil {
+		t.Fatal(err)
+	}
+
+	const opID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d0"
+	_, err := db.ExecContext(t.Context(), `INSERT INTO "KRENALIS_SYSTEM_OPERATIONS"
+		("ID", "OPERATION_TYPE", "COMPLETED_AT") VALUES (?, ?, ?)`, opID, identityResolution, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localErr := errors.New("commit response unavailable")
+	err = warehouse.finalizeIdentityResolution(t.Context(), db, opID, localErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var operationError string
+	if err := db.QueryRowContext(t.Context(),
+		`SELECT "ERROR" FROM "KRENALIS_SYSTEM_OPERATIONS" WHERE "ID" = ?`, opID).Scan(&operationError); err != nil {
+		t.Fatal(err)
+	}
+	if operationError != "" {
+		t.Fatalf("expected successful operation to remain successful, got error %q", operationError)
+	}
+
+}
+
+// TestResolveIdentitiesPreservesProfilesViewAfterPendingFailure verifies that
+// replacing a failed pending operation does not leave the profiles view
+// referencing a removed table when the replacement also fails.
+func TestResolveIdentitiesPreservesProfilesViewAfterPendingFailure(t *testing.T) {
+
+	warehouse, db := newTestSnowflakeWarehouse(t)
+	profileColumns := []warehouses.Column{{Name: "email", Type: types.String(), Nullable: true}}
+	if err := warehouse.Initialize(t.Context(), profileColumns); err != nil {
+		t.Fatal(err)
+	}
+
+	const failedOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d5"
+	_, err := db.ExecContext(t.Context(), `INSERT INTO "KRENALIS_SYSTEM_OPERATIONS"
+		("ID", "OPERATION_TYPE", "COMPLETED_AT", "ERROR") VALUES (?, ?, ?, ?)`,
+		failedOpID, identityResolution, time.Now().UTC(), "identity resolution failed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE "KRENALIS_PROFILES_1" LIKE "KRENALIS_PROFILES_0"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.ExecContext(t.Context(), `INSERT INTO "KRENALIS_PROFILE_SCHEMA_VERSIONS" ("VERSION", "OPERATION", "TIMESTAMP")`+
+		` VALUES (?, ?, ?)`, 1, failedOpID, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.ExecContext(t.Context(),
+		createPendingViewQuery("KRENALIS_PROFILES_0", "KRENALIS_PROFILES_1", failedOpID, profileColumns))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var profilesBefore int
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM "PROFILES"`).Scan(&profilesBefore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	badProfileColumns := append([]warehouses.Column{}, profileColumns...)
+	badProfileColumns = append(badProfileColumns, warehouses.Column{
+		Name:     "column_not_in_profiles_table",
+		Type:     types.String(),
+		Nullable: true,
+	})
+	const replacementOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d6"
+	err = warehouse.ResolveIdentities(t.Context(), replacementOpID, profileColumns, badProfileColumns, nil)
+	isOperationError := false
+	if err != nil {
+		_, isOperationError = errors.AsType[*warehouses.OperationError](err)
+	}
+	if !isOperationError {
+		t.Fatalf("expected replacement operation to return *warehouses.OperationError, got %v", err)
+	}
+	var profilesAfter int
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM "PROFILES"`).Scan(&profilesAfter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profilesAfter != profilesBefore {
+		t.Fatalf("failed replacement changed visible profiles from %d to %d", profilesBefore, profilesAfter)
+	}
+
+}
+
+// TestResolveIdentitiesRemovesObsoleteProfileTables verifies that a successful
+// operation after a failure removes obsolete profile tables and retains only
+// the published table.
+func TestResolveIdentitiesRemovesObsoleteProfileTables(t *testing.T) {
+
+	warehouse, db := newTestSnowflakeWarehouse(t)
+	profileColumns := []warehouses.Column{{Name: "email", Type: types.String(), Nullable: true}}
+	if err := warehouse.Initialize(t.Context(), profileColumns); err != nil {
+		t.Fatal(err)
+	}
+
+	badProfileColumns := append([]warehouses.Column{}, profileColumns...)
+	badProfileColumns = append(badProfileColumns, warehouses.Column{
+		Name:     "column_not_in_profiles_table",
+		Type:     types.String(),
+		Nullable: true,
+	})
+	const failedOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d1"
+	err := warehouse.ResolveIdentities(t.Context(), failedOpID, profileColumns, badProfileColumns, nil)
+	isOperationError := false
+	if err != nil {
+		_, isOperationError = errors.AsType[*warehouses.OperationError](err)
+	}
+	if !isOperationError {
+		t.Fatalf("expected failed operation to return *warehouses.OperationError, got %v", err)
+	}
+
+	const successfulOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d2"
+	err = warehouse.ResolveIdentities(t.Context(), successfulOpID, profileColumns, profileColumns, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tables := []struct {
+		name        string
+		shouldExist bool
+	}{
+		{name: "KRENALIS_PROFILES_0", shouldExist: false},
+		{name: "KRENALIS_PROFILES_1", shouldExist: false},
+		{name: "KRENALIS_PROFILES_2", shouldExist: true},
+	}
+	for _, table := range tables {
+		var exists bool
+		err := db.QueryRowContext(t.Context(), `SELECT COUNT(*) > 0
+			FROM INFORMATION_SCHEMA.TABLES
+			WHERE TABLE_SCHEMA = CURRENT_SCHEMA() AND TABLE_NAME = ?`, table.name).Scan(&exists)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists != table.shouldExist {
+			t.Fatalf("expected table %q existence to be %t, got %t", table.name, table.shouldExist, exists)
+		}
+	}
+
+}
+
+// TestResolveIdentitiesRetainsProfileTableFromRunningOperation verifies that
+// a second operation fails without removing the unpublished profiles table of
+// an operation still in progress.
+func TestResolveIdentitiesRetainsProfileTableFromRunningOperation(t *testing.T) {
+
+	warehouse, db := newTestSnowflakeWarehouse(t)
+	profileColumns := []warehouses.Column{{Name: "email", Type: types.String(), Nullable: true}}
+	if err := warehouse.Initialize(t.Context(), profileColumns); err != nil {
+		t.Fatal(err)
+	}
+
+	const runningOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d3"
+	_, err := db.ExecContext(t.Context(), `INSERT INTO "KRENALIS_SYSTEM_OPERATIONS" ("ID", "OPERATION_TYPE") VALUES (?, ?)`,
+		runningOpID, identityResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE "KRENALIS_PROFILES_1" LIKE "KRENALIS_PROFILES_0"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.ExecContext(t.Context(), `INSERT INTO "KRENALIS_PROFILE_SCHEMA_VERSIONS" ("VERSION", "OPERATION", "TIMESTAMP")`+
+		` VALUES (?, ?, ?)`, 1, runningOpID, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const conflictingOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d4"
+	err = warehouse.ResolveIdentities(t.Context(), conflictingOpID, profileColumns, profileColumns, nil)
+	isOperationError := false
+	if err != nil {
+		_, isOperationError = errors.AsType[*warehouses.OperationError](err)
+	}
+	if !isOperationError {
+		t.Fatalf("expected conflicting operation to return *warehouses.OperationError, got %v", err)
+	}
+
+	tables := []struct {
+		name        string
+		shouldExist bool
+	}{
+		{name: "KRENALIS_PROFILES_1", shouldExist: true},
+		{name: "KRENALIS_PROFILES_2", shouldExist: false},
+	}
+	for _, table := range tables {
+		var exists bool
+		err := db.QueryRowContext(t.Context(), `SELECT COUNT(*) > 0
+			FROM INFORMATION_SCHEMA.TABLES
+			WHERE TABLE_SCHEMA = CURRENT_SCHEMA() AND TABLE_NAME = ?`, table.name).Scan(&exists)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists != table.shouldExist {
+			t.Fatalf("expected table %q existence to be %t, got %t", table.name, table.shouldExist, exists)
+		}
+	}
+
+}

--- a/warehouses/snowflake/identityresolution_test.go
+++ b/warehouses/snowflake/identityresolution_test.go
@@ -69,6 +69,155 @@ func Test_finalizeIdentityResolutionPreservesPersistedSuccess(t *testing.T) {
 
 }
 
+// TestAlterProfileSchemaUsesPublishedProfilesAfterIdentityResolutionFailure
+// verifies that after a failed Identity Resolution, altering the profile schema
+// keeps the last published profiles visible and updates the published profiles
+// table.
+func TestAlterProfileSchemaUsesPublishedProfilesAfterIdentityResolutionFailure(t *testing.T) {
+
+	warehouse, db := newTestSnowflakeWarehouse(t)
+	profileColumns := []warehouses.Column{{Name: "email", Type: types.String(), Nullable: true}}
+	identifiers := profileColumns
+	err := warehouse.Initialize(t.Context(), profileColumns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.ExecContext(t.Context(), `INSERT INTO "KRENALIS_PROFILES_0"
+		("_KPID", "_IDENTITIES", "_UPDATED_AT", "EMAIL") SELECT ?, ARRAY_CONSTRUCT(1), ?, ?`,
+		"a44731d8-d89d-44b9-ac87-a8ce1a8770d7", time.Now().UTC(), "person@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	badProfileColumns := append([]warehouses.Column{}, profileColumns...)
+	badProfileColumns = append(badProfileColumns, warehouses.Column{
+		Name:     "column_not_in_profiles_table",
+		Type:     types.String(),
+		Nullable: true,
+	})
+	const failedOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d8"
+	err = warehouse.ResolveIdentities(t.Context(), failedOpID, identifiers, badProfileColumns, nil)
+	if err != nil {
+		_, ok := errors.AsType[*warehouses.OperationError](err)
+		if !ok {
+			t.Fatalf("expected failed operation to return *warehouses.OperationError, got %T: %v", err, err)
+		}
+	}
+	if err == nil {
+		t.Fatal("expected Identity Resolution to fail")
+	}
+
+	var email string
+	err = db.QueryRowContext(t.Context(), `SELECT "EMAIL" FROM "PROFILES" WHERE "_KPID" = ?`,
+		"a44731d8-d89d-44b9-ac87-a8ce1a8770d7").Scan(&email)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if email != "person@example.com" {
+		t.Errorf("expected the published profile to remain visible after failed Identity Resolution, got email %q", email)
+	}
+
+	var failedProfilesTableExists bool
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) > 0
+		FROM INFORMATION_SCHEMA.TABLES
+		WHERE TABLE_SCHEMA = CURRENT_SCHEMA()
+			AND TABLE_NAME = 'KRENALIS_PROFILES_1'`).Scan(&failedProfilesTableExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !failedProfilesTableExists {
+		t.Fatal("expected the failed profiles table to exist")
+	}
+
+	newProfileColumns := append([]warehouses.Column{}, profileColumns...)
+	newProfileColumns = append(newProfileColumns, warehouses.Column{Name: "phone", Type: types.String(), Nullable: true})
+	alterOperations := []warehouses.AlterOperation{{
+		Operation: warehouses.OperationAddColumn,
+		Column:    "phone",
+		Type:      types.String(),
+	}}
+	preview, err := warehouse.PreviewAlterProfileSchema(t.Context(), newProfileColumns, alterOperations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previewSQL := strings.Join(preview, "\n")
+	if !strings.Contains(previewSQL, `ALTER TABLE "KRENALIS_PROFILES_0"`) {
+		t.Errorf("expected preview to alter the published profiles table, got:\n%s", previewSQL)
+	}
+	if strings.Contains(previewSQL, `ALTER TABLE "KRENALIS_PROFILES_1"`) {
+		t.Errorf("expected preview not to alter the failed profiles table, got:\n%s", previewSQL)
+	}
+
+	const alterOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770d9"
+	err = warehouse.AlterProfileSchema(t.Context(), alterOpID, newProfileColumns, alterOperations)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.QueryRowContext(t.Context(), `SELECT "EMAIL" FROM "PROFILES" WHERE "_KPID" = ?`,
+		"a44731d8-d89d-44b9-ac87-a8ce1a8770d7").Scan(&email)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if email != "person@example.com" {
+		t.Errorf("expected the published profile to remain visible, got email %q", email)
+	}
+
+	var columnExists bool
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) > 0
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = CURRENT_SCHEMA()
+			AND TABLE_NAME = 'KRENALIS_PROFILES_0'
+			AND COLUMN_NAME = 'PHONE'`).Scan(&columnExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !columnExists {
+		t.Error("expected the published profiles table to contain the new column")
+	}
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) > 0
+		FROM INFORMATION_SCHEMA.TABLES
+		WHERE TABLE_SCHEMA = CURRENT_SCHEMA()
+			AND TABLE_NAME = 'KRENALIS_PROFILES_1'`).Scan(&failedProfilesTableExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !failedProfilesTableExists {
+		t.Fatal("expected the failed profiles table to remain after schema alteration")
+	}
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) > 0
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = CURRENT_SCHEMA()
+			AND TABLE_NAME = 'KRENALIS_PROFILES_1'
+			AND COLUMN_NAME = 'PHONE'`).Scan(&columnExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if columnExists {
+		t.Error("expected the failed profiles table not to contain the new column")
+	}
+
+	const successfulOpID = "a44731d8-d89d-44b9-ac87-a8ce1a8770da"
+	err = warehouse.ResolveIdentities(t.Context(), successfulOpID, identifiers, newProfileColumns, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) > 0
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = CURRENT_SCHEMA()
+			AND TABLE_NAME = 'KRENALIS_PROFILES_2'
+			AND COLUMN_NAME = 'PHONE'`).Scan(&columnExists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !columnExists {
+		t.Error("expected the next profiles table to copy the published schema")
+	}
+
+}
+
 // TestResolveIdentitiesPreservesProfilesViewAfterPendingFailure verifies that
 // replacing a failed pending operation does not leave the profiles view
 // referencing a removed table when the replacement also fails.

--- a/warehouses/snowflake/operations.go
+++ b/warehouses/snowflake/operations.go
@@ -7,10 +7,10 @@ package snowflake
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"time"
 
 	"github.com/krenalis/krenalis/tools/backoff"
+	"github.com/krenalis/krenalis/tools/errors"
 	"github.com/krenalis/krenalis/warehouses"
 )
 
@@ -24,87 +24,94 @@ const (
 type opStatus struct {
 	canBeStarted     bool
 	alreadyCompleted bool
-	// executionError is significant only if 'alreadyCompleted' is true.
-	// If executionError is not nil, it has type warehouses.OperationError.
-	executionError error
+	executionError   *warehouses.OperationError
+}
+
+// connection is implemented by Snowflake database handles and transactions.
+type connection interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 // executeOperation starts an operation, identified by an ID.
 //
-// The returned status indicates whether the operation can be started, or
-// returns the status of a current executing or previous execution.
+// The returned status indicates whether the operation can be started or
+// describes an operation that has already completed.
 func (warehouse *Snowflake) executeOperation(ctx context.Context, opID string, opType warehouseOp) (status *opStatus, err error) {
-	var completedAt *time.Time
-	var opError string
+
 	bo := backoff.New(200)
 	bo.SetCap(500 * time.Millisecond)
 	for bo.Next(ctx) {
-		err := warehouse.execTransaction(ctx, func(tx *sql.Tx) error {
-			var readID *string
-			rows, err := tx.Query(`SELECT "ID", "COMPLETED_AT", "ERROR" FROM "KRENALIS_SYSTEM_OPERATIONS" WHERE "ID" = ?`, opID)
+		err = warehouse.execTransaction(ctx, func(tx *sql.Tx) error {
+			status, err = warehouse.readOperationStatus(ctx, tx, opID)
+			if err != nil {
+				return err
+			}
+			if status != nil {
+				return nil
+			}
+			// No existing operation was found, so this one can be started.
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO "KRENALIS_SYSTEM_OPERATIONS" ("ID", "OPERATION_TYPE") VALUES (?, ?)`,
+				opID, opType)
 			if err != nil {
 				return snowflake(err)
 			}
-			defer rows.Close()
-			for rows.Next() {
-				err := rows.Scan(&readID, &completedAt, &opError)
-				if err != nil {
-					return snowflake(err)
-				}
-			}
-			if err := rows.Err(); err != nil {
-				return snowflake(err)
-			}
-			if readID == nil {
-				// No rows in DB, so the operation can be started.
-				_, err = tx.Exec(`INSERT INTO "KRENALIS_SYSTEM_OPERATIONS" ("ID", "OPERATION_TYPE") VALUES (?, ?)`, opID, opType)
-				if err != nil {
-					return snowflake(err)
-				}
-				status = &opStatus{canBeStarted: true}
-				return nil
-			}
+			status = &opStatus{canBeStarted: true}
 			return nil
 		})
 		if err != nil {
 			return nil, err
 		}
-		if status != nil {
+		if status.canBeStarted || status.alreadyCompleted {
 			return status, nil
 		}
-		// Operation is still running, so wait 500ms then try again to check if
-		// it has completed.
-		if completedAt == nil {
-			continue
-		}
-		// Operation is completed with an error.
-		if opError != "" {
-			return &opStatus{alreadyCompleted: true, executionError: warehouses.NewOperationError(errors.New(opError))}, nil
-		}
-		// Operations is completed without errors.
-		return &opStatus{alreadyCompleted: true}, nil
+		// The operation is still running, so wait before checking again.
 	}
+
 	return nil, ctx.Err()
 }
 
-// setOperationAsCompleted sets the given operation as completed. opError is the
-// possible error in the execution of the operation, which will be stored in the
-// database; nil means operation ended successfully.
-// If an operation has already been set as completed, this method does
-// nothing.
-func (warehouse *Snowflake) setOperationAsCompleted(ctx context.Context, opID string, opError error) error {
-	db, err := warehouse.openDB(ctx)
+// readOperationStatus reads the persisted status of an operation. It returns
+// nil when the operation does not exist.
+func (warehouse *Snowflake) readOperationStatus(ctx context.Context, conn connection, opID string) (*opStatus, error) {
+
+	var completedAt *time.Time
+	var opError string
+	err := conn.QueryRowContext(ctx, `SELECT "COMPLETED_AT", LEFT("ERROR", ?)`+
+		` FROM "KRENALIS_SYSTEM_OPERATIONS" WHERE "ID" = ? LIMIT 1`,
+		warehouses.MaxOperationErrorBytes+1, opID).
+		Scan(&completedAt, &opError)
 	if err != nil {
-		return snowflake(err)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, snowflake(err)
 	}
+	status := &opStatus{}
+	if completedAt == nil {
+		return status, nil
+	}
+	status.alreadyCompleted = true
+	if opError != "" {
+		status.executionError = warehouses.NewPersistedOperationError(opError)
+	}
+
+	return status, nil
+}
+
+// setOperationAsCompleted sets the given operation as completed. opError is the
+// error returned by the operation; nil indicates that it completed
+// successfully. If the operation has already been set as completed, this
+// method does nothing.
+func (warehouse *Snowflake) setOperationAsCompleted(ctx context.Context, conn connection, opID string, opError *warehouses.OperationError) error {
+
 	var opErrorStr string
 	if opError != nil {
 		opErrorStr = opError.Error()
 	}
-	_, err = db.ExecContext(ctx, `UPDATE "KRENALIS_SYSTEM_OPERATIONS" SET "COMPLETED_AT" = ?, "ERROR" = ?`+
+	_, err := conn.ExecContext(ctx, `UPDATE "KRENALIS_SYSTEM_OPERATIONS" SET "COMPLETED_AT" = ?, "ERROR" = ?`+
 		` WHERE "ID" = ? AND "COMPLETED_AT" IS NULL`, time.Now().UTC(), opErrorStr, opID)
-	if err != nil {
-		return snowflake(err)
-	}
-	return nil
+
+	return snowflake(err)
 }

--- a/warehouses/snowflake/tables/profile_schema_versions.sql
+++ b/warehouses/snowflake/tables/profile_schema_versions.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS "KRENALIS_PROFILE_SCHEMA_VERSIONS" (
     "VERSION" INTEGER NOT NULL,
-    "OPERATION" VARCHAR NOT NULL,        -- useful for logging purposes.
-    "TIMESTAMP" TIMESTAMP_NTZ NOT NULL,  -- useful for logging purposes.
+    "OPERATION" VARCHAR NOT NULL,        -- operation that created this version of the profile schema.
+    "TIMESTAMP" TIMESTAMP_NTZ NOT NULL,  -- timestamp when this version was created.
     PRIMARY KEY ("VERSION")
 );

--- a/warehouses/snowflake/warehouse.go
+++ b/warehouses/snowflake/warehouse.go
@@ -478,6 +478,27 @@ func (warehouse *Snowflake) profilesVersion(ctx context.Context) (int, error) {
 	return v, nil
 }
 
+// publishedProfilesVersion returns the version of the currently published
+// profiles table.
+func (warehouse *Snowflake) publishedProfilesVersion(ctx context.Context) (int, error) {
+	db, err := warehouse.openDB(ctx)
+	if err != nil {
+		return 0, snowflake(err)
+	}
+	var version int
+	err = db.QueryRowContext(ctx, `SELECT COALESCE(MAX("V"."VERSION"), 0)
+		FROM "KRENALIS_PROFILE_SCHEMA_VERSIONS" "V"
+		JOIN "KRENALIS_SYSTEM_OPERATIONS" "O" ON "O"."ID" = "V"."OPERATION"
+		WHERE "O"."COMPLETED_AT" IS NOT NULL AND "O"."ERROR" = ''`).Scan(&version)
+	if err != nil {
+		return 0, snowflake(err)
+	}
+	if version < 0 {
+		return 0, fmt.Errorf("warehouse returned a negative published profile schema version")
+	}
+	return version, nil
+}
+
 // accountFormat is the format of the account identifier in the settings.
 var accountFormat = regexp.MustCompile(`^[a-zA-Z0-9]+[.-][a-zA-Z0-9]+$`)
 

--- a/warehouses/snowflake/warehouse.go
+++ b/warehouses/snowflake/warehouse.go
@@ -78,8 +78,8 @@ func (warehouse *Snowflake) CheckReadOnlyAccess(ctx context.Context) error {
 		return snowflake(err)
 	}
 
-	// Retrieve the profiles table version.
-	profileSchemaVersion, err := warehouse.profilesVersion(ctx)
+	// Retrieve the greatest recorded profiles table version.
+	profileSchemaVersion, err := warehouse.maxProfilesVersion(ctx)
 	if err != nil {
 		return err
 	}
@@ -464,8 +464,9 @@ func (warehouse *Snowflake) openDB(ctx context.Context) (*sql.DB, error) {
 	return db, nil
 }
 
-// profilesVersion returns the version of the "KRENALIS_PROFILES" table.
-func (warehouse *Snowflake) profilesVersion(ctx context.Context) (int, error) {
+// maxProfilesVersion returns the greatest recorded version of the
+// "KRENALIS_PROFILES" table.
+func (warehouse *Snowflake) maxProfilesVersion(ctx context.Context) (int, error) {
 	db, err := warehouse.openDB(ctx)
 	if err != nil {
 		return 0, snowflake(err)

--- a/warehouses/snowflake/warehouse_test.go
+++ b/warehouses/snowflake/warehouse_test.go
@@ -7,6 +7,7 @@ package snowflake
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"testing"
@@ -258,4 +259,37 @@ func newTestSettingsLoader(settings json.Value) *testSettingsLoader {
 
 func (loader *testSettingsLoader) Load(ctx context.Context, dst any) error {
 	return json.Unmarshal(loader.settings, dst)
+}
+
+// newTestSnowflakeWarehouse creates a Snowflake test environment and opens a
+// warehouse connection to it.
+func newTestSnowflakeWarehouse(t *testing.T) (*Snowflake, *sql.DB) {
+
+	t.Helper()
+	if os.Getenv("KRENALIS_SKIP_SNOWFLAKE_TESTS") == "true" {
+		t.Skip()
+	}
+
+	testEnv, err := snowflaketester.CreateTestEnvironment()
+	if err != nil {
+		t.Fatalf("cannot create Snowflake test environment: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := testEnv.Teardown(); err != nil {
+			t.Logf("cannot teardown Snowflake environment: %s", err)
+		}
+	})
+
+	warehouse := warehouses.Registered("Snowflake").New(newTestSettingsLoader(testEnv.Settings().JSON())).(*Snowflake)
+	t.Cleanup(func() {
+		if err := warehouse.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	db, err := warehouse.openDB(t.Context())
+	if err != nil {
+		t.Fatalf("cannot open Snowflake warehouse: %s", err)
+	}
+
+	return warehouse, db
 }

--- a/warehouses/warehouses.go
+++ b/warehouses/warehouses.go
@@ -409,17 +409,55 @@ func IsValidSchemaName(name string) bool {
 	return IsValidIdentifier(name)
 }
 
-// OperationError represents an error that occurred in the data warehouse during
-// an Identity Resolution or profile schema update operation.
-type OperationError struct{ err error }
+// MaxOperationErrorBytes is the maximum supported size of an operation error
+// message.
+const MaxOperationErrorBytes = 4 << 10 // 4 KiB
 
-// NewOperationError returns a new *OperationError.
+// OperationError represents an error that occurred in the data warehouse during
+// an Identity Resolution or profile schema update operation. Its message is
+// valid UTF-8 and at most MaxOperationErrorBytes bytes long.
+type OperationError struct{ message string }
+
+// NewOperationError returns a new *OperationError. Messages longer than
+// MaxOperationErrorBytes are abbreviated at a Unicode character boundary with
+// a trailing "[...]". If the resulting message is not valid UTF-8, it is
+// replaced with a fixed message. NewOperationError panics if err is nil.
 func NewOperationError(err error) *OperationError {
-	return &OperationError{err: err}
+	if err == nil {
+		panic("warehouses.NewOperationError: nil error")
+	}
+	const invalidMessage = "warehouse operation failed with an invalid error message"
+	message := err.Error()
+	if len(message) > MaxOperationErrorBytes {
+		const suffix = "[...]"
+		end := MaxOperationErrorBytes - len(suffix)
+		for i := 0; i < utf8.UTFMax-1 && !utf8.RuneStart(message[end]); i++ {
+			end--
+		}
+		if !utf8.RuneStart(message[end]) {
+			return &OperationError{message: invalidMessage}
+		}
+		message = message[:end] + suffix
+	}
+	if !utf8.ValidString(message) {
+		message = invalidMessage
+	}
+	return &OperationError{message: message}
 }
 
+// NewPersistedOperationError returns an *OperationError for a message read from
+// a warehouse. Messages that are not valid UTF-8 or exceed
+// MaxOperationErrorBytes are replaced with a fixed message.
+func NewPersistedOperationError(message string) *OperationError {
+	if len(message) > MaxOperationErrorBytes || !utf8.ValidString(message) {
+		message = "warehouse operation failed with an invalid or oversized error message"
+	}
+	return &OperationError{message: message}
+}
+
+// Error returns the operation error message.
 func (err OperationError) Error() string {
-	return err.err.Error()
+	return err.message
 }
 
 // ValidateInt validates an int value.


### PR DESCRIPTION
```
warehouses: preserve profiles after failed Identity Resolution (#2432)

Publish a candidate profiles version only after Identity Resolution
succeeds, preserve the visible profiles on failure, and remove obsolete
failed candidates without interfering with operations that are still
running.

Use the last published profiles version for schema changes and as the
source of new candidates after a failed run. Continue allocating from
the highest recorded version so failed or running candidates are not
reused.

Reconcile ambiguous transaction commit responses with the operation
state stored in the warehouse, so retries preserve the persisted success
or failure. Limit warehouse operation error messages before they reach
Krenalis resources or logs.

Cover these recovery and schema-version paths with aligned PostgreSQL
and Snowflake integration tests.
```