### PR TITLE
core/appwriter: apply `Same` operation filter to `Peek`

### DIFF
--- a/core/internal/connections/appwriter/iterator.go
+++ b/core/internal/connections/appwriter/iterator.go
@@ -15,6 +15,7 @@ import (
 // sequence of records.
 type iterator struct {
 	writer    *Writer
+	op        op
 	index     int // read index in writer.records, set by the writer.
 	consumed  bool
 	iterating bool
@@ -23,7 +24,7 @@ type iterator struct {
 }
 
 func newIterator(w *Writer) *iterator {
-	it := iterator{writer: w}
+	it := iterator{writer: w, op: opAll}
 	return &it
 }
 
@@ -32,7 +33,7 @@ func (it *iterator) All() iter.Seq[connectors.Record] {
 		panic(it.writer.connector + " connector: Upsert method called Records.All after the records were consumed")
 	}
 	it.consumed = true
-	return it.seq(opAll)
+	return it.seq()
 }
 
 func (it *iterator) Discard(err error) {
@@ -78,7 +79,7 @@ func (it *iterator) Peek() (connectors.Record, bool) {
 	if trace {
 		fmt.Printf("iterator.Peek: iterator %p peek a record\n", it)
 	}
-	record, ok := it.writer.read(opAll, false)
+	record, ok := it.writer.read(it.op, false)
 	if !ok {
 		return connectors.Record{}, false
 	}
@@ -107,25 +108,24 @@ func (it *iterator) Same() iter.Seq[connectors.Record] {
 		panic(it.writer.connector + " connector: Upsert method called Records.Some after the records were consumed")
 	}
 	it.consumed = true
-	op := opUpdate
+	it.op = opUpdate
 	if record, _ := it.writer.read(opAll, false); record.ID == "" {
-		op = opCreate
+		it.op = opCreate
 	}
-	return it.seq(op)
+	return it.seq()
 }
 
-// seq returns a sequence of records. If op is not opAll, it restricts the
-// sequence to records of type creation (opCreate) or update (opUpdate).
-func (it *iterator) seq(op op) iter.Seq[connectors.Record] {
+// seq returns a sequence of records.
+func (it *iterator) seq() iter.Seq[connectors.Record] {
 	return func(yield func(record connectors.Record) bool) {
 		if trace {
-			fmt.Printf("iterator.seq: iterator %p starting to read %s records\n", it, op)
+			fmt.Printf("iterator.seq: iterator %p starting to read %s records\n", it, it.op)
 		}
 		it.iterating = true
 		for {
 			it.postponed = false
 			it.discarded = false
-			record, ok := it.writer.read(op, true)
+			record, ok := it.writer.read(it.op, true)
 			if !ok {
 				if trace {
 					fmt.Printf("iterator.seq: iterator %p finished reading the records; no more are available\n", it)

--- a/core/internal/connections/appwriter/iterator_test.go
+++ b/core/internal/connections/appwriter/iterator_test.go
@@ -15,9 +15,10 @@ import (
 func newPeekTestIterator() *iterator {
 	w := &Writer{
 		connector: "test",
-		available: 2,
+		available: 3,
 		records: []record{
 			{id: "first", attributes: map[string]any{"name": "First"}},
+			{attributes: map[string]any{"name": "Creation"}},
 			{id: "second", attributes: map[string]any{"name": "Second"}},
 		},
 	}
@@ -34,9 +35,10 @@ func Test_iterator_Peek(t *testing.T) {
 	tests := []struct {
 		name string
 		seq  func(*iterator) iter.Seq[connectors.Record]
+		want []string
 	}{
-		{name: "All", seq: (*iterator).All},
-		{name: "Same", seq: (*iterator).Same},
+		{name: "All", seq: (*iterator).All, want: []string{"first", "", "second"}},
+		{name: "Same", seq: (*iterator).Same, want: []string{"first", "second"}},
 	}
 
 	for _, test := range tests {
@@ -50,26 +52,26 @@ func Test_iterator_Peek(t *testing.T) {
 				t.Fatalf("repeated Peek before iteration: expected record ID %q and true, got %q and %t", first.ID, got.ID, ok)
 			}
 
-			want := []string{"first", "second"}
 			yielded := 0
 			for record := range test.seq(it) {
-				if yielded >= len(want) {
-					t.Fatalf("expected %d records, got more", len(want))
+				if yielded >= len(test.want) {
+					t.Fatalf("expected %d records, got more", len(test.want))
 				}
-				if record.ID != want[yielded] {
-					t.Fatalf("record %d: expected ID %q, got %q", yielded, want[yielded], record.ID)
+				if record.ID != test.want[yielded] {
+					t.Fatalf("record %d: expected ID %q, got %q", yielded, test.want[yielded], record.ID)
 				}
-				if yielded+1 < len(want) {
-					if got, ok := it.Peek(); !ok || got.ID != want[yielded+1] {
-						t.Fatalf("Peek during iteration: expected record ID %q and true, got %q and %t", want[yielded+1], got.ID, ok)
+				if yielded+1 < len(test.want) {
+					if got, ok := it.Peek(); !ok || got.ID != test.want[yielded+1] {
+						t.Fatalf("Peek during iteration: expected record ID %q and true, got %q and %t", test.want[yielded+1],
+							got.ID, ok)
 					}
 				} else if got, ok := it.Peek(); ok || got.ID != "" || got.Attributes != nil || !got.UpdatedAt.IsZero() || got.Err != nil {
 					t.Fatalf("Peek at the end of the iteration: expected a zero record and false, got %#v and %t", got, ok)
 				}
 				yielded++
 			}
-			if yielded != len(want) {
-				t.Fatalf("expected %d records, got %d", len(want), yielded)
+			if yielded != len(test.want) {
+				t.Fatalf("expected %d records, got %d", len(test.want), yielded)
 			}
 
 			defer func() {


### PR DESCRIPTION
```
core/appwriter: apply `Same` operation filter to `Peek` (#2436)

Peek always read with opAll, so during a Same iteration it could return
a record of the opposite operation type that the iteration would never
yield.

Store the selected operation on the iterator and use it for both Peek
and the iteration.
```