### PR TITLE
core/internal/connections: reset database record update time

### DIFF
--- a/core/internal/connections/database.go
+++ b/core/internal/connections/database.go
@@ -601,6 +601,7 @@ func (r *databaseRecords) All(ctx context.Context) iter.Seq[Record] {
 				}
 				record.ID = ""
 				record.Attributes = nil
+				record.UpdatedAt = time.Time{}
 				record.Err = nil
 			}
 			if err := ctx.Err(); err != nil {


### PR DESCRIPTION
```
core/internal/connections: reset database record update time (#2437)

databaseRecords reuses the same Record value across rows, but does not
reset its UpdatedAt together with the other fields after yielding it. If
the next row fails before its update time is read, the errored record
inherits the previous row's update time.

Reset UpdatedAt together with the other fields so each record starts
with a clean state.
```