### PR TITLE
core: document import cursor behavior for failed records

### DIFF
--- a/core/run_import.go
+++ b/core/run_import.go
@@ -181,6 +181,9 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 			}
 
 			// Set the cursor.
+			// The cursor may move past records that failed input validation or transformation.
+			// Incremental imports do not move the cursor back to retry failed records.
+			// Processing them again requires a non-incremental import.
 			err = this.setRunCursor(ctx, cursor)
 			if err != nil {
 				return err


### PR DESCRIPTION
```
core: document import cursor behavior for failed records (#2438)

Document that incremental imports may move the cursor past records that
fail input validation or transformation, while retrying them requires a
non-incremental import.
```