### PR TITLE
core: fix batching across application record pages

### DIFF
--- a/core/connection.go
+++ b/core/connection.go
@@ -275,9 +275,7 @@ func (this *Connection) ApplicationUsers(ctx context.Context, schema types.Type,
 			return nil, "", errors.Unavailable("%s has returned an invalid user; %s", this.application().Connector(), user.Err)
 		}
 		users = append(users, user.Attributes)
-		if records.Last() {
-			last = user
-		}
+		last = user
 		if len(users) == 100 {
 			break
 		}

--- a/core/internal/connections/application.go
+++ b/core/internal/connections/application.go
@@ -543,19 +543,20 @@ type appRecords struct {
 	updatedAt   time.Time
 	connector   string
 	inner       any
-	last        bool
 	err         error
 	closed      bool
 }
 
+// All returns an iterator over the application records.
 func (r *appRecords) All(ctx context.Context) iter.Seq[Record] {
 
 	return func(yield func(Record) bool) {
 
 		if r.closed {
-			r.err = errors.New("connectors: For called on a closed Records")
+			r.err = errors.New("connectors: All called on a closed Records")
 			return
 		}
+		defer r.Close()
 
 		var cursor string
 
@@ -586,9 +587,6 @@ func (r *appRecords) All(ctx context.Context) iter.Seq[Record] {
 				}
 				return
 			}
-
-			// previous is the previous read record.
-			var previous Record
 
 			for _, user := range users {
 
@@ -651,20 +649,10 @@ func (r *appRecords) All(ctx context.Context) iter.Seq[Record] {
 					}
 				}
 
-				if previous.ID != "" {
-					if !yield(previous) {
-						return
-					}
-				}
-				previous = record
-
-			}
-
-			if previous.ID != "" {
-				r.last = true
-				if !yield(previous) {
+				if !yield(record) {
 					return
 				}
+
 			}
 
 			if eof {
@@ -684,10 +672,6 @@ func (r *appRecords) Close() error {
 
 func (r *appRecords) Err() error {
 	return r.err
-}
-
-func (r *appRecords) Last() bool {
-	return r.last
 }
 
 type schema struct {

--- a/core/internal/connections/application_test.go
+++ b/core/internal/connections/application_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 	"iter"
+	"slices"
 	"testing"
 	"time"
 
@@ -25,6 +26,141 @@ func (recordFetcherFunc) RecordSchema(context.Context, connectors.Targets, conne
 
 func (f recordFetcherFunc) Records(ctx context.Context, target connectors.Targets, updatedAt time.Time, cursor string, schema types.Type) ([]connectors.Record, string, error) {
 	return f(ctx, target, updatedAt, cursor, schema)
+}
+
+// TestAppRecordsPaging verifies paging, deduplication, and lazy record processing.
+func TestAppRecordsPaging(t *testing.T) {
+
+	schema := types.Object([]types.Property{
+		{Name: "email", Type: types.String()},
+	})
+	updatedAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	newRecord := func(id string) connectors.Record {
+		return connectors.Record{
+			ID:         id,
+			Attributes: map[string]any{"email": id + "@example.com"},
+			UpdatedAt:  updatedAt,
+		}
+	}
+
+	t.Run("deduplicates records", func(t *testing.T) {
+
+		duplicateUser1 := newRecord("user-1")
+		duplicateUser1.Attributes["email"] = "duplicate-user-1@example.com"
+		duplicateUser2 := newRecord("user-2")
+		duplicateUser2.Attributes["email"] = "duplicate-user-2@example.com"
+		records := &appRecords{
+			schema:    schema,
+			appSchema: schema,
+			connector: "test",
+			inner: recordFetcherFunc(func(_ context.Context, _ connectors.Targets, _ time.Time, cursor string, _ types.Type) ([]connectors.Record, string, error) {
+				switch cursor {
+				case "":
+					return []connectors.Record{newRecord("user-1"), duplicateUser1, newRecord("user-2")}, "second", nil
+				case "second":
+					return []connectors.Record{duplicateUser2, newRecord("user-3")}, "third", nil
+				case "third":
+					return []connectors.Record{newRecord("user-1"), newRecord("user-3")}, "", io.EOF
+				default:
+					t.Fatalf("unexpected cursor %q", cursor)
+					return nil, "", nil
+				}
+			}),
+		}
+		defer records.Close()
+
+		var got []string
+		var user1Email, user2Email any
+		for record := range records.All(t.Context()) {
+			got = append(got, record.ID)
+			switch record.ID {
+			case "user-1":
+				user1Email = record.Attributes["email"]
+			case "user-2":
+				user2Email = record.Attributes["email"]
+			}
+		}
+		if err := records.Err(); err != nil {
+			t.Fatalf("expected no iterator error, got %s", err)
+		}
+		if expected := []string{"user-1", "user-2", "user-3"}; !slices.Equal(got, expected) {
+			t.Fatalf("expected record IDs %q, got %q", expected, got)
+		}
+		if user1Email != "user-1@example.com" {
+			t.Fatalf("expected the first user-1 record to be retained, got email %v", user1Email)
+		}
+		if user2Email != "user-2@example.com" {
+			t.Fatalf("expected the first user-2 record to be retained, got email %v", user2Email)
+		}
+
+	})
+
+	t.Run("yields records returned with EOF", func(t *testing.T) {
+
+		records := &appRecords{
+			schema:    schema,
+			appSchema: schema,
+			connector: "test",
+			inner: recordFetcherFunc(func(_ context.Context, _ connectors.Targets, _ time.Time, cursor string, _ types.Type) ([]connectors.Record, string, error) {
+				if cursor != "" {
+					t.Fatalf("unexpected cursor %q", cursor)
+				}
+				return []connectors.Record{newRecord("user-1")}, "", io.EOF
+			}),
+		}
+		defer records.Close()
+
+		var got []string
+		for record := range records.All(t.Context()) {
+			got = append(got, record.ID)
+		}
+		if err := records.Err(); err != nil {
+			t.Fatalf("expected no iterator error, got %s", err)
+		}
+		if expected := []string{"user-1"}; !slices.Equal(got, expected) {
+			t.Fatalf("expected record IDs %q, got %q", expected, got)
+		}
+
+	})
+
+	t.Run("does not process records ahead of iteration", func(t *testing.T) {
+
+		// invalidRecord makes appRecords fail if it processes past user-2.
+		invalidRecord := newRecord("")
+		records := &appRecords{
+			schema:    schema,
+			appSchema: schema,
+			connector: "test",
+			inner: recordFetcherFunc(func(_ context.Context, _ connectors.Targets, _ time.Time, cursor string, _ types.Type) ([]connectors.Record, string, error) {
+				switch cursor {
+				case "":
+					return []connectors.Record{newRecord("user-1")}, "second", nil
+				case "second":
+					return []connectors.Record{newRecord("user-2"), invalidRecord}, "", io.EOF
+				default:
+					t.Fatalf("unexpected cursor %q", cursor)
+					return nil, "", nil
+				}
+			}),
+		}
+		defer records.Close()
+
+		var got []string
+		for record := range records.All(t.Context()) {
+			got = append(got, record.ID)
+			if len(got) == 2 {
+				break
+			}
+		}
+		if err := records.Err(); err != nil {
+			t.Fatalf("expected no iterator error, got %s", err)
+		}
+		if expected := []string{"user-1", "user-2"}; !slices.Equal(got, expected) {
+			t.Fatalf("expected record IDs %q, got %q", expected, got)
+		}
+
+	})
+
 }
 
 // TestAppRecordsPreservesConnectorRecordError verifies that an application
@@ -48,6 +184,7 @@ func TestAppRecordsPreservesConnectorRecordError(t *testing.T) {
 			}}, "", io.EOF
 		}),
 	}
+	defer records.Close()
 
 	var got []Record
 	for record := range records.All(t.Context()) {
@@ -71,9 +208,6 @@ func TestAppRecordsPreservesConnectorRecordError(t *testing.T) {
 	}
 	if record.Attributes != nil {
 		t.Fatalf("expected nil attributes, got %#v", record.Attributes)
-	}
-	if !records.Last() {
-		t.Fatal("expected the errored record to be the last record")
 	}
 }
 

--- a/core/internal/connections/connections.go
+++ b/core/internal/connections/connections.go
@@ -81,25 +81,21 @@ func (err *UnavailableError) Error() string {
 // the placeholder is allowed.
 type PlaceholderReplacer func(name string) (string, bool)
 
-// Records is the iterator interface used to iterate over the records read from
-// apps, databases, and files.
+// Records is an interface for iterating over records read from apps, databases,
+// and files.
 type Records interface {
 
-	// All returns an iterator to iterate over the records. After All completes, it
-	// is also necessary to check the result of Err for any potential errors.
+	// All returns a sequence of records. When the sequence is iterated, Close is
+	// called automatically when iteration finishes or is stopped early. Err must
+	// be checked afterward.
 	All(ctx context.Context) iter.Seq[Record]
 
-	// Close closes the iterator. It is automatically called by the For method
-	// before returning. Close is idempotent and does not impact the result of Err.
+	// Close releases resources associated with Records and is idempotent. Callers
+	// must call Close if iteration is never started.
 	Close() error
 
-	// Err returns any error encountered during iteration, excluding errors returned
-	// by the yield function, which may have occurred after an explicit or implicit
-	// Close.
+	// Err returns any error encountered during iteration or cleanup.
 	Err() error
-
-	// Last reports whether the last record has been read.
-	Last() bool
 }
 
 type EventType = connectors.EventType

--- a/core/internal/connections/database.go
+++ b/core/internal/connections/database.go
@@ -544,7 +544,6 @@ type databaseRecords struct {
 	columns     []connectors.Column
 	pipeline    *state.Pipeline
 	timeLayouts *state.TimeLayouts
-	last        bool
 	err         error
 	closed      bool
 }
@@ -560,6 +559,7 @@ func newDatabaseRecords(rows connectors.Rows, columns []connectors.Column, pipel
 	return &records
 }
 
+// All returns an iterator over the database records.
 func (r *databaseRecords) All(ctx context.Context) iter.Seq[Record] {
 	return func(yield func(Record) bool) {
 		if r.closed {
@@ -591,7 +591,8 @@ func (r *databaseRecords) All(ctx context.Context) iter.Seq[Record] {
 			}
 			n++
 		}
-		// Read the rows.
+		// Delay yielding each record until the next iteration so every row-processing
+		// error path can use continue Rows without duplicating the yield logic.
 		var record Record
 	Rows:
 		for r.rows.Next() {
@@ -664,7 +665,6 @@ func (r *databaseRecords) All(ctx context.Context) iter.Seq[Record] {
 			}
 		}
 		if record.Attributes != nil || record.Err != nil {
-			r.last = true
 			if !yield(record) {
 				return
 			}
@@ -689,10 +689,6 @@ func (r *databaseRecords) Close() error {
 
 func (r *databaseRecords) Err() error {
 	return r.err
-}
-
-func (r *databaseRecords) Last() bool {
-	return r.last
 }
 
 // queryScanValue implements the sql.Scanner interface to read the database

--- a/core/internal/connections/file.go
+++ b/core/internal/connections/file.go
@@ -477,10 +477,11 @@ type fileRecords struct {
 	closed bool
 }
 
+// All returns an iterator over the file records.
 func (r *fileRecords) All(ctx context.Context) iter.Seq[Record] {
 	return func(yield func(Record) bool) {
 		if r.closed {
-			r.err = errors.New("connectors: For called on a closed Records")
+			r.err = errors.New("connectors: All called on a closed Records")
 			return
 		}
 		defer func() {
@@ -489,9 +490,8 @@ func (r *fileRecords) All(ctx context.Context) iter.Seq[Record] {
 				r.err = ErrNoColumnsFound
 			}
 		}()
-		r.rw.setYieldFunc(yield)
+		r.rw.yield = yield
 		err := readFromFileConnector(ctx, r.inner, &r.rc, r.sheet, r.rw)
-		r.rw.close()
 		if err != nil && err != errRecordStop {
 			r.err = connectorError(err)
 		}
@@ -512,10 +512,6 @@ func (r *fileRecords) Close() error {
 
 func (r *fileRecords) Err() error {
 	return r.err
-}
-
-func (r *fileRecords) Last() bool {
-	return r.rw.last()
 }
 
 // funcReadCloser wraps an io.Reader and implements io.ReadCloser. It calls a
@@ -627,8 +623,8 @@ func (closedReadCloser) Close() error {
 }
 
 var (
-	// errRecordStop is returned by recordWriter methods when the maximum row
-	// limit has been reached, signaling the need to stop writing rows.
+	// errRecordStop is returned by recordWriter methods when the consumer stops
+	// iterating or the configured row limit is reached.
 	errRecordStop = errors.New("stop record")
 
 	// errReadStopped is returned to a file connector when it calls w.Write and the
@@ -682,29 +678,6 @@ func (rr *recordReader) Record(ctx context.Context) (map[string]any, error) {
 	}
 }
 
-// newRecordWriter returns a new record writer implementing the RecordWriter
-// interface. It calls the yield function, which must be set by calling the
-// setYieldFunc method, for each record written, up to a maximum of limit
-// records.
-//
-// storageUpdatedAt is the update time provided by the storage connector, used
-// when the file columns do not specify an update time property.
-//
-// The close method should be called when there are no more records to write.
-func newRecordWriter(format string, pipeline *state.Pipeline, storageUpdatedAt time.Time, layout *state.TimeLayouts, startTime time.Time, limit int) *recordWriter {
-	rw := recordWriter{
-		format:            format,
-		pipeline:          pipeline,
-		storageUpdatedAt:  storageUpdatedAt,
-		timeLayouts:       layout,
-		startTime:         startTime,
-		limit:             limit,
-		userIDColumnIndex: -1,
-		updatedAtIndex:    -1,
-	}
-	return &rw
-}
-
 // recordWriter implements the connector.RecordWriter interface.
 type recordWriter struct {
 	format                 string
@@ -718,9 +691,26 @@ type recordWriter struct {
 	numPropertiesPerRecord int
 	properties             []types.Property // properties of the pipeline's schema, or the file's columns if a pipeline has not been provided
 	issues                 []string
-	record                 Record
 	yield                  func(Record) bool
-	isLast                 bool
+}
+
+// newRecordWriter returns a new record writer. Its yield function must be set
+// before writing records.
+//
+// storageUpdatedAt is the update time reported by the storage connector. It is
+// used when a record does not provide an updated-at value.
+func newRecordWriter(format string, pipeline *state.Pipeline, storageUpdatedAt time.Time, layout *state.TimeLayouts, startTime time.Time, limit int) *recordWriter {
+	rw := recordWriter{
+		format:            format,
+		pipeline:          pipeline,
+		storageUpdatedAt:  storageUpdatedAt,
+		timeLayouts:       layout,
+		startTime:         startTime,
+		limit:             limit,
+		userIDColumnIndex: -1,
+		updatedAtIndex:    -1,
+	}
+	return &rw
 }
 
 // Columns sets the columns of the records as properties.
@@ -801,13 +791,7 @@ func (rw *recordWriter) Record(record map[string]any) error {
 			}
 		}
 	}
-	// Call the yield function passing the previous record.
-	if rw.record.Attributes != nil || rw.record.Err != nil {
-		if !rw.yield(rw.record) {
-			return errRecordStop
-		}
-	}
-	rw.record = Record{
+	result := Record{
 		Attributes: make(map[string]any, rw.numPropertiesPerRecord),
 		UpdatedAt:  updatedAt,
 		Err:        err,
@@ -815,13 +799,13 @@ func (rw *recordWriter) Record(record map[string]any) error {
 	// Get the user ID column.
 	if i := rw.userIDColumnIndex; i >= 0 {
 		p := rw.properties[i]
-		rw.record.ID, err = parseUserIDColumn(p.Name, p.Type, record[p.Name], rw.timeLayouts)
+		result.ID, err = parseUserIDColumn(p.Name, p.Type, record[p.Name], rw.timeLayouts)
 		if err != nil {
-			rw.record.Err = err
+			result.Err = err
 		}
 	}
 	// Get the attributes.
-	if rw.record.Err == nil {
+	if result.Err == nil {
 		for _, p := range rw.properties {
 			if p.Name == "" {
 				continue
@@ -829,24 +813,20 @@ func (rw *recordWriter) Record(record map[string]any) error {
 			v, ok := record[p.Name]
 			if !ok {
 				if !p.ReadOptional {
-					rw.record.Err = inputValidationErrorf(p.Name, "does not have a value, but the property is not optional for reading")
+					result.Err = inputValidationErrorf(p.Name, "does not have a value, but the property is not optional for reading")
 					break
 				}
 				continue
 			}
 			v, err = normalize(p.Name, p.Type, v, p.Nullable, rw.timeLayouts)
 			if err != nil {
-				rw.record.Err = err
+				result.Err = err
 				break
 			}
-			rw.record.Attributes[p.Name] = v
+			result.Attributes[p.Name] = v
 		}
 	}
-	rw.limit--
-	if rw.limit == 0 {
-		return errRecordStop
-	}
-	return nil
+	return rw.yieldRecord(result)
 }
 
 // RecordSlice writes a record.
@@ -875,13 +855,7 @@ func (rw *recordWriter) RecordSlice(record []any) error {
 			}
 		}
 	}
-	// Call the yield function passing the previous record.
-	if rw.record.Attributes != nil || rw.record.Err != nil {
-		if !rw.yield(rw.record) {
-			return errRecordStop
-		}
-	}
-	rw.record = Record{
+	result := Record{
 		Attributes: make(map[string]any, rw.numPropertiesPerRecord),
 		UpdatedAt:  updatedAt,
 		Err:        err,
@@ -889,30 +863,26 @@ func (rw *recordWriter) RecordSlice(record []any) error {
 	// Get the user ID column.
 	if i := rw.userIDColumnIndex; i >= 0 {
 		p := rw.properties[i]
-		rw.record.ID, err = parseUserIDColumn(p.Name, p.Type, record[i], rw.timeLayouts)
+		result.ID, err = parseUserIDColumn(p.Name, p.Type, record[i], rw.timeLayouts)
 		if err != nil {
-			rw.record.Err = err
+			result.Err = err
 		}
 	}
 	// Get the attributes.
-	if rw.record.Err == nil {
+	if result.Err == nil {
 		for i, p := range rw.properties {
 			if p.Name == "" {
 				continue
 			}
 			v, err := normalize(p.Name, p.Type, record[i], p.Nullable, rw.timeLayouts)
 			if err != nil {
-				rw.record.Err = err
+				result.Err = err
 				break
 			}
-			rw.record.Attributes[p.Name] = v
+			result.Attributes[p.Name] = v
 		}
 	}
-	rw.limit--
-	if rw.limit == 0 {
-		return errRecordStop
-	}
-	return nil
+	return rw.yieldRecord(result)
 }
 
 // RecordStrings writes a record represented as a slice of strings. The slice
@@ -950,13 +920,7 @@ func (rw *recordWriter) RecordStrings(record []string) error {
 			}
 		}
 	}
-	// Call the yield function passing the previous record.
-	if rw.record.Attributes != nil || rw.record.Err != nil {
-		if !rw.yield(rw.record) {
-			return errRecordStop
-		}
-	}
-	rw.record = Record{
+	result := Record{
 		Attributes: make(map[string]any, rw.numPropertiesPerRecord),
 		UpdatedAt:  updatedAt,
 		Err:        err,
@@ -964,57 +928,38 @@ func (rw *recordWriter) RecordStrings(record []string) error {
 	// Get the user ID column.
 	if i := rw.userIDColumnIndex; i >= 0 {
 		p := rw.properties[i]
-		rw.record.ID, err = parseUserIDColumn(p.Name, p.Type, record[i], rw.timeLayouts)
+		result.ID, err = parseUserIDColumn(p.Name, p.Type, record[i], rw.timeLayouts)
 		if err != nil {
-			rw.record.Err = err
+			result.Err = err
 		}
 	}
 	// Get the attributes.
-	if rw.record.Err == nil {
+	if result.Err == nil {
 		for i, p := range rw.properties {
 			if p.Name == "" {
 				continue
 			}
 			v, err := normalize(p.Name, p.Type, record[i], p.Nullable, rw.timeLayouts)
 			if err != nil {
-				rw.record.Err = err
+				result.Err = err
 				break
 			}
-			rw.record.Attributes[p.Name] = v
+			result.Attributes[p.Name] = v
 		}
 	}
+	return rw.yieldRecord(result)
+}
+
+// yieldRecord calls the yield function with record and applies the record limit.
+func (rw *recordWriter) yieldRecord(record Record) error {
 	rw.limit--
+	if !rw.yield(record) {
+		return errRecordStop
+	}
 	if rw.limit == 0 {
 		return errRecordStop
 	}
 	return nil
-}
-
-// close closes the record writer. It should be called when there are no more
-// records to write. If there is a last record, it calls the yield function with
-// that record. After close is called, no other methods of the record writer
-// should be called except for the 'last' method.
-func (rw *recordWriter) close() {
-	if rw.record.Attributes == nil && rw.record.Err == nil {
-		return
-	}
-	rw.isLast = true
-	rw.yield(rw.record)
-	rw.record.Attributes = nil
-	rw.record.Err = nil
-}
-
-// last reports whether the record passed to the yield function is the last
-// record. It should be only called in the yield function.
-func (rw *recordWriter) last() bool {
-	return rw.isLast
-}
-
-// setYieldFunc sets the yield function that will be called for each written
-// record. setYieldFunc must be set before calling the Record, RecordSlice, and
-// RecordStrings methods.
-func (rw *recordWriter) setYieldFunc(yield func(Record) bool) {
-	rw.yield = yield
 }
 
 // storageWriteCloser wraps an io.Writer and implements io.WriteCloser. It calls a

--- a/core/internal/connections/file_test.go
+++ b/core/internal/connections/file_test.go
@@ -5,12 +5,14 @@
 package connections
 
 import (
-	"errors"
 	"io"
 	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
+
+	"github.com/krenalis/krenalis/tools/errors"
+	"github.com/krenalis/krenalis/tools/types"
 )
 
 // TestMaterializeReadSeeker verifies that a streaming reader is materialized as
@@ -125,6 +127,42 @@ func TestMaterializeReadSeekerReusesReadSeekAt(t *testing.T) {
 	}
 	if !originalReader.closed {
 		t.Fatal("expected returned closer to close reused reader")
+	}
+
+}
+
+// TestRecordWriterYieldsRecordAtLimit verifies that the record at the configured
+// limit is yielded before reading stops.
+func TestRecordWriterYieldsRecordAtLimit(t *testing.T) {
+
+	rw := newRecordWriter("test", nil, time.Time{}, nil, time.Time{}, 2)
+	var got []Record
+	rw.yield = func(record Record) bool {
+		got = append(got, record)
+		return true
+	}
+	err := rw.Columns([]types.Property{{Name: "email", Type: types.String()}})
+	if err != nil {
+		t.Fatalf("expected Columns to succeed, got %s", err)
+	}
+	err = rw.Record(map[string]any{"email": "first@example.com"})
+	if err != nil {
+		t.Fatalf("expected the first record to succeed, got %s", err)
+	}
+	err = rw.Record(map[string]any{"email": "second@example.com"})
+	if err != nil {
+		if !errors.Is(err, errRecordStop) {
+			t.Fatalf("expected the second record to stop reading, got %v", err)
+		}
+	}
+	if err == nil {
+		t.Fatal("expected the second record to stop reading")
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected two yielded records, got %d", len(got))
+	}
+	if got[1].Attributes["email"] != "second@example.com" {
+		t.Fatalf("expected the record at the limit to be yielded, got %#v", got[1])
 	}
 
 }

--- a/core/internal/connections/filestorage.go
+++ b/core/internal/connections/filestorage.go
@@ -157,16 +157,15 @@ func (storage *FileStorage) Read(ctx context.Context, file *state.Connector, nam
 	rw := newRecordWriter(file.Code, nil, storageTimestamp, &file.TimeLayouts, time.Time{}, limit)
 	var records []map[string]any
 	var recordErr error
-	rw.setYieldFunc(func(record Record) bool {
+	rw.yield = func(record Record) bool {
 		if record.Err != nil {
 			recordErr = record.Err
 			return false
 		}
 		records = append(records, record.Attributes)
 		return true
-	})
+	}
 	err = readFromFileConnector(ctx, _file, &r, sheet, rw)
-	rw.close()
 	if err != nil && err != errRecordStop {
 		return nil, nil, nil, connectorError(err)
 	}

--- a/core/run_export.go
+++ b/core/run_export.go
@@ -349,10 +349,9 @@ func (this *Pipeline) syncDestinationProfiles(ctx context.Context) error {
 			})
 		}
 
-		if len(profiles) > 0 && (len(profiles) == 10000 || records.Last()) {
+		if len(profiles) == 10000 {
 			// Merge destination profiles.
-			err = this.connection.store.MergeDestinationUsers(ctx, this.pipeline.ID, profiles, nil)
-			if err != nil {
+			if err := store.MergeDestinationUsers(ctx, this.pipeline.ID, profiles, nil); err != nil {
 				return err
 			}
 			profiles = profiles[0:0]
@@ -361,6 +360,11 @@ func (this *Pipeline) syncDestinationProfiles(ctx context.Context) error {
 	}
 	if err = records.Err(); err != nil {
 		return err
+	}
+	if len(profiles) > 0 {
+		if err := store.MergeDestinationUsers(ctx, this.pipeline.ID, profiles, nil); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/core/run_import.go
+++ b/core/run_import.go
@@ -106,6 +106,49 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 
 	cursor := run.Cursor
 
+	// processBatch transforms and queues identities, then persists the cursor reached by the batch.
+	processBatch := func(batch []connections.Record) error {
+
+		// Transform the users.
+		transformationRecords = transformationRecords[:len(batch)]
+		for i, user := range batch {
+			transformationRecords[i] = transformers.Record{Attributes: user.Attributes}
+		}
+		err := transformer.Transform(ctx, transformationRecords)
+		if err != nil {
+			if _, ok := err.(transformers.FunctionExecError); ok {
+				err = newPipelineError(metrics.TransformationStep, err)
+			}
+			return err
+		}
+
+		// Set the identities into the data warehouse.
+		for i, record := range transformationRecords {
+			user := batch[i]
+			if err := record.Err; err != nil {
+				switch err.(type) {
+				case transformers.RecordTransformationError:
+					this.core.metrics.TransformationFailed(pipeline.ID, 1, err.Error())
+				case transformers.RecordValidationError:
+					this.core.metrics.TransformationPassed(pipeline.ID, 1)
+					this.core.metrics.OutputValidationFailed(pipeline.ID, 1, err.Error())
+				}
+				_ = iw.Keep(ctx, user.ID)
+				continue
+			}
+			user.Attributes = record.Attributes
+			this.core.metrics.TransformationPassed(pipeline.ID, 1)
+			this.core.metrics.OutputValidationPassed(pipeline.ID, 1)
+			_ = iw.Write(ctx, datastore.Identity{
+				ID:         user.ID,
+				Attributes: user.Attributes,
+				UpdatedAt:  user.UpdatedAt,
+			})
+		}
+
+		return this.setRunCursor(ctx, cursor)
+	}
+
 	// Read the users.
 	for user := range records.All(ctx) {
 
@@ -117,7 +160,7 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 			} else {
 				this.core.metrics.ReceiveFailed(pipeline.ID, 1, user.Err.Error())
 			}
-			goto Next
+			continue
 		}
 
 		this.core.metrics.ReceivePassed(pipeline.ID, 1)
@@ -127,7 +170,7 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 		if connector.Type != state.Database {
 			if !filters.Applies(pipeline.Filter, user.Attributes) {
 				this.core.metrics.FilterFailed(pipeline.ID, 1)
-				goto Next
+				continue
 			}
 			this.core.metrics.FilterPassed(pipeline.ID, 1)
 		}
@@ -138,57 +181,12 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 
 		users = append(users, user)
 
-	Next:
-
-		// Does a batch processing of users.
-		if len(users) == 100 || records.Last() {
-
-			// Transform the users.
-			transformationRecords = transformationRecords[0:len(users)]
-			for i, user := range users {
-				transformationRecords[i].Attributes = user.Attributes
-			}
-			err := transformer.Transform(ctx, transformationRecords)
-			if err != nil {
-				if _, ok := err.(transformers.FunctionExecError); ok {
-					err = newPipelineError(metrics.TransformationStep, err)
-				}
+		if len(users) == 100 {
+			if err := processBatch(users); err != nil {
 				return err
 			}
-
-			// Set the identities into the data warehouse.
-			for i, record := range transformationRecords {
-				user := users[i]
-				if err := record.Err; err != nil {
-					switch err.(type) {
-					case transformers.RecordTransformationError:
-						this.core.metrics.TransformationFailed(pipeline.ID, 1, err.Error())
-					case transformers.RecordValidationError:
-						this.core.metrics.TransformationPassed(pipeline.ID, 1)
-						this.core.metrics.OutputValidationFailed(pipeline.ID, 1, err.Error())
-					}
-					_ = iw.Keep(ctx, user.ID)
-					continue
-				}
-				user.Attributes = record.Attributes
-				this.core.metrics.TransformationPassed(pipeline.ID, 1)
-				this.core.metrics.OutputValidationPassed(pipeline.ID, 1)
-				_ = iw.Write(ctx, datastore.Identity{
-					ID:         user.ID,
-					Attributes: user.Attributes,
-					UpdatedAt:  user.UpdatedAt,
-				})
-			}
-
-			// Set the cursor.
-			err = this.setRunCursor(ctx, cursor)
-			if err != nil {
-				return err
-			}
-
 			clear(users)
 			users = users[0:0]
-
 		}
 
 	}
@@ -201,6 +199,11 @@ func (this *Pipeline) importUsers(ctx context.Context) error {
 			err = fmt.Errorf("file does not contain any sheet named %q", pipeline.Sheet)
 		}
 		return newPipelineError(metrics.ReceiveStep, err)
+	}
+	if len(users) > 0 {
+		if err := processBatch(users); err != nil {
+			return err
+		}
 	}
 
 	// TODO(Gianluca): calling Close may return error in case the warehouse mode


### PR DESCRIPTION
```
core: fix batching across application record pages (#2439)

Prevent page boundaries from marking records on subsequent pages as
final, which causes imports and exports to flush one record at a time
after the first page.

Simplify record iteration by removing final-record tracking and
completing pending batches after iteration ends.
 ```