### PR TITLE
test/krenalistester: drop Krenalis env variables in compiled mode

### DIFF
--- a/test/krenalistester/build_run_krenalis.go
+++ b/test/krenalistester/build_run_krenalis.go
@@ -107,6 +107,19 @@ func generateAssets(ctx context.Context, repo string) error {
 	return nil
 }
 
+// environWithoutKrenalisVars returns the environment of the current process
+// without the variables that configure Krenalis.
+func environWithoutKrenalisVars() []string {
+	var env []string
+	for _, v := range os.Environ() {
+		if key, _, ok := strings.Cut(v, "="); ok && strings.HasPrefix(key, "KRENALIS_") {
+			continue
+		}
+		env = append(env, v)
+	}
+	return env
+}
+
 func launchKrenalis(ctx context.Context, env []string) error {
 	repo, err := filepath.Abs("../")
 	if err != nil {

--- a/test/krenalistester/krenalistester.go
+++ b/test/krenalistester/krenalistester.go
@@ -329,18 +329,19 @@ func (k *Krenalis) Start() {
 			k.t.Fatal(err)
 		}
 		// Build the environment for the Krenalis process by starting from the
-		// current process's environment (os.Environ()) and adding the
-		// Krenalis-specific variables.
+		// current process's environment, without the Krenalis variables, and
+		// adding the Krenalis-specific variables needed by the tests.
 		//
-		// We must preserve the existing environment variables because:
+		// The Krenalis variables already present in the environment are
+		// removed to keep behavior consistent with the "embedded" test mode,
+		// where Krenalis is configured programmatically and does not read the
+		// environment.
 		//
-		// (1) it keeps behavior consistent with the "embedded" test mode,
-		//     which also inherits the full environment, and
+		// The other environment variables must be preserved because Krenalis
+		// may fail if certain system environment variables are missing (e.g.,
+		// this causes errors on Windows).
 		//
-		// (2) Krenalis may fail if certain system environment variables are
-		//     missing (e.g., this causes errors on Windows).
-		//
-		env := append(os.Environ(), []string{
+		env := append(environWithoutKrenalisVars(), []string{
 			"KRENALIS_EXTERNAL_ASSETS_URLS=https://assets.krenalis.com/",
 			"KRENALIS_POTENTIAL_CONNECTORS_URL=https://assets.krenalis.com/admin/connectors/potentials.json",
 			"KRENALIS_TELEMETRY_LEVEL=none",


### PR DESCRIPTION
## Commit message

```
test/krenalistester: drop Krenalis env variables in compiled mode (#2443)

When Krenalis is launched as an external process, its environment is
built from the environment of the test process, so any KRENALIS_
variable set in the environment reaches the configuration loader. The
same variables have no effect in embedded mode, where Krenalis is
configured programmatically and does not read the environment, making
the two test modes behave differently.

Remove the KRENALIS_ variables from the inherited environment before
adding the ones the tests set explicitly. Keep the remaining variables,
which Krenalis may need in order to start.
```