### PR TITLE
tools/backoff: add retry state reset

### DIFF
--- a/tools/backoff/backoff.go
+++ b/tools/backoff/backoff.go
@@ -134,6 +134,14 @@ func (bo *Backoff) Next(ctx context.Context) bool {
 	return true
 }
 
+// Reset clears the attempt counter and next wait time while preserving the
+// configured attempts, base, and cap. It must not be called while an AfterFunc
+// callback is pending.
+func (bo *Backoff) Reset() {
+	bo.attempt = 0
+	bo.waitTime = 0
+}
+
 // SetAttempts sets the attempts. Use backoff.NoLimit for unlimited attempts.
 // It panics if attempts is zero or negative.
 func (bo *Backoff) SetAttempts(attempts int) {

--- a/tools/backoff/backoff_test.go
+++ b/tools/backoff/backoff_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"math"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -234,6 +235,59 @@ func Test_Next_Cap(t *testing.T) {
 			}
 		}
 	}
+}
+
+// Test_Reset verifies that Reset restores the initial retry state while
+// preserving configuration.
+func Test_Reset(t *testing.T) {
+
+	synctest.Test(t, func(t *testing.T) {
+
+		const (
+			attempts    = 2
+			base        = 7
+			capDuration = 5 * time.Millisecond
+		)
+		bo := New(base)
+		bo.SetAttempts(attempts)
+		bo.SetCap(capDuration)
+		if !bo.Next(t.Context()) {
+			t.Fatal("Next returned false on first call")
+		}
+		if !bo.Next(t.Context()) {
+			t.Fatal("Next returned false on second call")
+		}
+		bo.SetNextWaitTime(time.Hour)
+
+		bo.Reset()
+
+		if got := bo.Attempt(); got != 0 {
+			t.Fatalf("expected attempt 0 after reset, got %d", got)
+		}
+		if got := bo.WaitTime(); got != 0 {
+			t.Fatalf("expected waiting time 0 after reset, got %s", got)
+		}
+		if got := bo.attempts; got != attempts {
+			t.Fatalf("expected %d configured attempts after reset, got %d", attempts, got)
+		}
+		if got := bo.base; got != base {
+			t.Fatalf("expected configured base %d after reset, got %v", base, got)
+		}
+		if got := bo.cap; got != capDuration {
+			t.Fatalf("expected configured cap %s after reset, got %s", capDuration, got)
+		}
+		if !bo.Next(t.Context()) {
+			t.Fatal("Next returned false on first call after reset")
+		}
+		if !bo.Next(t.Context()) {
+			t.Fatal("Next returned false on second call after reset")
+		}
+		if bo.Next(t.Context()) {
+			t.Fatal("Next returned true after the configured attempts")
+		}
+
+	})
+
 }
 
 // Test_SetNextWaitTime validates that SetNextWaitTime overrides the next


### PR DESCRIPTION
```
tools/backoff: add retry state reset (#2446)

Add Reset to restart a backoff sequence while preserving its
configuration. Reset clears the attempt count and next wait duration.

Reset must not be called while an AfterFunc callback is pending.
```