### PR TITLE
core/internal/datastore: fix object property name reuse

### DIFF
--- a/core/internal/datastore/diffschemas/diffschemas.go
+++ b/core/internal/datastore/diffschemas/diffschemas.go
@@ -230,6 +230,7 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 		}
 
 		if v, ok := rePaths[keptPath]; ok && v == nil {
+			columnBase := pathToColumn(keptPath)
 			if renamed {
 				// New properties with the same name of a renamed property. They
 				// appear in "rePaths" (the key is the name of the created
@@ -249,13 +250,13 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 					for _, p := range propertyPaths(oldProp.Type) {
 						operations = append(operations, warehouses.AlterOperation{
 							Operation: warehouses.OperationDropColumn,
-							Column:    pathToColumn(appendPath(path, appendPath(keptName, p))),
+							Column:    columnBase + "_" + pathToColumn(p),
 						})
 					}
 				} else {
 					operations = append(operations, warehouses.AlterOperation{
 						Operation: warehouses.OperationDropColumn,
-						Column:    pathToColumn(keptPath),
+						Column:    columnBase,
 					})
 				}
 			}
@@ -263,7 +264,7 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 				for _, c := range util.PropertiesToColumns(newProp.Type.Properties()) {
 					operations = append(operations, warehouses.AlterOperation{
 						Operation: warehouses.OperationAddColumn,
-						Column:    pathToColumn(keptPath) + "_" + c.Name,
+						Column:    columnBase + "_" + c.Name,
 						Type:      c.Type,
 					})
 				}
@@ -271,7 +272,7 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 				operations = append(operations,
 					warehouses.AlterOperation{
 						Operation: warehouses.OperationAddColumn,
-						Column:    pathToColumn(keptPath),
+						Column:    columnBase,
 						Type:      newProp.Type,
 					})
 			}

--- a/core/internal/datastore/diffschemas/diffschemas.go
+++ b/core/internal/datastore/diffschemas/diffschemas.go
@@ -263,7 +263,7 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 				for _, c := range util.PropertiesToColumns(newProp.Type.Properties()) {
 					operations = append(operations, warehouses.AlterOperation{
 						Operation: warehouses.OperationAddColumn,
-						Column:    pathToColumn(appendPath(path, keptPath)) + "_" + c.Name,
+						Column:    pathToColumn(keptPath) + "_" + c.Name,
 						Type:      c.Type,
 					})
 				}

--- a/core/internal/datastore/diffschemas/diffschemas.go
+++ b/core/internal/datastore/diffschemas/diffschemas.go
@@ -245,11 +245,19 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 				// New properties with the same name as a deleted property. They
 				// appear in "rePaths" (the key is the name of the created
 				// property, the value is nil).
-				operations = append(operations,
-					warehouses.AlterOperation{
+				if oldProp.Type.Kind() == types.ObjectKind {
+					for _, p := range propertyPaths(oldProp.Type) {
+						operations = append(operations, warehouses.AlterOperation{
+							Operation: warehouses.OperationDropColumn,
+							Column:    pathToColumn(appendPath(path, appendPath(keptName, p))),
+						})
+					}
+				} else {
+					operations = append(operations, warehouses.AlterOperation{
 						Operation: warehouses.OperationDropColumn,
 						Column:    pathToColumn(keptPath),
 					})
+				}
 			}
 			if newProp.Type.Kind() == types.ObjectKind {
 				for _, c := range util.PropertiesToColumns(newProp.Type.Properties()) {

--- a/core/internal/datastore/diffschemas/diffschemas_test.go
+++ b/core/internal/datastore/diffschemas/diffschemas_test.go
@@ -378,6 +378,30 @@ func TestDiff(t *testing.T) {
 			},
 		},
 		{
+			name: "One nested object property removed and then an object property added with the same name",
+			fromSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "a", Type: types.Object([]types.Property{
+						{Name: "b", Type: types.String(), Nullable: true},
+						{Name: "c", Type: types.Int(32), Nullable: true},
+					})},
+				})},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "a", Type: types.Object([]types.Property{
+						{Name: "d", Type: types.String(), Nullable: true},
+					})},
+				})},
+			}),
+			rePaths: map[string]any{"x.a": nil},
+			expectedOps: []warehouses.AlterOperation{
+				{Operation: warehouses.OperationDropColumn, Column: "x_a_b"},
+				{Operation: warehouses.OperationDropColumn, Column: "x_a_c"},
+				{Operation: warehouses.OperationAddColumn, Column: "x_a_d", Type: types.String()},
+			},
+		},
+		{
 			name: "One property removed and then added again (with another type) at second level",
 			fromSchema: types.Object([]types.Property{
 				{Name: "x", Type: types.Object([]types.Property{

--- a/core/internal/datastore/diffschemas/diffschemas_test.go
+++ b/core/internal/datastore/diffschemas/diffschemas_test.go
@@ -338,6 +338,46 @@ func TestDiff(t *testing.T) {
 			},
 		},
 		{
+			name: "One object property removed and then a scalar property added with the same name",
+			fromSchema: types.Object([]types.Property{
+				{Name: "a", Type: types.Object([]types.Property{
+					{Name: "b", Type: types.String(), Nullable: true},
+					{Name: "c", Type: types.Int(32), Nullable: true},
+				})},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "a", Type: types.String(), Nullable: true},
+			}),
+			rePaths: map[string]any{"a": nil},
+			expectedOps: []warehouses.AlterOperation{
+				{Operation: warehouses.OperationDropColumn, Column: "a_b"},
+				{Operation: warehouses.OperationDropColumn, Column: "a_c"},
+				{Operation: warehouses.OperationAddColumn, Column: "a", Type: types.String()},
+			},
+		},
+		{
+			name: "One nested object property removed and then a scalar property added with the same name",
+			fromSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "a", Type: types.Object([]types.Property{
+						{Name: "b", Type: types.String(), Nullable: true},
+						{Name: "c", Type: types.Int(32), Nullable: true},
+					})},
+				})},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "a", Type: types.String(), Nullable: true},
+				})},
+			}),
+			rePaths: map[string]any{"x.a": nil},
+			expectedOps: []warehouses.AlterOperation{
+				{Operation: warehouses.OperationDropColumn, Column: "x_a_b"},
+				{Operation: warehouses.OperationDropColumn, Column: "x_a_c"},
+				{Operation: warehouses.OperationAddColumn, Column: "x_a", Type: types.String()},
+			},
+		},
+		{
 			name: "One property removed and then added again (with another type) at second level",
 			fromSchema: types.Object([]types.Property{
 				{Name: "x", Type: types.Object([]types.Property{


### PR DESCRIPTION
```
core/internal/datastore: fix object property name reuse (#2447)

When a deleted object property is replaced by a property with the same
name, drop the deleted property's flattened warehouse columns before
adding the replacement.

This prevents schema alterations from trying to drop the deleted
property's logical name, which is not a warehouse column.
```