### PR TITLE
core/internal/datastore/diffschemas: fix drop of a reused object property

### DIFF
--- a/core/internal/datastore/diffschemas/diffschemas.go
+++ b/core/internal/datastore/diffschemas/diffschemas.go
@@ -274,10 +274,19 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 		// They appear in "rePaths" (the key is the name of the property that
 		// "occupied the name", the value is the name of the deleted property).
 		if oldPath, ok := rePaths[keptPath].(string); ok {
-			operations = append(operations, warehouses.AlterOperation{
-				Operation: warehouses.OperationDropColumn,
-				Column:    pathToColumn(keptPath),
-			})
+			if oldProp.Type.Kind() == types.ObjectKind {
+				for _, p := range propertyPaths(oldProp.Type) {
+					operations = append(operations, warehouses.AlterOperation{
+						Operation: warehouses.OperationDropColumn,
+						Column:    pathToColumn(appendPath(keptPath, p)),
+					})
+				}
+			} else {
+				operations = append(operations, warehouses.AlterOperation{
+					Operation: warehouses.OperationDropColumn,
+					Column:    pathToColumn(keptPath),
+				})
+			}
 			if !types.Equal(oldProp.Type, newProp.Type) {
 				return nil, fmt.Errorf("error on property %q: type changes are not supported", appendPath(path, oldProp.Name))
 			}

--- a/core/internal/datastore/diffschemas/diffschemas_test.go
+++ b/core/internal/datastore/diffschemas/diffschemas_test.go
@@ -708,6 +708,68 @@ func TestDiff(t *testing.T) {
 			},
 		},
 		{
+			name: "Object property deleted and its name reused by a renamed object property",
+			fromSchema: types.Object([]types.Property{
+				{Name: "foo", Type: types.Object([]types.Property{
+					{Name: "b", Type: types.String(), Nullable: true},
+					{Name: "c", Type: types.String(), Nullable: true},
+				})},
+				{Name: "bar", Type: types.Object([]types.Property{
+					{Name: "b", Type: types.String(), Nullable: true},
+					{Name: "c", Type: types.String(), Nullable: true},
+				})},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "foo", Type: types.Object([]types.Property{
+					{Name: "b", Type: types.String(), Nullable: true},
+					{Name: "c", Type: types.String(), Nullable: true},
+				})},
+			}),
+			rePaths: map[string]any{"foo": "bar"},
+			expectedOps: []warehouses.AlterOperation{
+				{Operation: warehouses.OperationDropColumn, Column: "foo_b"},
+				{Operation: warehouses.OperationDropColumn, Column: "foo_c"},
+				{Operation: warehouses.OperationRenameColumn, Column: "bar_b", NewColumn: "foo_b"},
+				{Operation: warehouses.OperationRenameColumn, Column: "bar_c", NewColumn: "foo_c"},
+			},
+		},
+		{
+			name: "Object property deleted and its name reused by a renamed object property. Within an object property",
+			fromSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "foo", Type: types.Object([]types.Property{
+						{Name: "b", Type: types.String(), Nullable: true},
+						{Name: "d", Type: types.Object([]types.Property{
+							{Name: "e", Type: types.String(), Nullable: true},
+						})},
+					})},
+					{Name: "bar", Type: types.Object([]types.Property{
+						{Name: "b", Type: types.String(), Nullable: true},
+						{Name: "d", Type: types.Object([]types.Property{
+							{Name: "e", Type: types.String(), Nullable: true},
+						})},
+					})},
+				})},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "foo", Type: types.Object([]types.Property{
+						{Name: "b", Type: types.String(), Nullable: true},
+						{Name: "d", Type: types.Object([]types.Property{
+							{Name: "e", Type: types.String(), Nullable: true},
+						})},
+					})},
+				})},
+			}),
+			rePaths: map[string]any{"x.foo": "x.bar"},
+			expectedOps: []warehouses.AlterOperation{
+				{Operation: warehouses.OperationDropColumn, Column: "x_foo_b"},
+				{Operation: warehouses.OperationDropColumn, Column: "x_foo_d_e"},
+				{Operation: warehouses.OperationRenameColumn, Column: "x_bar_b", NewColumn: "x_foo_b"},
+				{Operation: warehouses.OperationRenameColumn, Column: "x_bar_d_e", NewColumn: "x_foo_d_e"},
+			},
+		},
+		{
 			name: "Rename an object property and create a new property with the same name (but different type)",
 			fromSchema: types.Object([]types.Property{
 				{Name: "x", Type: types.Object([]types.Property{


### PR DESCRIPTION
## Commit message

```
core/internal/datastore/diffschemas: fix drop of reused object property (#2452)

This commit is similar to e4fd56faf (#2447, "fix object property name
reuse"), with the difference that #2447 handled the drop of a deleted
object property whose name is reused by a newly created property, while
this commit handles the same drop when the name is instead reused by a
renamed property.

When a property is deleted and the name it frees is taken over by a
renamed property, Diff emits a single DropColumn for the freed path. If
the deleted property is an object, no column with that name exists in
the warehouse, since object properties are flattened into one column per
leaf. The real columns are therefore never dropped, and the drop targets
a column that does not exist. The RenameColumn operations emitted right
after take over those same leaf columns, which are still occupied.

Drop one column per leaf of the deleted property, the same handling
#2447 added for a name reused by a new property rather than by a rename.
```