### PR TITLE
core/internal/datastore/diffschemas: fix type check on renames

### DIFF
--- a/core/internal/datastore/diffschemas/diffschemas.go
+++ b/core/internal/datastore/diffschemas/diffschemas.go
@@ -278,8 +278,13 @@ func Diff(oldSchema, newSchema types.Type, rePaths map[string]any, path string) 
 				Operation: warehouses.OperationDropColumn,
 				Column:    pathToColumn(keptPath),
 			})
-			if !types.Equal(oldProp.Type, newProp.Type) {
-				return nil, fmt.Errorf("error on property %q: type changes are not supported", appendPath(path, oldProp.Name))
+			// The type to compare with the new one is that of the renamed
+			// property, at oldPath, and not that of the deleted property, whose
+			// name is the one that has been reused.
+			oldName := propPathToName(oldPath)
+			renamedProp, _ := oldProperties.ByName(oldName)
+			if !types.Equal(renamedProp.Type, newProp.Type) {
+				return nil, fmt.Errorf("error on property %q (renamed to %q): type changes are not supported", appendPath(path, oldName), keptPath)
 			}
 			if newProp.Type.Kind() == types.ObjectKind {
 				for _, c := range util.PropertiesToColumns(newProp.Type.Properties()) {

--- a/core/internal/datastore/diffschemas/diffschemas_test.go
+++ b/core/internal/datastore/diffschemas/diffschemas_test.go
@@ -75,7 +75,7 @@ func TestDiff(t *testing.T) {
 			rePaths: map[string]any{
 				"lastName": "firstName",
 			},
-			expectedErr: `error on property "lastName": type changes are not supported`,
+			expectedErr: `error on property "firstName" (renamed to "lastName"): type changes are not supported`,
 		},
 		{
 			name: "No changes",
@@ -705,6 +705,49 @@ func TestDiff(t *testing.T) {
 			expectedOps: []warehouses.AlterOperation{
 				{Operation: warehouses.OperationRenameColumn, Column: "x_a", NewColumn: "x_a2"},
 				{Operation: warehouses.OperationAddColumn, Column: "x_a", Type: types.String()},
+			},
+		},
+		{
+			name: "Property deleted and its name reused by a renamed property whose type has changed",
+			fromSchema: types.Object([]types.Property{
+				{Name: "foo", Type: types.String(), Nullable: true},
+				{Name: "bar", Type: types.Int(32), Nullable: true},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "foo", Type: types.String(), Nullable: true},
+			}),
+			rePaths:     map[string]any{"foo": "bar"},
+			expectedErr: `error on property "bar" (renamed to "foo"): type changes are not supported`,
+		},
+		{
+			name: "Property deleted and its name reused by a renamed property whose type has changed. Within an object property",
+			fromSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "foo", Type: types.String(), Nullable: true},
+					{Name: "bar", Type: types.Int(32), Nullable: true},
+				})},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "x", Type: types.Object([]types.Property{
+					{Name: "foo", Type: types.String(), Nullable: true},
+				})},
+			}),
+			rePaths:     map[string]any{"x.foo": "x.bar"},
+			expectedErr: `error on property "x.bar" (renamed to "x.foo"): type changes are not supported`,
+		},
+		{
+			name: "Property deleted and its name reused by a renamed property of the same type, but with a different type than the deleted one",
+			fromSchema: types.Object([]types.Property{
+				{Name: "foo", Type: types.Int(32), Nullable: true},
+				{Name: "bar", Type: types.String(), Nullable: true},
+			}),
+			toSchema: types.Object([]types.Property{
+				{Name: "foo", Type: types.String(), Nullable: true},
+			}),
+			rePaths: map[string]any{"foo": "bar"},
+			expectedOps: []warehouses.AlterOperation{
+				{Operation: warehouses.OperationDropColumn, Column: "foo"},
+				{Operation: warehouses.OperationRenameColumn, Column: "bar", NewColumn: "foo"},
 			},
 		},
 		{


### PR DESCRIPTION
## Commit message

```
core/internal/datastore/diffschemas: fix type check on renames (#2453)

When a property is deleted and the name it frees is taken over by a
renamed property, Diff compares the type of the deleted property with
the new one, instead of the type of the property being renamed. A type
change on the renamed property therefore goes unnoticed, and the
RenameColumn operation leaves in the warehouse a column with the old
type under a property declared with the new one. Conversely, a rename
onto the name of a deleted property of a different type is rejected
with a misleading error.

Compare the property at the old path with the new one, as already done
for renames to a name that did not exist in the old schema. Report the
error on the renamed property, naming both its old and its new path.
```