### PR TITLE
tools/backoff: remove stale `NoLimit` references

### DIFF
--- a/tools/backoff/backoff.go
+++ b/tools/backoff/backoff.go
@@ -142,8 +142,8 @@ func (bo *Backoff) Reset() {
 	bo.waitTime = 0
 }
 
-// SetAttempts sets the attempts. Use backoff.NoLimit for unlimited attempts.
-// It panics if attempts is zero or negative.
+// SetAttempts limits the backoff to attempts total attempts. A Backoff returned
+// by New has no attempt limit. It panics if attempts is zero or negative.
 func (bo *Backoff) SetAttempts(attempts int) {
 	if attempts <= 0 {
 		panic("backoff: attempts is zero or negative")

--- a/tools/backoff/backoff_test.go
+++ b/tools/backoff/backoff_test.go
@@ -19,7 +19,7 @@ func Test_AfterFunc(t *testing.T) {
 	c := make(chan struct{})
 	f := func(_ context.Context) { c <- struct{}{} }
 
-	// Test NoLimit attempts.
+	// Test unlimited attempts.
 	cap := 10 * time.Millisecond
 	bo := New(1)
 	bo.SetCap(cap)
@@ -172,7 +172,7 @@ func Test_InvalidInputPanics(t *testing.T) {
 // limit when set.
 func Test_Next(t *testing.T) {
 
-	// Test NoLimit attempts.
+	// Test unlimited attempts.
 	bo := New(1)
 	bo.SetCap(10 * time.Millisecond)
 	i := 0


### PR DESCRIPTION
```
tools/backoff: remove stale `NoLimit` references (#2454)
```