### PR TITLE
tools/backoff: handle lowered attempt limits

### DIFF
--- a/tools/backoff/backoff.go
+++ b/tools/backoff/backoff.go
@@ -67,7 +67,7 @@ func New(base int) *Backoff {
 // so as soon as possible after cancellation.
 func (bo *Backoff) AfterFunc(ctx context.Context, f func(ctx context.Context)) bool {
 	if bo.attempt > 0 {
-		if bo.attempt == bo.attempts {
+		if bo.attempts != 0 && bo.attempt >= bo.attempts {
 			return false
 		}
 		if bo.waitTime == 0 {
@@ -108,7 +108,7 @@ func (bo *Backoff) Attempt() int {
 // made, otherwise, it returns false.
 func (bo *Backoff) Next(ctx context.Context) bool {
 	if bo.attempt > 0 {
-		if bo.attempt == bo.attempts {
+		if bo.attempts != 0 && bo.attempt >= bo.attempts {
 			return false
 		}
 		if bo.waitTime == 0 {
@@ -197,7 +197,7 @@ func (bo *Backoff) Stop() bool {
 // already been called or if there are no other retry attempts.
 func (bo *Backoff) WaitTime() time.Duration {
 	if bo.attempt > 0 {
-		if bo.attempt == bo.attempts {
+		if bo.attempts != 0 && bo.attempt >= bo.attempts {
 			return 0
 		}
 		if bo.waitTime == 0 {

--- a/tools/backoff/backoff_test.go
+++ b/tools/backoff/backoff_test.go
@@ -290,6 +290,39 @@ func Test_Reset(t *testing.T) {
 
 }
 
+// Test_SetAttempts verifies that lowering the attempt limit below the current
+// attempt count prevents further attempts.
+func Test_SetAttempts(t *testing.T) {
+
+	synctest.Test(t, func(t *testing.T) {
+
+		bo := New(0)
+		if !bo.Next(t.Context()) {
+			t.Fatal("Next returned false on first call")
+		}
+		if !bo.Next(t.Context()) {
+			t.Fatal("Next returned false on second call")
+		}
+		if got := bo.Attempt(); got != 2 {
+			t.Fatalf("expected attempt 2, got %d", got)
+		}
+
+		bo.SetAttempts(1)
+
+		if got := bo.WaitTime(); got != 0 {
+			t.Errorf("expected WaitTime 0 after lowering attempt limit, got %s", got)
+		}
+		if bo.Next(t.Context()) {
+			t.Error("Next returned true after lowering attempt limit")
+		}
+		if bo.AfterFunc(t.Context(), func(context.Context) {}) {
+			t.Error("AfterFunc returned true after lowering attempt limit")
+		}
+
+	})
+
+}
+
 // Test_SetNextWaitTime validates that SetNextWaitTime overrides the next
 // calculated wait time.
 func Test_SetNextWaitTime(t *testing.T) {


### PR DESCRIPTION
```
tools/backoff: handle lowered attempt limits (#2456)

SetAttempts can lower the limit below the current attempt count. In that
case, checking for equality allows the backoff to continue indefinitely.

Stop when the current attempt count is greater than or equal to a
positive limit, while preserving zero as the internal representation of
unlimited attempts.
```