### PR TITLE
tools/backoff: stop timer when `Next` exits on cancellation

### DIFF
--- a/tools/backoff/backoff.go
+++ b/tools/backoff/backoff.go
@@ -124,6 +124,7 @@ func (bo *Backoff) Next(ctx context.Context) bool {
 		bo.waitTime = 0
 		select {
 		case <-ctx.Done():
+			bo.timer.Stop()
 			return false
 		case <-bo.timer.C:
 		}

--- a/tools/backoff/backoff_test.go
+++ b/tools/backoff/backoff_test.go
@@ -222,6 +222,23 @@ func Test_Next_Context(t *testing.T) {
 
 }
 
+// Test_Next_ContextCancellationStopsTimer verifies that Next stops the active
+// backoff timer when the provided context is canceled.
+func Test_Next_ContextCancellationStopsTimer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		bo := New(1)
+		bo.SetNextWaitTime(time.Hour)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		if bo.Next(ctx) {
+			t.Fatal("Next returned true after its context timed out")
+		}
+		if bo.Stop() {
+			t.Fatal("Stop returned true after Next stopped its timer")
+		}
+	})
+}
+
 // Test_Next_Cap asserts WaitTime never exceeds the configured cap.
 func Test_Next_Cap(t *testing.T) {
 	for i := 1; i < 10; i++ {


### PR DESCRIPTION
```
tools/backoff: stop timer when `Next` exits on cancellation (#2457)

When the context passed to Next is canceled, stop the active timer
before returning. This prevents the timer from remaining armed until its
original deadline.
```