### PR TITLE
core: use `Backoff.Reset` for retry phases

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1511,7 +1511,7 @@ func (core *Core) tryStartPipelineRun(run *state.PipelineRun) {
 		defer stopPing()
 
 		// Prepare the run metrics.
-		bo = backoff.New(200)
+		bo.Reset()
 		for bo.Next(executionCtx) {
 			res, err := core.db.Exec(executionCtx,
 				// If statistics from previous runs of the same pipeline are available,
@@ -1794,7 +1794,7 @@ func (core *Core) executeIdentityResolution(workspace, opID string) {
 		ID:        opID,
 		EndTime:   time.Now().UTC(),
 	}
-	bo = backoff.New(200)
+	bo.Reset()
 	bo.SetCap(time.Second)
 	for bo.Next(ctx) {
 		err := core.state.Transaction(ctx, func(tx *dbpkg.Tx) (any, error) {

--- a/core/internal/datastore/flusher.go
+++ b/core/internal/datastore/flusher.go
@@ -180,8 +180,7 @@ func (f *flusher[T]) loop(opts flusherOptions, startOperation startOperationFunc
 		// Flush buffered rows. If the flush is interrupted (Close canceled the context),
 		// return and let the main loop exit without starting another flush.
 		var latestErrorMsg string
-		bo = backoff.New(1000)
-		bo.SetCap(10 * time.Second)
+		bo.Reset()
 		for bo.Next(flushCtx) {
 			err := innerFlush(flushCtx, rows)
 			if err != nil {


### PR DESCRIPTION
```
core: use `Backoff.Reset` for retry phases (#2458)

Use Backoff.Reset between consecutive retry phases instead of manually
resetting the backoff state.
```